### PR TITLE
[#77] 검색: 검색결과에 따른 컬렉션뷰를 바인딩

### DIFF
--- a/ThingLog/Resource/Colors.xcassets/systemBlue.colorset/Contents.json
+++ b/ThingLog/Resource/Colors.xcassets/systemBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.953",
+          "green" : "0.502",
+          "red" : "0.227"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.925",
+          "green" : "0.486",
+          "red" : "0.220"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ThingLog/SwiftGen/ColorsAsset.swift
+++ b/ThingLog/SwiftGen/ColorsAsset.swift
@@ -26,6 +26,7 @@ internal enum SwiftGenColors {
   internal static let gray4 = ColorSwiftGen(name: "gray4")
   internal static let gray5 = ColorSwiftGen(name: "gray5")
   internal static let gray6 = ColorSwiftGen(name: "gray6")
+  internal static let systemBlue = ColorSwiftGen(name: "systemBlue")
   internal static let white = ColorSwiftGen(name: "white")
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name

--- a/ThingLog/View/CategoryFilterView.swift
+++ b/ThingLog/View/CategoryFilterView.swift
@@ -45,7 +45,7 @@ final class CategoryFilterView: UIView {
     // DropBox뷰를 addSubView할 superView 프로퍼티다 ( ViewController.view )
     private var superView: UIView
     
-    private let leadingMarginConstraint: CGFloat = 16
+    private let leadingMarginConstraint: CGFloat = 18
     
     // MARK: - Init
     /// 현재 해당 뷰가 뷰 계층 구조에서 최상단에 속해있는 view를 넣는다.
@@ -72,7 +72,7 @@ final class CategoryFilterView: UIView {
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
         
-        updateDropBoxView(.total, superView: superView)
+        updateDropBoxView(nil, superView: superView)
     }
 }
 
@@ -81,7 +81,7 @@ extension CategoryFilterView {
     /// - Parameters:
     ///   - type: 클릭한 카테고리의 탭의 타입( TopCategoryType ) 을 넣는다.
     ///   - superView: 현재 해당 뷰가 뷰 계층 구조에서 최상단에 속해있는 view를 넣는다. ( VIewController의 View를 넣는다 )
-    func updateDropBoxView(_ type: TopCategoryType, superView: UIView ) {
+    func updateDropBoxView(_ type: TopCategoryType? , superView: UIView ) {
         // 기존 stackView를 모두 제거한다.
         stackView.arrangedSubviews.forEach {
             $0.removeFromSuperview()
@@ -91,6 +91,8 @@ extension CategoryFilterView {
         stackView.addArrangedSubview(emptyView)
         
         emptyLeadingView.widthAnchor.constraint(equalToConstant: leadingMarginConstraint).isActive = true
+        
+        guard let type = type else { return }
         
         type.filterTypes.forEach {
             let dropBox: DropBoxView = DropBoxView(type: $0, superView: superView)
@@ -104,7 +106,7 @@ extension CategoryFilterView {
     
     /// 결과에 따른 총 게시물 검색 수를 변경하기 위한 메서드다.
     /// - Parameter totalCount: 총 게시물 검색 수를 지정한다.
-    func udpateResultTotalLabel(totalCount: Int ) {
-        resultTotalLabel.text = "총 " + String(totalCount) + "건"
+    func updateResultTotalLabel(by title: String ) {
+        resultTotalLabel.text = title
     }
 }

--- a/ThingLog/View/CategoryView.swift
+++ b/ThingLog/View/CategoryView.swift
@@ -99,6 +99,7 @@ final class CategoryView: UIView {
         self.categoryFilterView = {
             let categoryFilterView: CategoryFilterView = CategoryFilterView(superView: superView)
             categoryFilterView.setContentCompressionResistancePriority(.required, for: .vertical)
+            categoryFilterView.updateDropBoxView(.total, superView: superView)
             return categoryFilterView
         }()
         
@@ -108,6 +109,7 @@ final class CategoryView: UIView {
     
     required init?(coder: NSCoder) {
         self.categoryFilterView = CategoryFilterView(superView: UIView())
+        
         self.superView = UIView()
         super.init(coder: coder)
     }

--- a/ThingLog/View/RecentSearchView.swift
+++ b/ThingLog/View/RecentSearchView.swift
@@ -32,6 +32,7 @@ import UIKit
  
  stackView: UIStackView - vertical {
  [ headerStackView,
+ emptyHeightView,
  informationStackView,
  tableView,
  autoSaveStackView]
@@ -177,9 +178,16 @@ final class RecentSearchView: UIView {
         return stackView
     }()
     
+    private let emptyHeightView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     private lazy var stackView: UIStackView = {
         let stackView: UIStackView = UIStackView(arrangedSubviews: [
             headerStackView,
+            emptyHeightView,
             informationStackView,
             tableView,
             autoSaveStackView
@@ -197,6 +205,8 @@ final class RecentSearchView: UIView {
     private let informationLabelHeight: CGFloat = 147
     private var tableViewHeightConstraint: NSLayoutConstraint?
     private let autoSaveStackViewHeight: CGFloat = 40
+    private let headerStackViewHeight: CGFloat = 44
+    private let emptyHeightViewHeight: CGFloat = 14
     
     var selectedIndexPathSubject: PublishSubject<String> = PublishSubject() 
     var disposeBag: DisposeBag = DisposeBag()
@@ -249,6 +259,8 @@ final class RecentSearchView: UIView {
             emptyLeadingView.widthAnchor.constraint(equalToConstant: emptyViewWidth),
             emptyTrailingView.widthAnchor.constraint(equalToConstant: emptyViewWidth),
             
+            emptyHeightView.heightAnchor.constraint(equalToConstant: emptyHeightViewHeight),
+            headerStackView.heightAnchor.constraint(equalToConstant: headerStackViewHeight),
             autoSaveLeadingEmptyView.widthAnchor.constraint(equalToConstant: autoSaveEmptyViewWidth),
             informationStackView.heightAnchor.constraint(equalToConstant: informationLabelHeight),
             informationBorderLineView.heightAnchor.constraint(equalToConstant: 0.5),

--- a/ThingLog/View/SearchTextField.swift
+++ b/ThingLog/View/SearchTextField.swift
@@ -68,6 +68,8 @@ final class SearchTextField: UIView {
         textField.textColor = SwiftGenColors.gray3.color
         textField.clearButtonMode = .whileEditing
         if let button: UIButton = textField.value(forKey: "clearButton") as? UIButton {
+            let templateImage: UIImage? = button.imageView?.image?.withRenderingMode(.alwaysTemplate)
+            button.setImage(templateImage, for: .normal)
             button.tintColor = SwiftGenColors.gray3.color
         }
         textField.translatesAutoresizingMaskIntoConstraints = false

--- a/ThingLog/View/SearchTextField.swift
+++ b/ThingLog/View/SearchTextField.swift
@@ -131,9 +131,8 @@ final class SearchTextField: UIView {
         textFieldView.layer.cornerRadius = bounds.height / 2
     }
     
-    func changeBackButton(isBackMode: Bool) {
-        backButton.setImage(isBackMode ? backImage : nil, for: .normal)
-        backButton.setTitle(isBackMode ? "" : "닫기", for: .normal)
+    func changeTextField(by text: String) {
+        textField.text = text
     }
 }
 

--- a/ThingLog/View/SearchTextField.swift
+++ b/ThingLog/View/SearchTextField.swift
@@ -171,14 +171,22 @@ extension SearchTextField {
     }
     
     func setupToolBar() {
-        let numberToolbar: UIToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
-        numberToolbar.barStyle = .default
-        let action: UIBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(cancleKeyboard))
-        action.tintColor = SwiftGenColors.black.color
-        numberToolbar.barTintColor = SwiftGenColors.gray6.color
-        numberToolbar.items = [action]
-        numberToolbar.sizeToFit()
-        textField.inputAccessoryView = numberToolbar
+        let keyboardToolBar: UIToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
+        keyboardToolBar.barStyle = .default
+        let cancleButton: UIButton = {
+            let button: UIButton = UIButton()
+            button.titleLabel?.font = UIFont.Pretendard.title2
+            button.setTitle("취소", for: .normal)
+            button.setTitleColor(SwiftGenColors.systemBlue.color, for: .normal)
+            button.addTarget(self, action: #selector(cancleKeyboard), for: .touchUpInside)
+            return button
+        }()
+        let cancleBarButton: UIBarButtonItem = UIBarButtonItem(customView: cancleButton)
+        cancleBarButton.tintColor = SwiftGenColors.black.color
+        keyboardToolBar.barTintColor = SwiftGenColors.gray6.color
+        keyboardToolBar.items = [cancleBarButton, UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)]
+        keyboardToolBar.sizeToFit()
+        textField.inputAccessoryView = keyboardToolBar
     }
     
     @objc

--- a/ThingLog/View/SearchTextField.swift
+++ b/ThingLog/View/SearchTextField.swift
@@ -151,6 +151,7 @@ extension SearchTextField {
         
         setupTextFieldView()
         setupTextField()
+        setupToolBar()
     }
     
     // textField와 searchIcon을 담은 iConTextFieldStackView를 TextFieldView에 추가한다.
@@ -166,6 +167,22 @@ extension SearchTextField {
             searchIcon.heightAnchor.constraint(equalToConstant: iconHeight),
             searchIcon.widthAnchor.constraint(equalTo: searchIcon.heightAnchor)
         ])
+    }
+    
+    func setupToolBar() {
+        let numberToolbar: UIToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
+        numberToolbar.barStyle = .default
+        let action: UIBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(cancleKeyboard))
+        action.tintColor = SwiftGenColors.black.color
+        numberToolbar.barTintColor = SwiftGenColors.gray6.color
+        numberToolbar.items = [action]
+        numberToolbar.sizeToFit()
+        textField.inputAccessoryView = numberToolbar
+    }
+    
+    @objc
+    private func cancleKeyboard() {
+        textField.endEditing(true)
     }
     
     private func setupTextField() {

--- a/ThingLog/View/TableVeiwCell/LeftLabelRightButtonTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/LeftLabelRightButtonTableCell.swift
@@ -88,7 +88,7 @@ final class LeftLabelRightButtonTableCell: UITableViewCell {
     }()
     
     // MARK: - Properties
-    private let emptyViewHeight: CGFloat = 9
+    private let emptyViewHeight: CGFloat = 11
     private let rightButtonWidth: CGFloat = 40
     private let paddingConstraint: CGFloat = 16
     private let leadingEmptyViewWidth: CGFloat = 10

--- a/ThingLog/ViewController/SearchResultsViewController.swift
+++ b/ThingLog/ViewController/SearchResultsViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 
 /// 검색홈에서 검색결과에 CollectionView형태로 보여주는 Controller다.
 class SearchResultsViewController: UIViewController {
-    var collectionView: UICollectionView = {
+    let collectionView: UICollectionView = {
         let collectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: ResultCollectionSection.resultsCollectionViewLayout())
         collectionView.register(ContentsCollectionViewCell.self, forCellWithReuseIdentifier: ContentsCollectionViewCell.reuseIdentifier)
         collectionView.register(ContentsDetailCollectionViewCell.self, forCellWithReuseIdentifier: ContentsDetailCollectionViewCell.reuseIdentifier)
@@ -18,11 +18,30 @@ class SearchResultsViewController: UIViewController {
         return collectionView
     }()
     
+    lazy var totalFilterView: CategoryFilterView = {
+        let view: CategoryFilterView = CategoryFilterView(superView: view)
+        view.updateResultTotalLabel(by: "검색결과 " + "15" + "건")
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     // TODO: ⚠️ NSFetchResultsController가질 예정 
+    private let totalFilterViewHeight: CGFloat = 44.0
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupTotalFilterView()
         setupCollectionView()
+    }
+    
+    func setupTotalFilterView() {
+        view.addSubview(totalFilterView)
+        NSLayoutConstraint.activate([
+            totalFilterView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            totalFilterView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            totalFilterView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            totalFilterView.heightAnchor.constraint(equalToConstant: totalFilterViewHeight)
+        ])
     }
     
     func setupCollectionView() {
@@ -30,7 +49,7 @@ class SearchResultsViewController: UIViewController {
         NSLayoutConstraint.activate([
             collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            collectionView.topAnchor.constraint(equalTo: totalFilterView.bottomAnchor),
             collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
         collectionView.dataSource = self

--- a/ThingLog/ViewController/SearchViewController.swift
+++ b/ThingLog/ViewController/SearchViewController.swift
@@ -177,23 +177,37 @@ final class SearchViewController: UIViewController {
 
 extension SearchViewController: SearchTextFieldDelegate {
     func searchTextFieldDidChangeSelection(_ textField: UITextField) {
-        guard let text = textField.text,
-              !text.isEmpty,
-              !text.filter({ $0 != " " }).isEmpty else {
+        guard let text: String = checkTextField(textField.text) else {
             showSearchResultsViewController(false)
             isShowingResults = false
             return
         }
+        print(text)
         isShowingResults = true
     }
     
     func searchTextFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if recentSearchDataViewModel.isAutoSaveMode {
-            recentSearchDataViewModel.add(textField.text!)
+        if let text: String = checkTextField(textField.text) {
+            if recentSearchDataViewModel.isAutoSaveMode {
+                recentSearchDataViewModel.add(textField.text!)
+            }
+            // TODO: - ⚠️ 키워드를 통해서 NSFetchRequest + NSFetchResultsController 생성하여 업데이트
+            print(text)
+            showSearchResultsViewController(true)
         }
-        // TODO: - ⚠️ 키워드를 통해서 NSFetchRequest + NSFetchResultsController 생성하여 업데이트
-        showSearchResultsViewController(true)
         hideKeyboard()
         return true
+    }
+    
+    /// 공백만 포함된 경우를 체크한다.
+    /// - Parameter text: String 옵셔널 타입을 주입한다.
+    /// - Returns: 공백일 경우는 nil, 그렇지 않은 경우는 String이 된다.
+    func checkTextField(_ text: String? ) -> String? {
+        guard let text = text,
+              !text.isEmpty,
+              !text.filter({ $0 != " " }).isEmpty else {
+            return nil
+        }
+        return text
     }
 }


### PR DESCRIPTION
## 개요
검색결과에 따른 컬렉션뷰를 바인딩

## 시연 
![검색결과](https://user-images.githubusercontent.com/48749182/136155958-ba299d92-b3c6-4e7a-aace-63b892926cd1.gif)


## 작업 사항

- 키보드위에 취소버튼 추가
    - `SearchTextField`에 키보드 나타날때 취소버튼 추가
- 검색결과화면 상단 레이블 추가 
    -  ![image](https://user-images.githubusercontent.com/48749182/136157214-9b0571eb-1581-45d9-9936-a6fafdc918ea.png)
    - `CategoryFilterView`를 이용하여 재사용함.
    - `CategoryFilterView`를 재사용하기 위해 약간의 리팩토링
    - `SearchResultsViewController`에 상단에 검색결과 레이블 뷰 추가
- 검색결과 화면 바인딩
    - `SearchViewController`에 검색완료 했을 떄 검색결과화면 나오도록 로직 구현
- 텍스트필드 `clearButton` 틴트
    - 에디팅모드일때 다크모드에서도 `clearButton` 색 변경

## 예외사항 
- 검색결과에서 모두보기 구현하지 않음 
- 모든 결과데이터는 테스트 데이터값

### Linked Issue

close #77 
close #84 