### PR TITLE
[#48] 최근검색어 데이터 모델  

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		DB148C2C2705855A00FDC48F /* CategoryTypeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C2B2705855A00FDC48F /* CategoryTypeButton.swift */; };
 		DB148C302705863100FDC48F /* CategoryTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C2F2705863100FDC48F /* CategoryTabView.swift */; };
 		DB1745B72708700200EF083E /* SearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1745B62708700200EF083E /* SearchTextField.swift */; };
+		DB1745B927098E8A00EF083E /* RecentSearchDataViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1745B827098E8A00EF083E /* RecentSearchDataViewModel.swift */; };
 		DB331DA926FDD00A00A629F5 /* ColorsAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA626FDD00A00A629F5 /* ColorsAsset.swift */; };
 		DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA726FDD00A00A629F5 /* ImageAssets.swift */; };
 		DB331DAB26FDD00A00A629F5 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA826FDD00A00A629F5 /* Fonts.swift */; };
@@ -73,6 +74,7 @@
 		DB8BF6792705D25700FD5FDB /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6782705D25700FD5FDB /* LogoView.swift */; };
 		DB8BF6812706D89E00FD5FDB /* CategoryFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6802706D89E00FD5FDB /* CategoryFilterView.swift */; };
 		DB8BF6832706DA7900FD5FDB /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6822706DA7900FD5FDB /* CategoryView.swift */; };
+		DBA0F8192709A79A009553FC /* ThingLogRecentSearchDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA0F8182709A79A009553FC /* ThingLogRecentSearchDataTests.swift */; };
 		DBA1FD4526FB701C00F50DE5 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DBA1FD4726FB701C00F50DE5 /* InfoPlist.strings */; };
 		DBAB64A426FCC2C5006D95ED /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04A526F5F281009F5C0A /* Coordinator.swift */; };
 		DBAB64A526FCC2F8006D95ED /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04A726F5F2BB009F5C0A /* HomeCoordinator.swift */; };
@@ -173,6 +175,7 @@
 		DB148C2B2705855A00FDC48F /* CategoryTypeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTypeButton.swift; sourceTree = "<group>"; };
 		DB148C2F2705863100FDC48F /* CategoryTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTabView.swift; sourceTree = "<group>"; };
 		DB1745B62708700200EF083E /* SearchTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextField.swift; sourceTree = "<group>"; };
+		DB1745B827098E8A00EF083E /* RecentSearchDataViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchDataViewModel.swift; sourceTree = "<group>"; };
 		DB331DA626FDD00A00A629F5 /* ColorsAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorsAsset.swift; sourceTree = "<group>"; };
 		DB331DA726FDD00A00A629F5 /* ImageAssets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAssets.swift; sourceTree = "<group>"; };
 		DB331DA826FDD00A00A629F5 /* Fonts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
@@ -198,6 +201,7 @@
 		DB8BF6782705D25700FD5FDB /* LogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoView.swift; sourceTree = "<group>"; };
 		DB8BF6802706D89E00FD5FDB /* CategoryFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFilterView.swift; sourceTree = "<group>"; };
 		DB8BF6822706DA7900FD5FDB /* CategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryView.swift; sourceTree = "<group>"; };
+		DBA0F8182709A79A009553FC /* ThingLogRecentSearchDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogRecentSearchDataTests.swift; sourceTree = "<group>"; };
 		DBA1FD3C26FB6F1D00F50DE5 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		DBA1FD4626FB701C00F50DE5 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		DBA1FD4826FB701F00F50DE5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -294,6 +298,7 @@
 				873EC02226D39057003C3525 /* ThingLogTests.swift */,
 				87F2188226FB5B4100C3FBCA /* ThingLogPostRepositoryTests.swift */,
 				87BEF07A2705C80D00797ECD /* ThingLogCategoryRepositoryTests.swift */,
+				DBA0F8182709A79A009553FC /* ThingLogRecentSearchDataTests.swift */,
 				873EC02426D39057003C3525 /* Info.plist */,
 			);
 			path = ThingLogTests;
@@ -386,6 +391,7 @@
 			children = (
 				DB7C04C626F9E693009F5C0A /* UserInformationViewModel.swift */,
 				DBD5454B27032C6600063C98 /* CategoryViewModel.swift */,
+				DB1745B827098E8A00EF083E /* RecentSearchDataViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -723,6 +729,7 @@
 				DB148C302705863100FDC48F /* CategoryTabView.swift in Sources */,
 				DB7C04E926FB19AE009F5C0A /* ContentsCollectionViewCell.swift in Sources */,
 				DB7C04BE26F9BE72009F5C0A /* ProfileView.swift in Sources */,
+				DB1745B927098E8A00EF083E /* RecentSearchDataViewModel.swift in Sources */,
 				DB7C04B626F8782B009F5C0A /* CategoryViewController.swift in Sources */,
 				DB148C282704A1A600FDC48F /* IgnoreTouchView.swift in Sources */,
 				DB7C04B226F87548009F5C0A /* TabBarController.swift in Sources */,
@@ -763,6 +770,7 @@
 			files = (
 				873EC02326D39057003C3525 /* ThingLogTests.swift in Sources */,
 				87BEF07B2705C80D00797ECD /* ThingLogCategoryRepositoryTests.swift in Sources */,
+				DBA0F8192709A79A009553FC /* ThingLogRecentSearchDataTests.swift in Sources */,
 				87F2188326FB5B4100C3FBCA /* ThingLogPostRepositoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ThingLog/Extension/UserDefaults+.swift
+++ b/ThingLog/Extension/UserDefaults+.swift
@@ -11,4 +11,5 @@ extension UserDefaults {
     static var userAliasName: String { "userAliasName" }
     static var userOneLineIntroduction: String { "userOneLineIntroduction" }
     static var isAutomatedDarkMode: String { "isAutomatedDarkMode" }
+    static var recentSearchData: String{ "recentSearchData" }
 }

--- a/ThingLog/ViewModel/RecentSearchDataViewModel.swift
+++ b/ThingLog/ViewModel/RecentSearchDataViewModel.swift
@@ -1,0 +1,60 @@
+//
+//  RecentSearchDataViewModel.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/03.
+//
+
+import Foundation
+import RxSwift
+
+/// 최근검색어 데이터를 관리하는 ViewModel이다.
+/// recentSearchData를 susbscribe하여 손쉽게 tableView를 reload, update하도록 한다.
+struct RecentSearchDataViewModel {
+    lazy var recentSearchDataSubject: BehaviorSubject<[String]> = BehaviorSubject(value: _recentSearchData )
+    
+    private var _recentSearchData: [String] = [] {
+        didSet {
+            // 변경되면 UserDefaults를 갱신하고, Subject에 주입한다.
+            UserDefaults.standard.setValue(_recentSearchData, forKey: UserDefaults.recentSearchData)
+            recentSearchDataSubject.onNext(_recentSearchData)
+        }
+    }
+    
+    init() {
+        guard let recentDatas = UserDefaults.standard.value(forKey: UserDefaults.recentSearchData) as? [String] else {
+            _recentSearchData = []
+            return
+        }
+        _recentSearchData = recentDatas
+    }
+    
+    /// 새로운 최근검색어를 추가한다.
+    /// - Parameter searchData: 추가하고자 하는 검색어를 주입한다.
+    mutating func add(_ searchData: String) {
+        if _recentSearchData.contains(searchData) {
+            return
+        }
+        
+        if _recentSearchData.count == 20 {
+            var newRecent: [String] = _recentSearchData
+            newRecent.insert(searchData, at: 0)
+            newRecent.removeLast()
+            _recentSearchData = newRecent
+        } else {
+            _recentSearchData.insert(searchData, at: 0)
+        }
+    }
+    
+    /// index에 해당하는 최근검색어를 삭제한다.
+    /// - Parameter index: 삭제하고자 하는 index를 주입한다.
+    mutating func remove(_ index: Int) {
+        if index < _recentSearchData.count {
+            _recentSearchData.remove(at: index)
+        }
+    }
+    
+    mutating func removeAll() {
+        _recentSearchData = []
+    }
+}

--- a/ThingLog/ViewModel/RecentSearchDataViewModel.swift
+++ b/ThingLog/ViewModel/RecentSearchDataViewModel.swift
@@ -21,6 +21,7 @@ struct RecentSearchDataViewModel {
         }
     }
     
+    private let maxSaveCount: Int = 20
     init() {
         guard let recentDatas = UserDefaults.standard.value(forKey: UserDefaults.recentSearchData) as? [String] else {
             _recentSearchData = []
@@ -36,7 +37,7 @@ struct RecentSearchDataViewModel {
             return
         }
         
-        if _recentSearchData.count == 20 {
+        if _recentSearchData.count == maxSaveCount {
             var newRecent: [String] = _recentSearchData
             newRecent.insert(searchData, at: 0)
             newRecent.removeLast()
@@ -48,7 +49,7 @@ struct RecentSearchDataViewModel {
     
     /// index에 해당하는 최근검색어를 삭제한다.
     /// - Parameter index: 삭제하고자 하는 index를 주입한다.
-    mutating func remove(_ index: Int) {
+    mutating func remove(at index: Int) {
         if index < _recentSearchData.count {
             _recentSearchData.remove(at: index)
         }

--- a/ThingLogTests/ThingLogRecentSearchDataTests.swift
+++ b/ThingLogTests/ThingLogRecentSearchDataTests.swift
@@ -47,7 +47,7 @@ class ThingLogRecentSearchDataTests: XCTestCase {
                 .disposed(by: disposeBag)
             
             self.recentViewModel.add("hiii")
-            self.recentViewModel.remove(0)
+            self.recentViewModel.remove(at: 0)
         }
     }
     
@@ -62,7 +62,7 @@ class ThingLogRecentSearchDataTests: XCTestCase {
     func test_최근검색어_삭제할수있다() {
         recentViewModel.removeAll()
         recentViewModel.add("hi")
-        recentViewModel.remove(0)
+        recentViewModel.remove(at: 0)
         XCTAssertTrue((UserDefaults.standard.value(forKey: UserDefaults.recentSearchData) as? [String])?.count == 0)
     }
 }

--- a/ThingLogTests/ThingLogRecentSearchDataTests.swift
+++ b/ThingLogTests/ThingLogRecentSearchDataTests.swift
@@ -1,0 +1,68 @@
+    //
+//  ThingLogRecentSearchDataTests.swift
+//  ThingLogTests
+//
+//  Created by hyunsu on 2021/10/03.
+//
+
+import XCTest
+@testable import ThingLog
+import RxSwift
+    
+class ThingLogRecentSearchDataTests: XCTestCase {
+
+    var recentViewModel: RecentSearchDataViewModel = RecentSearchDataViewModel()
+    var disposeBag: DisposeBag = DisposeBag()
+
+    func test_최근검색어_데이터를_하나추가하면_subject가_변경된다() throws {
+        recentViewModel.removeAll()
+        var count: Int = 0
+        timeout(3) { exp in
+            recentViewModel.recentSearchDataSubject
+                .bind { val in
+                    count += 1
+                    if count == 2 {
+                        exp.fulfill()
+                        XCTAssertTrue(val.count == 1 )
+                    }
+                }
+                .disposed(by: disposeBag)
+            
+            self.recentViewModel.add("hiii")
+        }
+    }
+    
+    func test_최근검색어_데이터를_하나추가하고_하나를_삭제해도_subject가_변경된다() throws {
+        recentViewModel.removeAll()
+        var count: Int = 0
+        timeout(3) { exp in
+            recentViewModel.recentSearchDataSubject
+                .bind { val in
+                    count += 1
+                    if count == 3 {
+                        exp.fulfill()
+                        XCTAssertTrue(val.count == 0 )
+                    }
+                }
+                .disposed(by: disposeBag)
+            
+            self.recentViewModel.add("hiii")
+            self.recentViewModel.remove(0)
+        }
+    }
+    
+    func test_같은_최근검색어는_추가되지_않는다() throws {
+        recentViewModel.removeAll()
+        recentViewModel.add("hi")
+        recentViewModel.add("hi")
+        
+        XCTAssertTrue((UserDefaults.standard.value(forKey: UserDefaults.recentSearchData) as? [String])?.count == 1)
+    }
+    
+    func test_최근검색어_삭제할수있다() {
+        recentViewModel.removeAll()
+        recentViewModel.add("hi")
+        recentViewModel.remove(0)
+        XCTAssertTrue((UserDefaults.standard.value(forKey: UserDefaults.recentSearchData) as? [String])?.count == 0)
+    }
+}


### PR DESCRIPTION
## 개요

검색홈에 필요한 최근검색어 데이터 리스트를 표현하기 위한 모델을 구현한다. 

## 작업 사항
- `UserDefaults`에 `key`값을 추가
- `RecentSearchDataViewModel` 구현 
- Test코드 작성 

### Linked Issue

close #48 

