### PR TITLE
[#38] 모아보기 - 카테고리 선택시 하단에 나타나는 hortizontal ScrollView 구현 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		DBAE8EB126FDBEAE00F536AD /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */; };
 		DBAE8EBB26FDCA7B00F536AD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */; };
 		DBD5455027033D9A00063C98 /* RoundButtonCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD5454F27033D9A00063C98 /* RoundButtonCollectionViewCell.swift */; };
+		DBD545522703409300063C98 /* HorizontalCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD545512703409300063C98 /* HorizontalCollectionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -147,6 +148,7 @@
 		DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		DBD5454F27033D9A00063C98 /* RoundButtonCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundButtonCollectionViewCell.swift; sourceTree = "<group>"; };
+		DBD545512703409300063C98 /* HorizontalCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalCollectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -318,6 +320,7 @@
 				DB7C04FB26FB27A6009F5C0A /* TemplateImageButton.swift */,
 				DB7C04BD26F9BE72009F5C0A /* ProfileView.swift */,
 				DB7C04B826F87BE9009F5C0A /* ChoiceWritingView.swift */,
+				DBD545512703409300063C98 /* HorizontalCollectionView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -575,6 +578,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBAB64A526FCC2F8006D95ED /* HomeCoordinator.swift in Sources */,
+				DBD545522703409300063C98 /* HorizontalCollectionView.swift in Sources */,
 				DBAB64A426FCC2C5006D95ED /* Coordinator.swift in Sources */,
 				DB7C04EE26FB1ACE009F5C0A /* ContentsTabView.swift in Sources */,
 				DB7C04F426FB1F45009F5C0A /* BoughtContentsCollectionViewController.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		DBAE8E9826FDB3EE00F536AD /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8E9526FDB3EE00F536AD /* Pretendard-SemiBold.otf */; };
 		DBAE8EB126FDBEAE00F536AD /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */; };
 		DBAE8EBB26FDCA7B00F536AD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */; };
+		DBD5455027033D9A00063C98 /* RoundButtonCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD5454F27033D9A00063C98 /* RoundButtonCollectionViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -145,6 +146,7 @@
 		DBAE8E9526FDB3EE00F536AD /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		DBD5454F27033D9A00063C98 /* RoundButtonCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundButtonCollectionViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -324,6 +326,7 @@
 			isa = PBXGroup;
 			children = (
 				DB7C04E826FB19AE009F5C0A /* ContentsCollectionViewCell.swift */,
+				DBD5454F27033D9A00063C98 /* RoundButtonCollectionViewCell.swift */,
 			);
 			path = CollectionViewCell;
 			sourceTree = "<group>";
@@ -578,6 +581,7 @@
 				DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */,
 				DBAB64A726FE2AFF006D95ED /* UIImage+.swift in Sources */,
 				873EC00D26D39055003C3525 /* ViewController.swift in Sources */,
+				DBD5455027033D9A00063C98 /* RoundButtonCollectionViewCell.swift in Sources */,
 				DB7C04CA26F9E69D009F5C0A /* UserDefaults+.swift in Sources */,
 				DB7C04E526FB1981009F5C0A /* BaseContentsCollectionViewController.swift in Sources */,
 				DB7C04F626FB1F4B009F5C0A /* WishContentsCollectionViewController.swift in Sources */,

--- a/ThingLog/View/CollectionViewCell/RoundButtonCollectionViewCell.swift
+++ b/ThingLog/View/CollectionViewCell/RoundButtonCollectionViewCell.swift
@@ -1,0 +1,52 @@
+//
+//  RoundButtonCollectionViewCell.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/09/28.
+//
+
+import UIKit
+
+class RoundButtonCollectionViewCell: UICollectionViewCell {
+    private var button: UIButton = {
+        let button: UIButton = UIButton()
+        button.layer.cornerRadius = 13
+        button.layer.borderWidth = 1.0
+        button.layer.borderColor = SwiftGenColors.gray5.color.cgColor
+        button.titleLabel?.font = UIFont.Pretendard.body2
+        button.clipsToBounds = true
+        button.backgroundColor = SwiftGenColors.gray5.color
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setupView() {
+        contentView.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            button.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            button.topAnchor.constraint(equalTo: contentView.topAnchor)
+        ])
+    }
+}
+
+extension RoundButtonCollectionViewCell {
+    func updateView(title: String) {
+        button.setTitle(title, for: .normal)
+    }
+    
+    func changeButtonColor(isSelected: Bool) {
+        button.backgroundColor = isSelected ? SwiftGenColors.gray5.color : SwiftGenColors.white.color
+        button.setTitleColor(isSelected ? SwiftGenColors.white.color : SwiftGenColors.gray5.color, for: .normal)
+    }
+}

--- a/ThingLog/View/CollectionViewCell/RoundButtonCollectionViewCell.swift
+++ b/ThingLog/View/CollectionViewCell/RoundButtonCollectionViewCell.swift
@@ -7,18 +7,24 @@
 
 import UIKit
 
-class RoundButtonCollectionViewCell: UICollectionViewCell {
+final class RoundButtonCollectionViewCell: UICollectionViewCell {
     private var button: UIButton = {
         let button: UIButton = UIButton()
-        button.layer.cornerRadius = 13
         button.layer.borderWidth = 1.0
         button.layer.borderColor = SwiftGenColors.gray5.color.cgColor
         button.titleLabel?.font = UIFont.Pretendard.body2
         button.clipsToBounds = true
-        button.backgroundColor = SwiftGenColors.gray5.color
+        button.backgroundColor = SwiftGenColors.white.color
+        button.setTitleColor(SwiftGenColors.gray5.color, for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.isUserInteractionEnabled = false 
         return button
     }()
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        changeButtonColor(isSelected: false)
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -31,6 +37,7 @@ class RoundButtonCollectionViewCell: UICollectionViewCell {
     
     private func setupView() {
         contentView.addSubview(button)
+        contentView.backgroundColor = SwiftGenColors.white.color
         NSLayoutConstraint.activate([
             button.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             button.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
@@ -41,8 +48,9 @@ class RoundButtonCollectionViewCell: UICollectionViewCell {
 }
 
 extension RoundButtonCollectionViewCell {
-    func updateView(title: String) {
+    func updateView(title: String, cornerRadius: CGFloat) {
         button.setTitle(title, for: .normal)
+        button.layer.cornerRadius = cornerRadius
     }
     
     func changeButtonColor(isSelected: Bool) {

--- a/ThingLog/View/HorizontalCollectionView.swift
+++ b/ThingLog/View/HorizontalCollectionView.swift
@@ -1,0 +1,139 @@
+//
+//  HorizontalCollectionView.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/09/28.
+//
+
+import UIKit
+
+/// 모아보기에서 최상단 카테고리 - "카테고리"를 선택했을 때, `CategoryEntity`들을 `horizontal`로 스크롤 가능한 뷰를 구성하기위한 뷰입니다.
+final class HorizontalCollectionView: UIView {
+    private var collectionView: UICollectionView = {
+        let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
+        flowLayout.minimumInteritemSpacing = 10
+        flowLayout.scrollDirection = .horizontal
+        let collectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.register(RoundButtonCollectionViewCell.self, forCellWithReuseIdentifier: RoundButtonCollectionViewCell.reuseIdentifier)
+        collectionView.backgroundColor = SwiftGenColors.white.color
+        collectionView.showsHorizontalScrollIndicator = false
+        return collectionView
+    }()
+    
+    // MARK: - Properties
+    // TODO: ⚠️ 추후에 Category 로 변경할 예정입니당  ( CategoryEntity의 객체 )
+    var categoryList: [String] = []
+    private var selectedIndexCell: IndexPath = IndexPath(item: 0, section: 0)
+    private let maxCollectionViewLeadingConstant: CGFloat = 16.0
+    private let maxCollectionViewTrailingConstant: CGFloat = -16.0
+    private var collectionViewLeadingAnchor: NSLayoutConstraint?
+    private var collectionViewTrailingAnchor: NSLayoutConstraint?
+    private let animationDuration: TimeInterval = 0.1
+    private let buttonHeight: CGFloat = 26
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setupView() {
+        backgroundColor = SwiftGenColors.white.color
+        addSubview(collectionView)
+        
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        
+        collectionViewLeadingAnchor = collectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: maxCollectionViewLeadingConstant)
+        collectionViewTrailingAnchor = collectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0)
+        collectionViewTrailingAnchor?.isActive = true
+        collectionViewLeadingAnchor?.isActive = true
+        NSLayoutConstraint.activate([
+            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            collectionView.topAnchor.constraint(equalTo: topAnchor)
+        ])
+    }
+    
+    /// 외부에서 CategoryEntity 리스트를 Fetch하여 reload시키기 위함입니다.
+    func reloadData() {
+        collectionView.reloadData()
+    }
+}
+
+extension HorizontalCollectionView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        categoryList.count
+    }
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RoundButtonCollectionViewCell.reuseIdentifier, for: indexPath) as? RoundButtonCollectionViewCell else { return UICollectionViewCell() }
+        
+        if selectedIndexCell == indexPath {
+            cell.changeButtonColor(isSelected: true)
+        }
+        cell.updateView(title: categoryList[indexPath.item], cornerRadius: buttonHeight / 2)
+        
+        return cell
+    }
+}
+
+extension HorizontalCollectionView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? RoundButtonCollectionViewCell else {
+            return
+        }
+        cell.changeButtonColor(isSelected: true)
+        
+        if selectedIndexCell != indexPath,
+           let cell: RoundButtonCollectionViewCell = collectionView.cellForItem(at: selectedIndexCell) as? RoundButtonCollectionViewCell {
+            cell.changeButtonColor(isSelected: false)
+        }
+        selectedIndexCell = indexPath
+    }
+}
+
+extension HorizontalCollectionView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let item: String = categoryList[indexPath.row]
+        var itemSize: CGSize = item.size(withAttributes: [
+            NSAttributedString.Key.font: UIFont.Pretendard.body2
+        ])
+        itemSize.width += 20
+        itemSize.height = buttonHeight
+        return itemSize
+    }
+}
+
+extension HorizontalCollectionView: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let nextOffsetX: CGFloat = scrollView.contentOffset.x
+        
+        // 왼쪽 애니메이션
+        UIView.animate(withDuration: animationDuration) {
+            if nextOffsetX <= 0 {
+                self.collectionViewLeadingAnchor?.constant = self.maxCollectionViewLeadingConstant
+                return
+            }
+            self.collectionViewLeadingAnchor?.constant = max(self.maxCollectionViewLeadingConstant - nextOffsetX, 0)
+        }
+        
+        // 오른쪽 애니메이션
+        UIView.animate(withDuration: animationDuration) {
+            let totalOffsetX: CGFloat = nextOffsetX + scrollView.frame.width
+            if totalOffsetX >= scrollView.contentSize.width {
+                self.collectionViewTrailingAnchor?.constant = self.maxCollectionViewTrailingConstant
+                return
+            }
+            self.collectionViewTrailingAnchor?.constant = min(0, (scrollView.contentSize.width - totalOffsetX + self.maxCollectionViewTrailingConstant))
+        }
+    }
+}

--- a/ThingLog/View/HorizontalCollectionView.swift
+++ b/ThingLog/View/HorizontalCollectionView.swift
@@ -13,6 +13,7 @@ final class HorizontalCollectionView: UIView {
         let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumInteritemSpacing = 10
         flowLayout.scrollDirection = .horizontal
+        flowLayout.sectionInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         let collectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.register(RoundButtonCollectionViewCell.self, forCellWithReuseIdentifier: RoundButtonCollectionViewCell.reuseIdentifier)
@@ -25,11 +26,6 @@ final class HorizontalCollectionView: UIView {
     // TODO: ⚠️ 추후에 Category 로 변경할 예정입니당  ( CategoryEntity의 객체 )
     var categoryList: [String] = []
     private var selectedIndexCell: IndexPath = IndexPath(item: 0, section: 0)
-    private let maxCollectionViewLeadingConstant: CGFloat = 16.0
-    private let maxCollectionViewTrailingConstant: CGFloat = -16.0
-    private var collectionViewLeadingAnchor: NSLayoutConstraint?
-    private var collectionViewTrailingAnchor: NSLayoutConstraint?
-    private let animationDuration: TimeInterval = 0.1
     private let buttonHeight: CGFloat = 26
     
     // MARK: - Init
@@ -48,12 +44,10 @@ final class HorizontalCollectionView: UIView {
         
         collectionView.delegate = self
         collectionView.dataSource = self
-        
-        collectionViewLeadingAnchor = collectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: maxCollectionViewLeadingConstant)
-        collectionViewTrailingAnchor = collectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0)
-        collectionViewTrailingAnchor?.isActive = true
-        collectionViewLeadingAnchor?.isActive = true
+
         NSLayoutConstraint.activate([
+            collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
             collectionView.topAnchor.constraint(equalTo: topAnchor)
         ])
@@ -110,30 +104,5 @@ extension HorizontalCollectionView: UICollectionViewDelegateFlowLayout {
         itemSize.width += 20
         itemSize.height = buttonHeight
         return itemSize
-    }
-}
-
-extension HorizontalCollectionView: UIScrollViewDelegate {
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let nextOffsetX: CGFloat = scrollView.contentOffset.x
-        
-        // 왼쪽 애니메이션
-        UIView.animate(withDuration: animationDuration) {
-            if nextOffsetX <= 0 {
-                self.collectionViewLeadingAnchor?.constant = self.maxCollectionViewLeadingConstant
-                return
-            }
-            self.collectionViewLeadingAnchor?.constant = max(self.maxCollectionViewLeadingConstant - nextOffsetX, 0)
-        }
-        
-        // 오른쪽 애니메이션
-        UIView.animate(withDuration: animationDuration) {
-            let totalOffsetX: CGFloat = nextOffsetX + scrollView.frame.width
-            if totalOffsetX >= scrollView.contentSize.width {
-                self.collectionViewTrailingAnchor?.constant = self.maxCollectionViewTrailingConstant
-                return
-            }
-            self.collectionViewTrailingAnchor?.constant = min(0, (scrollView.contentSize.width - totalOffsetX + self.maxCollectionViewTrailingConstant))
-        }
     }
 }


### PR DESCRIPTION
## 개요

- 모아보기 - 카테고리 - 카테고리 선택시 하단에 나타나는 horizontal scrollView 구현하기. 
-   ![image](https://user-images.githubusercontent.com/48749182/135119093-f0764116-8dc2-4584-ac9f-8741cd0ceebc.png)

## 시연
![horizontalScrollView](https://user-images.githubusercontent.com/48749182/135119046-741e2d01-fc31-4019-8c39-60dba5db8462.gif)


## 작업 사항
- `RoundButtonCollectionViewCell` 구현
- `HoriztonalCollectionView` 구현 

### Linked Issue

close #38 

## Test Code 
```swift
import UIKit 
class ViewController: UIViewController {
    var horizontalView: HorizontalCollectionView = {
        let view =  HorizontalCollectionView()
        view.translatesAutoresizingMaskIntoConstraints = false
        return view
    }()
    override func viewDidLoad() {
        super.viewDidLoad()
        view.backgroundColor = .black
        view.addSubview(horizontalView)
        horizontalView.categoryList = ["학용품","다이어리","학용품","다이어리","학용품","다이어리","학용품","다이어리", "학용품","다이어리","학용품","다이어리","학용품","다이어리","학용품","다이어리"]
        NSLayoutConstraint.activate([
            horizontalView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
            horizontalView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
            horizontalView.topAnchor.constraint(equalTo: view.topAnchor, constant: 100),
            horizontalView.heightAnchor.constraint(equalToConstant: 44)
        ])
        // Do any additional setup after loading the view.
    }
}

```

