### PR TITLE
[#24] 모아보기 화면에 필요한 데이터 구조 정의 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		DBAE8EB126FDBEAE00F536AD /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */; };
 		DBAE8EBB26FDCA7B00F536AD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */; };
 		DBD5454727032B1C00063C98 /* FilterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD5454627032B1C00063C98 /* FilterType.swift */; };
+		DBD5454927032BAA00063C98 /* TopCategoryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD5454827032BAA00063C98 /* TopCategoryType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -147,6 +148,7 @@
 		DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		DBD5454627032B1C00063C98 /* FilterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterType.swift; sourceTree = "<group>"; };
+		DBD5454827032BAA00063C98 /* TopCategoryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCategoryType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -266,6 +268,7 @@
 			children = (
 				875A965F26F0E4EB001BF0D0 /* CoreDataStack.swift */,
 				DBD5454627032B1C00063C98 /* FilterType.swift */,
+				DBD5454827032BAA00063C98 /* TopCategoryType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -588,6 +591,7 @@
 				DB7C04EC26FB1A04009F5C0A /* UIView+.swift in Sources */,
 				DB7C04FC26FB27A6009F5C0A /* TemplateImageButton.swift in Sources */,
 				DB7C04F826FB1F52009F5C0A /* GiftContentsCollectionViewController.swift in Sources */,
+				DBD5454927032BAA00063C98 /* TopCategoryType.swift in Sources */,
 				DB331DA926FDD00A00A629F5 /* ColorsAsset.swift in Sources */,
 				DB7C04F226FB1F36009F5C0A /* ContentsPageViewController.swift in Sources */,
 				DB7C04E926FB19AE009F5C0A /* ContentsCollectionViewCell.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		DBAE8EBB26FDCA7B00F536AD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */; };
 		DBD5454727032B1C00063C98 /* FilterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD5454627032B1C00063C98 /* FilterType.swift */; };
 		DBD5454927032BAA00063C98 /* TopCategoryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD5454827032BAA00063C98 /* TopCategoryType.swift */; };
+		DBD5454C27032C6600063C98 /* CategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD5454B27032C6600063C98 /* CategoryViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -149,6 +150,7 @@
 		DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		DBD5454627032B1C00063C98 /* FilterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterType.swift; sourceTree = "<group>"; };
 		DBD5454827032BAA00063C98 /* TopCategoryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCategoryType.swift; sourceTree = "<group>"; };
+		DBD5454B27032C6600063C98 /* CategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -287,6 +289,7 @@
 			isa = PBXGroup;
 			children = (
 				DB7C04C626F9E693009F5C0A /* UserInformationViewModel.swift */,
+				DBD5454B27032C6600063C98 /* CategoryViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -605,6 +608,7 @@
 				DB7C04C726F9E693009F5C0A /* UserInformationViewModel.swift in Sources */,
 				873EC00B26D39055003C3525 /* SceneDelegate.swift in Sources */,
 				8736B3F426FDD55E000433E1 /* UIFont+.swift in Sources */,
+				DBD5454C27032C6600063C98 /* CategoryViewModel.swift in Sources */,
 				DB7C04F026FB1EFF009F5C0A /* HomeViewController.swift in Sources */,
 				DB331DAB26FDD00A00A629F5 /* Fonts.swift in Sources */,
 				875A966026F0E4EB001BF0D0 /* CoreDataStack.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		DBAE8E9826FDB3EE00F536AD /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8E9526FDB3EE00F536AD /* Pretendard-SemiBold.otf */; };
 		DBAE8EB126FDBEAE00F536AD /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */; };
 		DBAE8EBB26FDCA7B00F536AD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */; };
+		DBD5454727032B1C00063C98 /* FilterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD5454627032B1C00063C98 /* FilterType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -145,6 +146,7 @@
 		DBAE8E9526FDB3EE00F536AD /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		DBD5454627032B1C00063C98 /* FilterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -263,6 +265,7 @@
 			isa = PBXGroup;
 			children = (
 				875A965F26F0E4EB001BF0D0 /* CoreDataStack.swift */,
+				DBD5454627032B1C00063C98 /* FilterType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -576,6 +579,7 @@
 				DB7C04EE26FB1ACE009F5C0A /* ContentsTabView.swift in Sources */,
 				DB7C04F426FB1F45009F5C0A /* BoughtContentsCollectionViewController.swift in Sources */,
 				DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */,
+				DBD5454727032B1C00063C98 /* FilterType.swift in Sources */,
 				DBAB64A726FE2AFF006D95ED /* UIImage+.swift in Sources */,
 				873EC00D26D39055003C3525 /* ViewController.swift in Sources */,
 				DB7C04CA26F9E69D009F5C0A /* UserDefaults+.swift in Sources */,

--- a/ThingLog/Model/FilterType.swift
+++ b/ThingLog/Model/FilterType.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 /// 모아보기 - 상단 탭을 클릭할 시 각 탭마다 필요한 드롭박스에 필요한 데이터들을 정의한 객체다.
 enum FilterType {
     case preference, latest, year, month

--- a/ThingLog/Model/FilterType.swift
+++ b/ThingLog/Model/FilterType.swift
@@ -1,0 +1,31 @@
+//
+//  FilterType.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/09/28.
+//
+
+import Foundation
+
+
+/// 모아보기 - 상단 탭을 클릭할 시 각 탭마다 필요한 드롭박스에 필요한 데이터들을 정의한 객체다.
+enum FilterType {
+    case preference, latest, year, month
+    
+    var list: [String] {
+        switch self {
+        case .latest:
+            return ["최신순", "오래된 순"]
+        case .month:
+            return Array(1...12).map { String($0) + "월" }
+        case .year:
+            return Array(2_000...3_000).map { String($0) + "년" }
+        case .preference:
+            return ["높은순", "낮은순"]
+        }
+    }
+    
+    var defaultValue: String {
+        list[0]
+    }
+}

--- a/ThingLog/Model/TopCategoryType.swift
+++ b/ThingLog/Model/TopCategoryType.swift
@@ -1,0 +1,25 @@
+//
+//  TopCategoryType.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/09/28.
+//
+
+import Foundation
+
+
+/// 모아보기 - 최상단에 있는 카테고리 탭에 필요한 데이터를 추상화한 객체다.
+enum TopCategoryType {
+    case total, date, category, like, preference, price
+    
+    var filterTypes: [FilterType] {
+        switch self {
+        case .like, .preference, .price:
+            return [.preference]
+        case .total, .category:
+            return [.latest]
+        case .date:
+            return [.year, .month, .latest]
+        }
+    }
+}

--- a/ThingLog/Model/TopCategoryType.swift
+++ b/ThingLog/Model/TopCategoryType.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 /// 모아보기 - 최상단에 있는 카테고리 탭에 필요한 데이터를 추상화한 객체다.
+/// 각 탭에 대하여 필요한 `FilterType`들을 제공한다.
 enum TopCategoryType {
     case total, date, category, like, preference, price
     

--- a/ThingLog/SupportingFiles/Info.plist
+++ b/ThingLog/SupportingFiles/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/ThingLog/ViewModel/CategoryViewModel.swift
+++ b/ThingLog/ViewModel/CategoryViewModel.swift
@@ -1,0 +1,82 @@
+//
+//  CategoryViewModel.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/09/28.
+//
+
+import CoreData
+import Foundation
+
+/// 모아보기 홈에서 상단의 탭들의 선택에 따른 `NSFetchRequest<PostEntity>`를 쉽게 생성하여 `NSFetchResultsController`를 호출하도록 한다.
+/// 모아보기에서 각 뷰들의 액션에 따라 프로퍼티들을 변경하도록 하여, `fetchRequest`를 호출한다.
+final class CategoryViewModel {
+    // MARK: - Properties
+    var currentTopCategoryType: TopCategoryType  // 모아보기 최상단 탭
+    var currentSubCategoryType: String?          /// 최상단 탭이 `카테고리`인 경우
+    var currentFilterType: [(type: FilterType, value: String)]
+    var fetchResultController: NSFetchedResultsController<PostEntity>?
+    private let batchSize: Int = 25
+    
+    // MARK: - init
+    /// 모아보기 처음 진입시, 초기 탭 및 FilterType을 초기화한다. ex) 전체 - 최신순
+    init() {
+        currentTopCategoryType = .total
+        currentFilterType = currentTopCategoryType.filterTypes.map { ($0, $0.defaultValue) }
+    }
+    
+    /// 드롭박스의 데이터를 선택했을 때 변경한 데이터로 FilterType을 변경한다.
+    /// - Parameters:
+    ///   - type: 해당 범주의 타입을 주입한다.
+    ///   - value: 해당 범주의 변경한 데이터를 주입한다.
+    func changeCurrentFilterType( type: FilterType, value: String ) {
+        guard let index = currentTopCategoryType.filterTypes.firstIndex(of: type) else {
+            return
+        }
+        currentFilterType[index].value = value
+    }
+    
+    /// 선택되어진 `FilterType`을 기반으로 `NSFetchRequest`를 작성한다.
+    /// - Returns: PostEntity의 NSFetchRequest를 반환한다.
+    private func currentNSFetchRequest() -> NSFetchRequest<PostEntity> {
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        var predicates: [NSPredicate] = [NSPredicate]()
+        if let subType: String = currentSubCategoryType {
+            // TODO: ⚠️ releationShip - Category 배열 - title 작성
+            predicates.append(NSPredicate(format: "", subType as String ))
+        }
+        currentFilterType.forEach {
+            switch $0.type {
+            case .latest:
+                let isAscending: Bool = $0.value == "최신순" ? false : true
+                request.sortDescriptors = [NSSortDescriptor(key: "createDate", ascending: isAscending)]
+                
+            // TODO: ⚠️ month, year 합쳐서 createDate로 NSPredicate 작성
+            case .month:
+                predicates.append(NSPredicate(format: "month == %@", $0.value))
+            case .year:
+                predicates.append(NSPredicate(format: "year == %@", $0.value))
+            case .preference:
+                // TODO: ⚠️ releationShip - rating - score 작성
+                request.sortDescriptors = [NSSortDescriptor(key: "rating.score", ascending: true)]
+            }
+        }
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+        return request
+    }
+    
+    /// 현재 상태에 따른 `NSfetchRequest`를 통하여 `NSFetchResultController`를 초기화하여 데이터를 가져와 completion 블록을 호출한다.
+    /// - Parameter completion: NSfetchResultsController의 데이터를 사용할 컬렉션뷰를 reload하도록 한다.
+    func fetchRequest(_ completion: @escaping (Result<Bool, Error>) -> Void ) {
+        let request: NSFetchRequest<PostEntity> = currentNSFetchRequest()
+        request.fetchBatchSize = batchSize
+        fetchResultController = NSFetchedResultsController(fetchRequest: request, managedObjectContext: CoreDataStack.shared.persistentContainer.viewContext, sectionNameKeyPath: nil, cacheName: nil)
+        do {
+            try fetchResultController?.performFetch()
+            completion(.success(true))
+        } catch {
+            completion(.failure(error))
+            print(error.localizedDescription)
+        }
+    }
+}

--- a/ThingLogTests/Info.plist
+++ b/ThingLogTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>4</string>
 </dict>
 </plist>

--- a/ThingLogUITests/Info.plist
+++ b/ThingLogUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>4</string>
 </dict>
 </plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,8 +23,8 @@ platform :ios do
       )
       upload_to_testflight
       slack(
-        message: "Testflight 배포에 성공했습니다!",
-        slack_url: "https://hooks.slack.com/services/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"
+        message:"Testflight 배포에 성공했습니다!",
+        slack_url:"https://hooks.slack.com/services/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"
       )
     end
   end
@@ -58,16 +58,16 @@ platform :ios do
         submission_information: { add_id_info_uses_idfa: false }
       )
       slack(
-        message: "App store 배포에 성공했습니다🎉!",
-        slack_url: "https://hooks.slack.com/services/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"
+        message:"App store 배포에 성공했습니다🎉!",
+        slack_url:"https://hooks.slack.com/services/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"
       )
     end
   end
   error do |lane, exception, options|
     slack(
-      message: "에러 발생 : #{exception}",
+      message:"에러 발생 : #{exception}",
       success: false,
-      slack_url: "https://hooks.slack.com/services/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"
+      slack_url:"https://hooks.slack.com/services/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"
     )
   end
 end


### PR DESCRIPTION
## 개요

모아보기 화면에 필요한 데이터 구조를 정의한다. 

## 기능명세서 
https://www.notion.so/5da3a1f300a14a4fa07040f35e9bf7e4 

## 작업 사항
- `FilterType` 객체 구현
    - ![image](https://user-images.githubusercontent.com/48749182/135078409-87a98fcb-b9d0-4bac-a9b6-8f44a7ff7d36.png)
    - 특정 탭에 대한 드롭박스의 필요한 데이터를 추상화한 객체다. 
    - 해당 타입을 앞으로 사용할 View에 주입하여 손쉽게 표현하고자 한다. 

- `TopCategoryType` 객체 구현
    - ![image](https://user-images.githubusercontent.com/48749182/135078525-c6084509-2b6d-40df-938e-7bae1f06a91b.png)
    - 최상단 탭에 대한 데이터를 추상화한 객체다. 
    - 각 탭마다 필요한 드롭박스들의 데이터( `FilterType` ) 를 제공한다. 

- `CategoryViewModel` 객체 구현 
    모아보기에서 뷰들을 터치할 경우 `CetegoryViewModel`들의 프로퍼티를 변경하여, 그에 맞는 조합으로 `NSFetchRequest`를 작성하여 `NSFetchResultsController`를 초기화한다. 

## ⚠️예외사항 
-  코드내에서도 TODO로 주석처리 한 부분은 나중에 구현할 때 다시 수정하려고 합니다. 

### Linked Issue

close #24 

