### PR TITLE
[#36] 모아보기 화면 배치 구현 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -26,12 +26,12 @@
 		873EC04A26D504BA003C3525 /* RxCocoa.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 873EC04026D504BA003C3525 /* RxCocoa.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		873EC04E26D5068F003C3525 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 873EC04D26D5068F003C3525 /* .swiftlint.yml */; };
 		875A966026F0E4EB001BF0D0 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875A965F26F0E4EB001BF0D0 /* CoreDataStack.swift */; };
-		DB148C2C2705855A00FDC48F /* CategoryTypeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C2B2705855A00FDC48F /* CategoryTypeButton.swift */; };
-		DB148C302705863100FDC48F /* CategoryTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C2F2705863100FDC48F /* CategoryTabView.swift */; };
 		DB148C2027043CFC00FDC48F /* DropBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C1F27043CFC00FDC48F /* DropBoxView.swift */; };
 		DB148C222704623200FDC48F /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C212704623200FDC48F /* InsetButton.swift */; };
 		DB148C26270469B300FDC48F /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C25270469B300FDC48F /* Date+.swift */; };
 		DB148C282704A1A600FDC48F /* IgnoreTouchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C272704A1A500FDC48F /* IgnoreTouchView.swift */; };
+		DB148C2C2705855A00FDC48F /* CategoryTypeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C2B2705855A00FDC48F /* CategoryTypeButton.swift */; };
+		DB148C302705863100FDC48F /* CategoryTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C2F2705863100FDC48F /* CategoryTabView.swift */; };
 		DB331DA926FDD00A00A629F5 /* ColorsAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA626FDD00A00A629F5 /* ColorsAsset.swift */; };
 		DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA726FDD00A00A629F5 /* ImageAssets.swift */; };
 		DB331DAB26FDD00A00A629F5 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA826FDD00A00A629F5 /* Fonts.swift */; };
@@ -53,6 +53,7 @@
 		DB7C04F826FB1F52009F5C0A /* GiftContentsCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04F726FB1F52009F5C0A /* GiftContentsCollectionViewController.swift */; };
 		DB7C04FC26FB27A6009F5C0A /* TemplateImageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04FB26FB27A6009F5C0A /* TemplateImageButton.swift */; };
 		DB8BF6792705D25700FD5FDB /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6782705D25700FD5FDB /* LogoView.swift */; };
+		DB8BF6812706D89E00FD5FDB /* CategoryFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6802706D89E00FD5FDB /* CategoryFilterView.swift */; };
 		DBA1FD4526FB701C00F50DE5 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DBA1FD4726FB701C00F50DE5 /* InfoPlist.strings */; };
 		DBAB64A426FCC2C5006D95ED /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04A526F5F281009F5C0A /* Coordinator.swift */; };
 		DBAB64A526FCC2F8006D95ED /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04A726F5F2BB009F5C0A /* HomeCoordinator.swift */; };
@@ -126,12 +127,12 @@
 		873EC04026D504BA003C3525 /* RxCocoa.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxCocoa.xcframework; path = Carthage/Build/RxCocoa.xcframework; sourceTree = "<group>"; };
 		873EC04D26D5068F003C3525 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		875A965F26F0E4EB001BF0D0 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
-		DB148C2B2705855A00FDC48F /* CategoryTypeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTypeButton.swift; sourceTree = "<group>"; };
-		DB148C2F2705863100FDC48F /* CategoryTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTabView.swift; sourceTree = "<group>"; };
 		DB148C1F27043CFC00FDC48F /* DropBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropBoxView.swift; sourceTree = "<group>"; };
 		DB148C212704623200FDC48F /* InsetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetButton.swift; sourceTree = "<group>"; };
 		DB148C25270469B300FDC48F /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		DB148C272704A1A500FDC48F /* IgnoreTouchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreTouchView.swift; sourceTree = "<group>"; };
+		DB148C2B2705855A00FDC48F /* CategoryTypeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTypeButton.swift; sourceTree = "<group>"; };
+		DB148C2F2705863100FDC48F /* CategoryTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTabView.swift; sourceTree = "<group>"; };
 		DB331DA626FDD00A00A629F5 /* ColorsAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorsAsset.swift; sourceTree = "<group>"; };
 		DB331DA726FDD00A00A629F5 /* ImageAssets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAssets.swift; sourceTree = "<group>"; };
 		DB331DA826FDD00A00A629F5 /* Fonts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
@@ -155,6 +156,7 @@
 		DB7C04F726FB1F52009F5C0A /* GiftContentsCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftContentsCollectionViewController.swift; sourceTree = "<group>"; };
 		DB7C04FB26FB27A6009F5C0A /* TemplateImageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateImageButton.swift; sourceTree = "<group>"; };
 		DB8BF6782705D25700FD5FDB /* LogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoView.swift; sourceTree = "<group>"; };
+		DB8BF6802706D89E00FD5FDB /* CategoryFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFilterView.swift; sourceTree = "<group>"; };
 		DBA1FD3C26FB6F1D00F50DE5 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		DBA1FD4626FB701C00F50DE5 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		DBA1FD4826FB701F00F50DE5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -350,6 +352,7 @@
 				DB8BF6782705D25700FD5FDB /* LogoView.swift */,
 				DB148C2B2705855A00FDC48F /* CategoryTypeButton.swift */,
 				DB148C2F2705863100FDC48F /* CategoryTabView.swift */,
+				DB8BF6802706D89E00FD5FDB /* CategoryFilterView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -621,6 +624,7 @@
 				DB7C04CA26F9E69D009F5C0A /* UserDefaults+.swift in Sources */,
 				DB148C2C2705855A00FDC48F /* CategoryTypeButton.swift in Sources */,
 				DB7C04E526FB1981009F5C0A /* BaseContentsCollectionViewController.swift in Sources */,
+				DB8BF6812706D89E00FD5FDB /* CategoryFilterView.swift in Sources */,
 				DB7C04F626FB1F4B009F5C0A /* WishContentsCollectionViewController.swift in Sources */,
 				DB148C222704623200FDC48F /* InsetButton.swift in Sources */,
 				DB7C04EC26FB1A04009F5C0A /* UIView+.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		DB7C04FC26FB27A6009F5C0A /* TemplateImageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04FB26FB27A6009F5C0A /* TemplateImageButton.swift */; };
 		DB8BF6792705D25700FD5FDB /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6782705D25700FD5FDB /* LogoView.swift */; };
 		DB8BF6812706D89E00FD5FDB /* CategoryFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6802706D89E00FD5FDB /* CategoryFilterView.swift */; };
+		DB8BF6832706DA7900FD5FDB /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6822706DA7900FD5FDB /* CategoryView.swift */; };
 		DBA1FD4526FB701C00F50DE5 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DBA1FD4726FB701C00F50DE5 /* InfoPlist.strings */; };
 		DBAB64A426FCC2C5006D95ED /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04A526F5F281009F5C0A /* Coordinator.swift */; };
 		DBAB64A526FCC2F8006D95ED /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04A726F5F2BB009F5C0A /* HomeCoordinator.swift */; };
@@ -157,6 +158,7 @@
 		DB7C04FB26FB27A6009F5C0A /* TemplateImageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateImageButton.swift; sourceTree = "<group>"; };
 		DB8BF6782705D25700FD5FDB /* LogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoView.swift; sourceTree = "<group>"; };
 		DB8BF6802706D89E00FD5FDB /* CategoryFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFilterView.swift; sourceTree = "<group>"; };
+		DB8BF6822706DA7900FD5FDB /* CategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryView.swift; sourceTree = "<group>"; };
 		DBA1FD3C26FB6F1D00F50DE5 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		DBA1FD4626FB701C00F50DE5 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		DBA1FD4826FB701F00F50DE5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 				DB148C2B2705855A00FDC48F /* CategoryTypeButton.swift */,
 				DB148C2F2705863100FDC48F /* CategoryTabView.swift */,
 				DB8BF6802706D89E00FD5FDB /* CategoryFilterView.swift */,
+				DB8BF6822706DA7900FD5FDB /* CategoryView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -645,6 +648,7 @@
 				87078B5B26EA44B5007AE242 /* ThingLog.xcdatamodeld in Sources */,
 				873EC00926D39055003C3525 /* AppDelegate.swift in Sources */,
 				DB7C04C726F9E693009F5C0A /* UserInformationViewModel.swift in Sources */,
+				DB8BF6832706DA7900FD5FDB /* CategoryView.swift in Sources */,
 				873EC00B26D39055003C3525 /* SceneDelegate.swift in Sources */,
 				8736B3F426FDD55E000433E1 /* UIFont+.swift in Sources */,
 				DBD5454C27032C6600063C98 /* CategoryViewModel.swift in Sources */,

--- a/ThingLog/View/CategoryFilterView.swift
+++ b/ThingLog/View/CategoryFilterView.swift
@@ -1,0 +1,110 @@
+//
+//  CategoryFilterView.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/01.
+//
+
+import UIKit
+
+/// 모아보기 - 상단 카테고리 탭에서 선택에 따라 검색결과 및 `DropBoxView`들을 구성하는 View다.
+final class CategoryFilterView: UIView {
+    // MARK: - View
+    private let emptyView: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = SwiftGenColors.white.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return view
+    }()
+    
+    private let resultTotalLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.font = UIFont.Pretendard.body2
+        label.textColor = SwiftGenColors.gray3.color
+        label.text = "총 0건"
+        label.backgroundColor = SwiftGenColors.white.color
+        return label
+    }()
+    
+    private let emptyLeadingView: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = SwiftGenColors.white.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    lazy var stackView: UIStackView = {
+        let stackView: UIStackView = UIStackView()
+        stackView.backgroundColor = .white
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    // MARK: - Properties
+    // DropBox뷰를 addSubView할 superView 프로퍼티다 ( ViewController.view )
+    private var superView: UIView
+    
+    private let leadingMarginConstraint: CGFloat = 16
+    
+    // MARK: - Init
+    /// 현재 해당 뷰가 뷰 계층 구조에서 최상단에 속해있는 view를 넣는다.
+    /// - Parameter superView: VIewController의 View를 넣는다
+    init(superView: UIView) {
+        self.superView = superView
+        super.init(frame: .zero)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        self.superView = UIView()
+        super.init(coder: coder)
+    }
+    
+    private func setupView() {
+        backgroundColor = SwiftGenColors.white.color
+        addSubview(stackView)
+        
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        
+        updateDropBoxView(.total, superView: superView)
+    }
+}
+
+extension CategoryFilterView {
+    /// 상단 카테고리의 탭을 클릭할 때 마다 DropBoxView의 구성을 변경하기 위한 메소드이다.
+    /// - Parameters:
+    ///   - type: 클릭한 카테고리의 탭의 타입( TopCategoryType ) 을 넣는다.
+    ///   - superView: 현재 해당 뷰가 뷰 계층 구조에서 최상단에 속해있는 view를 넣는다. ( VIewController의 View를 넣는다 )
+    func updateDropBoxView(_ type: TopCategoryType, superView: UIView ) {
+        // 기존 stackView를 모두 제거한다.
+        stackView.arrangedSubviews.forEach {
+            $0.removeFromSuperview()
+        }
+        stackView.addArrangedSubview(emptyLeadingView)
+        stackView.addArrangedSubview(resultTotalLabel)
+        stackView.addArrangedSubview(emptyView)
+        
+        emptyLeadingView.widthAnchor.constraint(equalToConstant: leadingMarginConstraint).isActive = true
+        
+        type.filterTypes.forEach {
+            let dropBox: DropBoxView = DropBoxView(type: $0, superView: superView)
+            dropBox.translatesAutoresizingMaskIntoConstraints = false
+            stackView.addArrangedSubview(dropBox)
+            NSLayoutConstraint.activate([
+                dropBox.widthAnchor.constraint(equalToConstant: dropBox.titleButton.intrinsicContentSize.width)
+            ])
+        }
+    }
+    
+    /// 결과에 따른 총 게시물 검색 수를 변경하기 위한 메서드다.
+    /// - Parameter totalCount: 총 게시물 검색 수를 지정한다.
+    func udpateResultTotalLabel(totalCount: Int ) {
+        resultTotalLabel.text = "총 " + String(totalCount) + "건"
+    }
+}

--- a/ThingLog/View/CategoryTabView.swift
+++ b/ThingLog/View/CategoryTabView.swift
@@ -35,7 +35,7 @@ final class CategoryTabView: UIView {
     private var selectedButton: CategoryTypeButton?
     
     var topCategoryTypeSubject: PublishSubject<TopCategoryType> = PublishSubject()
-    var previousTopCateogryType: TopCategoryType = .total
+    private var previousTopCateogryType: TopCategoryType = .total
     
     let marginConstant: CGFloat = 15.0
     

--- a/ThingLog/View/CategoryTabView.swift
+++ b/ThingLog/View/CategoryTabView.swift
@@ -35,6 +35,7 @@ final class CategoryTabView: UIView {
     private var selectedButton: CategoryTypeButton?
     
     var topCategoryTypeSubject: PublishSubject<TopCategoryType> = PublishSubject()
+    var previousTopCateogryType: TopCategoryType = .total
     
     let marginConstant: CGFloat = 15.0
     
@@ -85,6 +86,11 @@ final class CategoryTabView: UIView {
         selectedButton?.updateColor(isTint: false)
         sender.updateColor(isTint: true)
         selectedButton = sender
+        // 같은 탭의 클릭은 무시하기 위함이다.
+        if previousTopCateogryType == sender.type {
+            return
+        }
+        previousTopCateogryType = sender.type
         topCategoryTypeSubject.onNext(sender.type)
     }
 }

--- a/ThingLog/View/CategoryView.swift
+++ b/ThingLog/View/CategoryView.swift
@@ -1,0 +1,110 @@
+//
+//  CategoryView.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/01.
+//
+
+import RxSwift
+import UIKit
+
+/// 모아보기 최상단에 뷰를 구성하는 뷰이다.
+final class CategoryView: UIView {
+    // MARK: - View
+    var categoryTapView: CategoryTabView = {
+        let categoryTabView: CategoryTabView = CategoryTabView()
+        categoryTabView.translatesAutoresizingMaskIntoConstraints = false
+        categoryTabView.setContentCompressionResistancePriority(.required, for: .vertical)
+        return categoryTabView
+    }()
+    
+    private var borderLineView: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = SwiftGenColors.gray5.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    var horizontalCollectionView: HorizontalCollectionView = {
+        let horizontalCollectionView: HorizontalCollectionView = HorizontalCollectionView()
+        horizontalCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        horizontalCollectionView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        return horizontalCollectionView
+    }()
+    
+    var categoryFilterView: CategoryFilterView
+    
+    private lazy var stackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [
+            categoryTapView,
+            borderLineView,
+            horizontalCollectionView,
+            categoryFilterView
+        ])
+        stackView.axis = .vertical
+        stackView.backgroundColor = SwiftGenColors.white.color
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    // MARK: - Properties
+    private var superView: UIView
+    
+    private let categoryContentsConstraint: CGFloat = 44
+    private let borderLineHeightConstraint: CGFloat = 1
+    
+    // 외부에서 참조하기 위한 뷰 사이즈다. 카테고리를 클릭했을 때 최대 높이를 반환한다.
+    var maxHeight: CGFloat {
+        categoryContentsConstraint * 3 + borderLineHeightConstraint
+    }
+    // 외부에서 참조하기 위한 뷰 사이즈다. 카테고리를 클릭하지 않았을 때 최대 높이를 반환한다.
+    var normalHeight: CGFloat {
+        categoryContentsConstraint * 2 + borderLineHeightConstraint
+    }
+    
+    private var disposeBag: DisposeBag = DisposeBag()
+    
+    // MARK: - Init
+    
+    /// 뷰를 초기화하는 메서드이며, CategoryFilterView의 DropBoxView의 계층구조를 위해 ViewController 의 view가 필요하다.
+    /// - Parameter superView: ViewController의 view를 주입한다.
+    init(superView: UIView) {
+        self.superView = superView
+        self.categoryFilterView = {
+            let categoryFilterView: CategoryFilterView = CategoryFilterView(superView: superView)
+            categoryFilterView.setContentCompressionResistancePriority(.required, for: .vertical)
+            return categoryFilterView
+        }()
+        
+        super.init(frame: .zero)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        self.categoryFilterView = CategoryFilterView(superView: UIView())
+        self.superView = UIView()
+        super.init(coder: coder)
+    }
+    
+    private func setupView() {
+        addSubview(stackView)
+        
+        let const1: NSLayoutConstraint = categoryTapView.heightAnchor.constraint(equalToConstant: categoryContentsConstraint)
+        let const2: NSLayoutConstraint = borderLineView.heightAnchor.constraint(equalToConstant: borderLineHeightConstraint)
+        let const3: NSLayoutConstraint = categoryFilterView.heightAnchor.constraint(equalToConstant: categoryContentsConstraint)
+        
+        const1.priority = UILayoutPriority(rawValue: 900)
+        const2.priority = UILayoutPriority(rawValue: 800)
+        const3.priority = UILayoutPriority(rawValue: 700)
+        
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            const1,
+            const3,
+            const2
+        ])
+    }
+}

--- a/ThingLog/View/DropBoxView.swift
+++ b/ThingLog/View/DropBoxView.swift
@@ -34,7 +34,7 @@ final class DropBoxView: UIView {
         tableView.isScrollEnabled = true
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.reuseIdentifier)
         tableView.clipsToBounds = true
-        tableView.showsVerticalScrollIndicator = false 
+        tableView.showsVerticalScrollIndicator = false
         return tableView
     }()
     
@@ -51,6 +51,8 @@ final class DropBoxView: UIView {
     // TableView를 외부 View에 추가하기 위해 필요한 UIView 프로퍼티
     private var superView: UIView?
     private var isShowingDropBox: Bool = false
+    // 최초로 버튼을 클릭했는지 여부를 확인하기 위한 프로퍼티이다.
+    private var isFirstClickButton: Bool = true
     private let tableViewCellHeight: CGFloat = 28
     private var maxTableViewHeight: CGFloat {
         if filterType.list.count >= 4 {
@@ -83,10 +85,6 @@ final class DropBoxView: UIView {
         super.init(coder: coder)
     }
     
-    override func didMoveToSuperview() {
-        setupTableView()
-    }
-    
     // MARK: - Setup
     private func setupView() {
         backgroundColor = SwiftGenColors.white.color
@@ -112,7 +110,8 @@ final class DropBoxView: UIView {
             tableView.trailingAnchor.constraint(equalTo: trailingAnchor),
             tableView.topAnchor.constraint(equalTo: bottomAnchor, constant: 1)
         ])
-        tableView.selectRow(at: selectedIndexPath, animated: true, scrollPosition: .top)
+        superView?.layoutIfNeeded()
+        tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .top)
     }
 }
 
@@ -123,6 +122,12 @@ extension DropBoxView {
     
     @objc
     func clickButton() {
+        // TableView ( dropBox )를 버튼을 최초로 클릭했을 때 constraint를 지정한다.
+        if isFirstClickButton {
+            setupTableView()
+            isFirstClickButton = false
+        }
+        
         changeButtonImageView()
     }
     
@@ -179,6 +184,7 @@ extension DropBoxView: UITableViewDataSource {
         let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: UITableViewCell.reuseIdentifier, for: indexPath)
         cell.selectionStyle = .none
         cell.backgroundColor = SwiftGenColors.white.color
+        cell.contentView.backgroundColor = SwiftGenColors.white.color
         cell.textLabel?.text = filterType.list[indexPath.row]
         cell.textLabel?.font = selectedIndexPath == indexPath ? UIFont.Pretendard.title3 : UIFont.Pretendard.body3
         cell.textLabel?.textColor = selectedIndexPath == indexPath ? SwiftGenColors.black.color : SwiftGenColors.gray4.color

--- a/ThingLog/View/HorizontalCollectionView.swift
+++ b/ThingLog/View/HorizontalCollectionView.swift
@@ -5,6 +5,7 @@
 //  Created by hyunsu on 2021/09/28.
 //
 
+import RxSwift
 import UIKit
 
 /// 모아보기에서 최상단 카테고리 - "카테고리"를 선택했을 때, `CategoryEntity`들을 `horizontal`로 스크롤 가능한 뷰를 구성하기위한 뷰입니다.
@@ -27,6 +28,9 @@ final class HorizontalCollectionView: UIView {
     var categoryList: [String] = []
     private var selectedIndexCell: IndexPath = IndexPath(item: 0, section: 0)
     private let buttonHeight: CGFloat = 26
+    
+    // 특정 Category를 선택할 때 마다 전달하기 위한 subject입니다.
+    var categoryTitleSubject: PublishSubject<String> = PublishSubject()
     
     // MARK: - Init
     override init(frame: CGRect) {
@@ -92,6 +96,7 @@ extension HorizontalCollectionView: UICollectionViewDelegate {
             cell.changeButtonColor(isSelected: false)
         }
         selectedIndexCell = indexPath
+        categoryTitleSubject.onNext(categoryList[indexPath.row])
     }
 }
 

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -50,14 +50,14 @@ final class CategoryViewController: UIViewController {
     // MARK: - Setup
     func setupCategoryView() {
         view.addSubview(categoryView)
-        let safeLayoutGide: UILayoutGuide = view.safeAreaLayoutGuide
+        let safeLayoutGuide: UILayoutGuide = view.safeAreaLayoutGuide
         categoryViewHeightConstriant = categoryView.heightAnchor.constraint(equalToConstant: categoryView.normalHeight)
         self.currentCategoryHeight = categoryView.normalHeight
         categoryViewHeightConstriant?.isActive = true
         NSLayoutConstraint.activate([
-            categoryView.leadingAnchor.constraint(equalTo: safeLayoutGide.leadingAnchor),
-            categoryView.trailingAnchor.constraint(equalTo: safeLayoutGide.trailingAnchor),
-            categoryView.topAnchor.constraint(equalTo: safeLayoutGide.topAnchor)
+            categoryView.leadingAnchor.constraint(equalTo: safeLayoutGuide.leadingAnchor),
+            categoryView.trailingAnchor.constraint(equalTo: safeLayoutGuide.trailingAnchor),
+            categoryView.topAnchor.constraint(equalTo: safeLayoutGuide.topAnchor)
         ])
     }
     

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -4,17 +4,87 @@
 //
 //  Created by hyunsu on 2021/09/20.
 //
-
+import RxSwift
 import UIKit
 
 final class CategoryViewController: UIViewController {
     var coordinator: Coordinator?
     
+    lazy var categoryView: CategoryView = {
+        let categoryView: CategoryView = CategoryView(superView: view)
+        categoryView.translatesAutoresizingMaskIntoConstraints = false
+        view.setContentCompressionResistancePriority(.required, for: .vertical)
+        return categoryView
+    }()
+    
+    // 게시물들을 보여주는 CollectioView가 담길 View이다.
+    var contentsContainerView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        return view
+    }()
+    
+    let contentsViewController: BaseContentsCollectionViewController = BaseContentsCollectionViewController()
+       
+    var viewModel: CategoryViewModel = CategoryViewModel()
+
+    var categoryViewHeightConstriant: NSLayoutConstraint?
+    var currentCategoryHeight: CGFloat = 0
+    var disposeBag: DisposeBag = DisposeBag()
+
     // MARK: - Life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = SwiftGenColors.white.color
         setupNavigationBar()
+        setupCategoryView()
+        setupContainerView()
+        setupContentsController()
+        
+        subscribeCategoryView()
+        subscribeCategoryFilterView()
+        subscribeHorizontalCollectionView()
+    }
+    
+    // MARK: - Setup
+    func setupCategoryView() {
+        view.addSubview(categoryView)
+        let safeLayoutGide: UILayoutGuide = view.safeAreaLayoutGuide
+        categoryViewHeightConstriant = categoryView.heightAnchor.constraint(equalToConstant: categoryView.normalHeight)
+        self.currentCategoryHeight = categoryView.normalHeight
+        categoryViewHeightConstriant?.isActive = true
+        NSLayoutConstraint.activate([
+            categoryView.leadingAnchor.constraint(equalTo: safeLayoutGide.leadingAnchor),
+            categoryView.trailingAnchor.constraint(equalTo: safeLayoutGide.trailingAnchor),
+            categoryView.topAnchor.constraint(equalTo: safeLayoutGide.topAnchor)
+        ])
+    }
+    
+    func setupContainerView() {
+        view.addSubview(contentsContainerView)
+        NSLayoutConstraint.activate([
+            contentsContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            contentsContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            contentsContainerView.topAnchor.constraint(equalTo: categoryView.bottomAnchor),
+            contentsContainerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    func setupContentsController() {
+        addChild(contentsViewController)
+        contentsViewController.setupBaseCollectionView()
+        
+        contentsContainerView.addSubview(contentsViewController.view)
+        let contentsView: UIView = contentsViewController.view
+        contentsView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            contentsView.leadingAnchor.constraint(equalTo: contentsContainerView.leadingAnchor),
+            contentsView.trailingAnchor.constraint(equalTo: contentsContainerView.trailingAnchor),
+            contentsView.topAnchor.constraint(equalTo: contentsContainerView.topAnchor),
+            contentsView.bottomAnchor.constraint(equalTo: contentsContainerView.bottomAnchor)
+        ])
     }
     
     func setupNavigationBar() {
@@ -48,5 +118,77 @@ final class CategoryViewController: UIViewController {
         let spacingBarButton: UIBarButtonItem = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
         spacingBarButton.width = 24
         navigationItem.rightBarButtonItems = [settingBarButton, spacingBarButton, searchBarButton]
+    }
+}
+
+extension CategoryViewController {
+    /// CategoryView의 액션에 맞게 원하는 결과값이 담기는지 확인하기 위한 메서드다. 이것이 성공한다면 각 조합에 맞는 fetchRequest가 정상적으로 호출할 수 있다.
+    func testViewModel() {
+        print(viewModel.currentTopCategoryType)
+        print(viewModel.currentSubCategoryType)
+        print(viewModel.currentFilterType)
+        print()
+    }
+    
+    /// 드롭박스를 탭할 경우를 subscribe한다.
+    func subscribeCategoryFilterView() {
+        categoryView.categoryFilterView.stackView.arrangedSubviews.forEach {
+            guard let dropBox: DropBoxView = $0 as? DropBoxView else {
+                return
+            }
+            dropBox.selectFilterTypeSubject
+                .subscribe( onNext: { [weak self] (value: (FilterType, String)) in
+                    // ViewModel 변경
+                    self?.viewModel.changeCurrentFilterType(type: value.0, value: value.1)
+                    self?.testViewModel()
+                })
+                .disposed(by: disposeBag)
+        }
+    }
+    
+    /// "카테고리"의 sub Category를 선택하는 경우를 subscribe한다.
+    func subscribeHorizontalCollectionView() {
+        categoryView.horizontalCollectionView.categoryTitleSubject
+            .subscribe( onNext: { [weak self] titleCategory in
+                self?.viewModel.currentSubCategoryType = titleCategory
+                self?.testViewModel()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    /// 최상단 CategoryTab에서 특정 카테고리를 탭할 경우를 subscribe한다.
+    func subscribeCategoryView() {
+        categoryView.categoryTapView.topCategoryTypeSubject
+            .subscribe(onNext: { [weak self] type in
+                // 1. ViewModel 변경
+                self?.viewModel.currentTopCategoryType = type
+                
+                // 2. HorizontalCollectionView 애니메이션
+                UIView.animate(withDuration: 0.2) {
+                    self?.categoryViewHeightConstriant?.constant = type == .category ? self?.categoryView.maxHeight ?? 0 : self?.categoryView.normalHeight ?? 0
+                    self?.currentCategoryHeight = type == .category ? self?.categoryView.maxHeight ?? 0 : self?.categoryView.normalHeight ?? 0
+
+                    self?.view.layoutIfNeeded()
+                }
+                
+                // 3. DropBox 변경
+                self?.categoryView.categoryFilterView.updateDropBoxView(type, superView: self?.view ?? UIView() )
+                
+                // 4. DropBox가 전부 변경되므로 subscribe한다.
+                self?.subscribeCategoryFilterView()
+                
+                // 5. HorizontalCollectionView 데이터 변경
+                if type == .category {
+                    // TODO: - ⚠️CoreData를 이용하여 가져올 예정이다.
+                    self?.categoryView.horizontalCollectionView.categoryList = [
+                        "학용품", "다이어리", "학용품", "다이어리", "학용품", "다이어리", "학용품", "다이어리",
+                        "학용품", "다이어리", "학용품", "다이어리", "학용품", "다이어리", "학용품", "다이어리"
+                    ]
+                    self?.categoryView.horizontalCollectionView.reloadData()
+                }
+                
+                self?.testViewModel()
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/ThingLog/ViewModel/CategoryViewModel.swift
+++ b/ThingLog/ViewModel/CategoryViewModel.swift
@@ -12,7 +12,16 @@ import Foundation
 /// 모아보기에서 각 뷰들의 액션에 따라 프로퍼티들을 변경하도록 하여, `fetchRequest`를 호출한다.
 final class CategoryViewModel {
     // MARK: - Properties
-    var currentTopCategoryType: TopCategoryType  // 모아보기 최상단 탭
+    // 모아보기 최상단 탭
+    var currentTopCategoryType: TopCategoryType {
+        // 최상 단 탭이 변경될 때 SubCategoryType 및 FilterType을 초기화한다.
+        didSet {
+            if currentTopCategoryType != .category {
+                currentSubCategoryType = nil
+            }
+            currentFilterType = currentTopCategoryType.filterTypes.map { ($0, $0.defaultValue) }
+        }
+    }
     var currentSubCategoryType: String?          /// 최상단 탭이 `카테고리`인 경우
     var currentFilterType: [(type: FilterType, value: String)]
     var fetchResultController: NSFetchedResultsController<PostEntity>?


### PR DESCRIPTION
## 개요
모아보기 상단에 필요한 화면 구현 하여 모아보기 홈에 배치 

## 시연
![categoryView](https://user-images.githubusercontent.com/48749182/135581777-c631ebbf-2bf1-44b2-af54-54ec68336966.gif)

## 목적 
- `View`는 단순히 `View`만 그리기 위한 목적으로 구현한다. 
- `ViewController`에서는`View`에서 발생하는 이벤트 액션들을 관리하여 로직을 구성함
    - `CategoryView`에 필요한 뷰들을 조립했으며, 뷰에 발생되는 액션을 통하여 데이터를 생성하는 것은 `CategoryViewController`에서 추가함.
    - 발생된 데이터를 통해서 `ViewModel`에 주입하여 `ViewModel`이 `NSFetchRequest`를 생성함.

## 작업 사항
- 모아보기 상단에 필요한 View 약간의 리팩토링 및 수정 
- 모아보기 상단에 들어가는 `DropBoxView`들이 포함된 `CategoryFilterView` 구현 
- 모아보기 상단에 필요한 `CategoryView `구현 
- 모아보기 화면에 들어가는 뷰들 배치


### Linked Issue

## 예외 사항 
- 디자이너님이 요구하신 하단 컬렉션뷰를 스크롤할 때 발생하는 에니메이션 및 버튼 추가는 하지 않음. 

## TestCode 
테스트코드는 작성되어있으며, 모아보기 홈으로 가면 확인할 수 있다. 

close #36 
