### PR TITLE
[#78] 모아보기홈에서 실제 데이터가 나오도록 한다

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -99,6 +99,9 @@
 		DBAE8E9826FDB3EE00F536AD /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8E9526FDB3EE00F536AD /* Pretendard-SemiBold.otf */; };
 		DBAE8EB126FDBEAE00F536AD /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */; };
 		DBAE8EBB26FDCA7B00F536AD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */; };
+		DBC45A9C270F24B800AB9499 /* DummyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9B270F24B800AB9499 /* DummyProtocol.swift */; };
+		DBC45A9E270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9D270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift */; };
+		DBC45AA0270F266800AB9499 /* ThingLogPostSearchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9F270F266800AB9499 /* ThingLogPostSearchRequestTests.swift */; };
 		DBD2244527085651004C5184 /* CategoryViewController+setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244427085651004C5184 /* CategoryViewController+setup.swift */; };
 		DBD2244727085671004C5184 /* CategoryViewController+subscribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244627085671004C5184 /* CategoryViewController+subscribe.swift */; };
 		DBD2244B27085DFB004C5184 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244A27085DFB004C5184 /* SearchViewController.swift */; };
@@ -241,6 +244,9 @@
 		DBAE8E9526FDB3EE00F536AD /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		DBAE8EB026FDBEAE00F536AD /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		DBAE8EBA26FDCA7B00F536AD /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		DBC45A9B270F24B800AB9499 /* DummyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyProtocol.swift; sourceTree = "<group>"; };
+		DBC45A9D270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostCategoryRequestTests.swift; sourceTree = "<group>"; };
+		DBC45A9F270F266800AB9499 /* ThingLogPostSearchRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostSearchRequestTests.swift; sourceTree = "<group>"; };
 		DBD2244427085651004C5184 /* CategoryViewController+setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CategoryViewController+setup.swift"; sourceTree = "<group>"; };
 		DBD2244627085671004C5184 /* CategoryViewController+subscribe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CategoryViewController+subscribe.swift"; sourceTree = "<group>"; };
 		DBD2244A27085DFB004C5184 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
@@ -330,6 +336,9 @@
 				87BEF07A2705C80D00797ECD /* ThingLogCategoryRepositoryTests.swift */,
 				DBA0F8182709A79A009553FC /* ThingLogRecentSearchDataTests.swift */,
 				873EC02426D39057003C3525 /* Info.plist */,
+				DBC45A9B270F24B800AB9499 /* DummyProtocol.swift */,
+				DBC45A9D270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift */,
+				DBC45A9F270F266800AB9499 /* ThingLogPostSearchRequestTests.swift */,
 			);
 			path = ThingLogTests;
 			sourceTree = "<group>";
@@ -845,8 +854,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				873EC02326D39057003C3525 /* ThingLogTests.swift in Sources */,
+				DBC45A9E270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift in Sources */,
 				87BEF07B2705C80D00797ECD /* ThingLogCategoryRepositoryTests.swift in Sources */,
+				DBC45AA0270F266800AB9499 /* ThingLogPostSearchRequestTests.swift in Sources */,
 				DBA0F8192709A79A009553FC /* ThingLogRecentSearchDataTests.swift in Sources */,
+				DBC45A9C270F24B800AB9499 /* DummyProtocol.swift in Sources */,
 				87F2188326FB5B4100C3FBCA /* ThingLogPostRepositoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA726FDD00A00A629F5 /* ImageAssets.swift */; };
 		DB331DAB26FDD00A00A629F5 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA826FDD00A00A629F5 /* Fonts.swift */; };
 		DB37EC77270C307C00030D9A /* RecentSearchView+update.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB37EC76270C307C00030D9A /* RecentSearchView+update.swift */; };
+		DB3A5165270FFE0C003B529D /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A5164270FFE0C003B529D /* String+.swift */; };
 		DB7C04AA26F5F308009F5C0A /* CategoryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04A926F5F308009F5C0A /* CategoryCoordinator.swift */; };
 		DB7C04B226F87548009F5C0A /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04B126F87548009F5C0A /* TabBarController.swift */; };
 		DB7C04B626F8782B009F5C0A /* CategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04B526F8782B009F5C0A /* CategoryViewController.swift */; };
@@ -205,6 +206,7 @@
 		DB331DA726FDD00A00A629F5 /* ImageAssets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAssets.swift; sourceTree = "<group>"; };
 		DB331DA826FDD00A00A629F5 /* Fonts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
 		DB37EC76270C307C00030D9A /* RecentSearchView+update.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchView+update.swift"; sourceTree = "<group>"; };
+		DB3A5164270FFE0C003B529D /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		DB7C04A526F5F281009F5C0A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		DB7C04A726F5F2BB009F5C0A /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		DB7C04A926F5F308009F5C0A /* CategoryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCoordinator.swift; sourceTree = "<group>"; };
@@ -516,6 +518,7 @@
 				8736B3F326FDD55E000433E1 /* UIFont+.swift */,
 				DBAB64A626FE2AFF006D95ED /* UIImage+.swift */,
 				DB148C25270469B300FDC48F /* Date+.swift */,
+				DB3A5164270FFE0C003B529D /* String+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -802,6 +805,7 @@
 				87BB17A72709898F0088B847 /* WriteViewController.swift in Sources */,
 				DB7C04F226FB1F36009F5C0A /* ContentsPageViewController.swift in Sources */,
 				DB148C302705863100FDC48F /* CategoryTabView.swift in Sources */,
+				DB3A5165270FFE0C003B529D /* String+.swift in Sources */,
 				DB7C04E926FB19AE009F5C0A /* ContentsCollectionViewCell.swift in Sources */,
 				DB7C04BE26F9BE72009F5C0A /* ProfileView.swift in Sources */,
 				DB1745B927098E8A00EF083E /* RecentSearchDataViewModel.swift in Sources */,

--- a/ThingLog/Extension/Date+.swift
+++ b/ThingLog/Extension/Date+.swift
@@ -14,4 +14,15 @@ extension Date {
     func toString(_ component: Calendar.Component) -> String {
         String(Calendar.current.component(component, from: self))
     }
+    
+    /// 특정날짜만큼 지난 날짜를 반환한다.
+    /// - Parameter offset: 이전, 이후 날짜만큼의 offset을 지정한다.
+    /// - Returns: 지나거나 이전의 날짜의 옵셔널을 반환한다.
+    ///
+    /// offset이 1일경우 1일이후 날짜를 반환하고, offset이 -1인경우에 1일이전 날짜를 반환한다.
+    func day(by offset: Int) -> Date? {
+        let calendar: Calendar = Calendar.current
+        let end: Date? = calendar.date(byAdding: .day, value: offset, to: calendar.startOfDay(for: self))
+        return end
+    }
 }

--- a/ThingLog/Extension/Date+.swift
+++ b/ThingLog/Extension/Date+.swift
@@ -16,13 +16,15 @@ extension Date {
     }
     
     /// 특정날짜만큼 지난 날짜를 반환한다.
-    /// - Parameter offset: 이전, 이후 날짜만큼의 offset을 지정한다.
+    /// - Parameters:
+    ///   - offset: 이전, 이후 날짜 만큼의 offset을 지정한다.
+    ///   - type: 일별, 월별로 타입을 지정하여, 타입만큼의 offset을 지정하도록 한다.
     /// - Returns: 지나거나 이전의 날짜의 옵셔널을 반환한다.
-    ///
-    /// offset이 1일경우 1일이후 날짜를 반환하고, offset이 -1인경우에 1일이전 날짜를 반환한다.
-    func day(by offset: Int) -> Date? {
-        let calendar: Calendar = Calendar.current
-        let end: Date? = calendar.date(byAdding: .day, value: offset, to: calendar.startOfDay(for: self))
+    /// offset이 1일경우 1type 이후 날짜를 반환하고, offset이 -1인경우에 1type 이전 날짜를 반환한다.
+    func offset(_ offset: Int, byAdding type: Calendar.Component) -> Date? {
+        var calendar: Calendar = Calendar.current
+        calendar.timeZone = NSTimeZone.local
+        let end: Date? = Calendar.current.date(byAdding: type, value: offset, to: calendar.startOfDay(for: self))
         return end
     }
 }

--- a/ThingLog/Extension/String+.swift
+++ b/ThingLog/Extension/String+.swift
@@ -1,0 +1,18 @@
+//
+//  String+.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/08.
+//
+
+import Foundation
+
+extension String {
+    /// dateFormat 형식으로 문자열을 Date 타입으로 변환하는 메서드다
+    /// - Returns: 변환된 Date타입을 옵셔널로 반환한다.
+    func convertToDate(dateFormat: String ) -> Date? {
+        let dateFormatter: DateFormatter = DateFormatter()
+        dateFormatter.dateFormat = dateFormat
+        return dateFormatter.date(from: self)
+    }
+}

--- a/ThingLog/ViewController.swift
+++ b/ThingLog/ViewController.swift
@@ -4,13 +4,80 @@
 //
 //  Created by 이지원 on 2021/08/23.
 //
-
+import CoreData
 import UIKit
 
 class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+    }
+}
+
+func makeDummy() {
+    guard let originalImage: UIImage = UIImage(systemName: "heart.fill") else {
+        fatalError("Not Found system Image")
+    }
+    let categoryList: [String] = ["문구", "가전", "화장품", "운동", "옷", "전자제품", "신발", "띵로그", "여행"]
+    let titleNameList: [String] = ["아이폰","맥북","아이폰11","아이패드프로","애플워치"]
+    let purchasePlaceList: [String] = ["강남","서울","경기","제주"]
+    let postType: [PageType] = [.bought, .gift, .wish]
+    
+    let newPosts: [Post] = (1...400).map { idx in
+        var categories = [Category.init(title: "")]
+        categories.removeLast()
+        categories.append(Category.init(title: categoryList[Int.random(in: 0..<categoryList.count)]))
+        //        for _ in 0...Int.random(in: 0..<categoryList.count) {
+        //            categories.append(Category.init(title: categoryList[Int.random(in: 0..<categoryList.count)]))
+        //        }
+        let newPost: Post = Post(title: titleNameList.randomElement()!,
+                                 price: 500 * idx,
+                                 purchasePlace: purchasePlaceList.randomElement()!,
+                                 contents: "Test Contents \(titleNameList.randomElement()!)...",
+                                 giftGiver: "현수",
+                                 postType: .init(isDelete: false, type: postType.randomElement()!),
+                                 rating: Rating(score: ScoreType(rawValue: Int16.random(in: 0..<5))!),
+                                 categories: categories,
+                                 attachments: [Attachment(thumbnail: originalImage,
+                                                          imageData: .init(originalImage: originalImage))],
+                                 comments: nil,
+                                 isLike: [true,false].randomElement()!,
+                                 createDate: Date().offset(idx, byAdding: .day)!)
+        return newPost
+    }.shuffled()
+    
+    let postRepository: PostRepository = PostRepository(fetchedResultsControllerDelegate: nil)
+    var count = 0
+    newPosts.forEach {
+        postRepository.create($0) { result in
+            switch result {
+            case .success(_):
+                count += 1
+                print("성공: \(count)")
+            case .failure(let error):
+                print("fail")
+            }
+        }
+    }
+}
+
+func deleteAllEntity() {
+    let postRepository: PostRepository = PostRepository(fetchedResultsControllerDelegate: nil)
+    let categoryRepository: CategoryRepository = CategoryRepository(fetchedResultsControllerDelegate: nil)
+    postRepository.deleteAll { result in
+        switch result {
+        case .success(_):
+            categoryRepository.deleteAll { categoryResult in
+                switch categoryResult {
+                case .success(_):
+                    print("삭제성공")
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+        case .failure(let error):
+            print(error.localizedDescription)
+        }
     }
 }
 

--- a/ThingLog/ViewController/CategoryViewController+subscribe.swift
+++ b/ThingLog/ViewController/CategoryViewController+subscribe.swift
@@ -4,16 +4,27 @@
 //
 //  Created by hyunsu on 2021/10/02.
 //
-
+import CoreData
 import UIKit
 
 extension CategoryViewController {
+    func fetchAllCategory() {
+        categoryView.horizontalCollectionView.fetchResultController = categoryRepo.fetchedResultsController
+    }
+    
     /// CategoryView의 액션에 맞게 원하는 결과값이 담기는지 확인하기 위한 메서드다. 이것이 성공한다면 각 조합에 맞는 fetchRequest가 정상적으로 호출할 수 있다.
-    func testViewModel() {
-        print(viewModel.currentTopCategoryType)
-        print(viewModel.currentSubCategoryType)
-        print(viewModel.currentFilterType)
-        print()
+    func fetchAllPosts() {
+        viewModel.fetchRequest { result in
+            switch result {
+            case .success(_):
+                self.contentsViewController.fetchResultController = self.viewModel.fetchResultController
+                let fetchedCount: Int? = self.viewModel.fetchResultController?.fetchedObjects?.count
+                self.updateResultsCountView(fetchedCount: fetchedCount)
+                self.contentsViewController.collectionView.reloadData()
+            case .failure(_):
+                return
+            }
+        }
     }
     
     /// 드롭박스를 탭할 경우를 subscribe한다.
@@ -26,7 +37,7 @@ extension CategoryViewController {
                 .subscribe( onNext: { [weak self] (value: (FilterType, String)) in
                     // ViewModel 변경
                     self?.viewModel.changeCurrentFilterType(type: value.0, value: value.1)
-                    self?.testViewModel()
+                    self?.fetchAllPosts()
                 })
                 .disposed(by: disposeBag)
         }
@@ -37,7 +48,7 @@ extension CategoryViewController {
         categoryView.horizontalCollectionView.categoryTitleSubject
             .subscribe( onNext: { [weak self] titleCategory in
                 self?.viewModel.currentSubCategoryType = titleCategory
-                self?.testViewModel()
+                self?.fetchAllPosts()
             })
             .disposed(by: disposeBag)
     }
@@ -49,32 +60,17 @@ extension CategoryViewController {
                 // 1. ViewModel 변경
                 self?.viewModel.currentTopCategoryType = type
                 
-                // 2. HorizontalCollectionView 애니메이션
-                UIView.animate(withDuration: 0.2) {
-                    self?.categoryViewHeightConstriant?.constant = type == .category ? self?.categoryView.maxHeight ?? 0 : self?.categoryView.normalHeight ?? 0
-                    self?.currentCategoryHeight = type == .category ? self?.categoryView.maxHeight ?? 0 : self?.categoryView.normalHeight ?? 0
-                    
-                    self?.view.layoutIfNeeded()
-                }
-                
-                // 3. DropBox 변경
+                // 2. DropBox 변경
                 self?.categoryView.categoryFilterView.updateDropBoxView(type, superView: self?.view ?? UIView() )
+                self?.view.layoutIfNeeded()
                 
-                // 4. DropBox가 전부 변경되므로 subscribe한다.
+                // 3. DropBox가 전부 변경되므로 subscribe한다.
                 self?.subscribeCategoryFilterView()
                 
-                // 5. HorizontalCollectionView 데이터 변경
-                if type == .category {
-                    // TODO: - ⚠️CoreData를 이용하여 가져올 예정이다.
-                    self?.categoryView.horizontalCollectionView.categoryList = [
-                        "학용품", "다이어리", "학용품", "다이어리", "학용품", "다이어리", "학용품", "다이어리",
-                        "학용품", "다이어리", "학용품", "다이어리", "학용품", "다이어리", "학용품", "다이어리"
-                    ]
-                    self?.categoryView.horizontalCollectionView.isCollapse = false
-                    self?.categoryView.horizontalCollectionView.reloadData()
-                }
+                // 4. HorizontalCollectionView 높이 변경
+                self?.hideHorizontalCollectionView(type != .category)
                 
-                self?.testViewModel()
+                self?.fetchAllPosts()
             })
             .disposed(by: disposeBag)
     }
@@ -110,5 +106,39 @@ extension CategoryViewController {
                 self?.categoryViewHeightConstriant?.constant = dist
             })
             .disposed(by: disposeBag)
+    }
+    
+    /// 카테고리의 서브카테고리 뷰의 높이를 변경하는 메서드다
+    private func hideHorizontalCollectionView(_ bool: Bool ) {
+        let subCategoryCount: Int = categoryRepo.fetchedResultsController.fetchedObjects?.count ?? 0
+        
+        UIView.animate(withDuration: 0.2) {
+            self.categoryViewHeightConstriant?.constant = (bool || subCategoryCount == 0 ) ? self.categoryView.normalHeight :  self.categoryView.maxHeight
+            self.currentCategoryHeight = (bool || subCategoryCount == 0 ) ? self.categoryView.normalHeight: self.categoryView.maxHeight
+            self.view.layoutIfNeeded()
+            self.categoryView.horizontalCollectionView.isCollapse = bool
+        }
+    }
+    
+    /// Post의 NSfetchResultsController의 Delegate - didChangeContents에 반응할 클로저를 세팅한다.
+    func setupContentsViewControllerCompletion() {
+        contentsViewController.completionBlock = { [weak self] updatedFetchCount in
+            self?.updateResultsCountView(fetchedCount: updatedFetchCount)
+        }
+    }
+    
+    /// Category의 NSfetchResultsController의 Delegate - didChangeContents에 반응할 클로저를 세팅한다.
+    func setupHorizontalColletionCompletion() {
+        categoryView.horizontalCollectionView.completionBlock = { [weak self] _ in
+            if self?.viewModel.currentTopCategoryType == .category {
+                self?.hideHorizontalCollectionView(false)
+            }
+        }
+    }
+
+    /// CategoryView의 하단에 fetch된 Post개시물의 개수를 업데이트하는 메서드다
+    /// - Parameter fetchedCount: fetch된 Post개시물의 개수를 주입한다.
+    private func updateResultsCountView(fetchedCount: Int? ) {
+        self.categoryView.categoryFilterView.updateResultTotalLabel(by: "총" + String(fetchedCount ?? 0) + "건")
     }
 }

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -40,6 +40,7 @@ final class CategoryViewController: UIViewController {
     let contentsViewController: BaseContentsCollectionViewController = BaseContentsCollectionViewController(willHideFilterView: true)
     
     var viewModel: CategoryViewModel = CategoryViewModel()
+    let categoryRepo: CategoryRepository = CategoryRepository(fetchedResultsControllerDelegate: nil)
     
     var categoryViewHeightConstriant: NSLayoutConstraint?
     var currentCategoryHeight: CGFloat = 0
@@ -59,6 +60,12 @@ final class CategoryViewController: UIViewController {
         subscribeCategoryFilterView()
         subscribeHorizontalCollectionView()
         subscribeBaseControllerScrollOffset()
+        
+        fetchAllPosts()
+        fetchAllCategory()
+        
+        setupHorizontalColletionCompletion()
+        setupContentsViewControllerCompletion()
     }
 }
 

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -4,7 +4,7 @@
 //
 //  Created by hyunsu on 2021/09/22.
 //
-
+import CoreData
 import UIKit
 
 class ContentsCollectionViewCell: UICollectionViewCell {
@@ -13,6 +13,16 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         imageview.backgroundColor = .clear
         imageview.translatesAutoresizingMaskIntoConstraints = false
         return imageview
+    }()
+    
+    var testLabel: UILabel = {
+        var label: UILabel = UILabel()
+        label.textColor = SwiftGenColors.systemBlue.color
+        label.font = UIFont.Pretendard.caption
+        label.backgroundColor = .clear
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
     
     override init(frame: CGRect) {
@@ -32,5 +42,29 @@ class ContentsCollectionViewCell: UICollectionViewCell {
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
+        testSetupLabel()
+    }
+    
+    func testSetupLabel() {
+        contentView.addSubview(testLabel)
+        NSLayoutConstraint.activate([
+            testLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            testLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            testLabel.topAnchor.constraint(equalTo: contentView.topAnchor),
+            testLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+
+    /// PostEntity를 기반으로 뷰를 업데이트한다.
+    /// - Parameter postEntity: 특정 PostEntity를 주입한다.
+    func updateView(_ postEntity: PostEntity) {
+        var text: String = ""
+        text += "제목: " + postEntity.title!
+        text += "\n카테고리: " + (postEntity.categories?.allObjects as? [CategoryEntity])!.map{ $0.title! }.joined(separator: " - ")
+        text += "\n가격: " + String(postEntity.price)
+        text += "\n" + ( postEntity.isLike ? "좋아요" : "싫어요" )
+        text += "\n날짜: " + (postEntity.createDate!.toString(.year))+(postEntity.createDate!.toString(.month))+(postEntity.createDate!.toString(.day))
+        text += "\n만족도: " + String(postEntity.rating!.score)
+        testLabel.text = text 
     }
 }

--- a/ThingLog/ViewController/TabBarController.swift
+++ b/ThingLog/ViewController/TabBarController.swift
@@ -104,7 +104,14 @@ final class TabBarController: UITabBarController {
             .bind { [weak self] type in
                 guard let self = self else { return }
                 self.touchDimmedView()
-                self.writeCoordinator.showWriteViewController(with: type)
+                
+                // Test Code
+                if type == .bought {
+                    makeDummy()
+                } else {
+                    deleteAllEntity()
+                }
+//                self.writeCoordinator.showWriteViewController(with: type)
             }
             .disposed(by: disposeBag)
     }

--- a/ThingLogTests/DummyProtocol.swift
+++ b/ThingLogTests/DummyProtocol.swift
@@ -48,7 +48,7 @@ extension DummyProtocol {
                                                               imageData: .init(originalImage: originalImage))],
                                      comments: nil,
                                      isLike: [true,false].randomElement()!,
-                                     createDate: Date().day(by: i)!)
+                                     createDate: Date().offset(i, byAdding: .day)!)
             return newPost
         }.shuffled()
         return newPosts

--- a/ThingLogTests/DummyProtocol.swift
+++ b/ThingLogTests/DummyProtocol.swift
@@ -1,0 +1,91 @@
+//
+//  DummyProtocol.swift
+//  ThingLogTests
+//
+//  Created by hyunsu on 2021/10/07.
+//
+
+import Foundation
+@testable import ThingLog
+import CoreData
+import XCTest
+
+/// 더미 Post데이터를 만들기 위한 프로토콜이다.
+protocol DummyProtocol where Self: XCTestCase {
+    var postRepository: PostRepository { get set }
+    var categoryRepository: CategoryRepository { get set }
+    
+    func dummyPost(_ count: Int) -> [Post]
+    func deleteAllEntity()
+    func create(_ newPost: Post)
+}
+
+extension DummyProtocol {
+    func dummyPost(_ count: Int) -> [Post] {
+        guard let originalImage: UIImage = UIImage(systemName: "heart.fill") else {
+            fatalError("Not Found system Image")
+        }
+        let categoryList: [String] = ["문구", "가전", "화장품", "운동", "옷"]
+        let titleNameList: [String] = ["아이폰","맥북","아이폰11","아이패드프로","애플워치"]
+        let purchasePlaceList: [String] = ["강남","서울","경기","제주"]
+        
+        
+        let newPosts: [Post] = (1...count).map { i in
+            var categories = [Category.init(title: "")]
+            categories.removeLast()
+            for _ in 0...Int.random(in: 0..<categoryList.count) {
+                categories.append(Category.init(title: categoryList[Int.random(in: 0..<categoryList.count)]))
+            }
+            let newPost: Post = Post(title: titleNameList.randomElement()!,
+                                     price: 500 * i,
+                                     purchasePlace: purchasePlaceList.randomElement()!,
+                                     contents: "Test Contents \(titleNameList.randomElement()!)...",
+                                     giftGiver: "현수",
+                                     postType: .init(isDelete: false, type: .bought),
+                                     rating: Rating(score: ScoreType(rawValue: Int16.random(in: 0..<5))!),
+                                     categories: categories,
+                                     attachments: [Attachment(thumbnail: originalImage,
+                                                              imageData: .init(originalImage: originalImage))],
+                                     comments: nil,
+                                     isLike: [true,false].randomElement()!,
+                                     createDate: Date().day(by: i)!)
+            return newPost
+        }.shuffled()
+        return newPosts
+    }
+    
+    func deleteAllEntity() {
+        timeout(10) { exp in
+            postRepository.deleteAll { result in
+                switch result {
+                case .success(_):
+                    self.categoryRepository.deleteAll { categoryResult in
+                        exp.fulfill()
+                        switch categoryResult {
+                        case .success(_):
+                            XCTAssert(true)
+                        case .failure(let error):
+                            XCTFail(error.localizedDescription)
+                        }
+                    }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
+            }
+        }
+    }
+    
+    func create(_ newPost: Post) {
+        timeout(3) { exp in
+            postRepository.create(newPost) { result in
+                exp.fulfill()
+                switch result {
+                case .success(_):
+                    XCTAssert(true)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
+            }
+        }
+    }
+}

--- a/ThingLogTests/ThingLogPostCategoryRequestTests.swift
+++ b/ThingLogTests/ThingLogPostCategoryRequestTests.swift
@@ -1,0 +1,264 @@
+//
+//  ThingLogPostCategoryRequestTests.swift
+//  ThingLogTests
+//
+//  Created by hyunsu on 2021/10/07.
+//
+
+import XCTest
+@testable import ThingLog
+import CoreData
+
+/// 모아보기에서 전체, 년도, 카테고리, 좋아요, 만족도, 가격 + dropBox에 해당하는 필터링등을 조건으로 데이터를 가져오는 테스트코드다.
+class ThingLogPostCategoryRequestTests: XCTestCase, DummyProtocol {
+    
+    let context: NSManagedObjectContext = CoreDataStack.shared.mainContext
+    var postRepository: PostRepository = PostRepository(fetchedResultsControllerDelegate: nil)
+    var categoryRepository: CategoryRepository = CategoryRepository(fetchedResultsControllerDelegate: nil)
+    
+    override func tearDown() {
+        deleteAllEntity()
+    }
+
+    func test_년도와_9월로_Date타입으로_yyyMM_포멧으로는_만들_수_없다() {
+        let year: String = "2021"
+        let month: String = "9"
+        let dateFormatter: DateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyyMM"
+        let date = dateFormatter.date(from: year+month)
+        XCTAssert(date == nil )
+    }
+    
+    func test_년도와_월로_Date타입으로_만들수_있다() {
+        let year: String = "2021"
+        let month: String = "12"
+        let dateFormatter: DateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyyMM"
+        let date = dateFormatter.date(from: year+month)
+        XCTAssert(date != nil )
+    }
+    
+    // MARK: - Test
+    func test_전체에서_최신순으로_post들을_가져올_수_있다() throws {
+        let posts = dummyPost(10) + dummyPost(10)
+        
+        posts.forEach {
+            create($0)
+        }
+        // 제일 높은
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "createDate", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                XCTAssertTrue(list.sorted(by: {$0.createDate! > $1.createDate!}) == list)
+            }
+        }
+    }
+    
+    func test_년도에서_날짜별로_post들을_가져올_수_있다() throws {
+        let posts = dummyPost(10) + dummyPost(10)
+        
+        posts.forEach {
+            create($0)
+        }
+        // 제일 높은
+        let targetDate: Date = Date().day(by: 3)!
+        let targetCount: Int = posts.filter { $0.createDate == targetDate }.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "createDate == %@", targetDate as NSDate)
+        request.sortDescriptors = [NSSortDescriptor(key: "rating.score", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count, targetCount)
+                XCTAssertTrue(list.count == targetCount)
+            }
+        }
+    }
+    
+    func test_특정_카테고리로_post들을_최신순으로_가져올_수_있다() throws {
+        let posts = dummyPost(10)
+        
+        posts.forEach {
+            create($0)
+        }
+        // 제일 높은
+        let targetCategoryTitle: String = "가전"
+        let targetCount: Int = posts.filter { $0.categories.contains(where: {$0.title == targetCategoryTitle} )}.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "ANY categories.title == %@", targetCategoryTitle)
+        request.sortDescriptors = [NSSortDescriptor(key: "createDate", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count, targetCount)
+                XCTAssertTrue(list.count == targetCount &&
+                                list.sorted(by: {$0.createDate! > $1.createDate!}) == list)
+            }
+        }
+    }
+    
+    func test_특정_카테고리가_특정_문자열이_포함된_카테고리로_post들을_최신순으로_가져올_수_있다() throws {
+        let posts = dummyPost(10)
+        
+        posts.forEach {
+            create($0)
+        }
+        // 제일 높은
+        let targetCategoryTitle: String = "가"
+        let targetCount: Int = posts.filter { $0.categories.contains(where: {$0.title.contains( targetCategoryTitle)} )}.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "ANY categories.title CONTAINS %@", targetCategoryTitle)
+        request.sortDescriptors = [NSSortDescriptor(key: "createDate", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count, targetCount)
+                XCTAssertTrue((list.count == targetCount &&
+                                list.sorted(by: {$0.createDate! > $1.createDate!}) == list))
+            }
+        }
+    }
+    
+    func test_좋아요가_높은순으로_post들을_가져올_수_있다() throws {
+        let posts = dummyPost(10)
+    
+        posts.forEach {
+            create($0)
+        }
+        
+        let likeCount: Int = posts.filter { $0.isLike }.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "isLike", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count)
+               XCTAssertTrue(list[0..<likeCount].filter { $0.isLike }.count == likeCount)
+            }
+        }
+    }
+    
+    func test_좋아요가_낮은순으로_post들을_가져올_수_있다() throws {
+        let posts = dummyPost(10)
+        
+        posts.forEach {
+            create($0)
+        }
+        
+        let dislikeCount: Int = posts.filter { !$0.isLike }.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "isLike", ascending: true)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count)
+               XCTAssertTrue(list[0..<dislikeCount].filter { !$0.isLike }.count == dislikeCount)
+            }
+        }
+    }
+    
+    func test_만족도가_높은순_으로_post들을_가져올_수_있다() throws {
+        let posts = dummyPost(10)
+        
+        posts.forEach {
+            create($0)
+        }
+        // 제일 높은
+        let ratingCount: Int = posts.filter { $0.rating.score ==  .excellent }.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "rating.score", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count, ratingCount)
+                XCTAssertTrue(list[0..<ratingCount].filter { ($0.rating!.scoreType == ScoreType.excellent) }.count == ratingCount)
+            }
+        }
+    }
+    
+    func test_만족도가_낮은순_으로_post들을_가져올_수_있다() throws {
+        let posts = dummyPost(10)
+        
+        posts.forEach {
+            create($0)
+        }
+        // 제일 낮은
+        let ratingCount: Int = posts.filter { $0.rating.score ==  .veryPoor }.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "rating.score", ascending: true)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count, ratingCount)
+                list.forEach{ print($0.rating!.scoreType)}
+                XCTAssertTrue(list[0..<ratingCount].filter { ($0.rating!.scoreType == ScoreType.veryPoor) }.count == ratingCount)
+            }
+        }
+    }
+    
+    func test_가격이_높은순_으로_post들을_가져올_수_있다() throws {
+        let posts = dummyPost(10)
+        
+        posts.forEach {
+            create($0)
+        }
+        // 제일 낮은
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "price", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                XCTAssertTrue(list == list.sorted(by: { $0.price > $1.price }))
+            }
+        }
+    }
+    
+    func test_가격이_낮은순_으로_post들을_가져올_수_있다() throws {
+        let posts = dummyPost(10)
+        
+        posts.forEach {
+            create($0)
+        }
+        // 제일 낮은
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "price", ascending: true)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                XCTAssertTrue(list == list.sorted(by: { $0.price < $1.price }))
+            }
+        }
+    }
+}

--- a/ThingLogTests/ThingLogPostCategoryRequestTests.swift
+++ b/ThingLogTests/ThingLogPostCategoryRequestTests.swift
@@ -66,7 +66,7 @@ class ThingLogPostCategoryRequestTests: XCTestCase, DummyProtocol {
             create($0)
         }
         // 제일 높은
-        let targetDate: Date = Date().day(by: 3)!
+        let targetDate: Date = Date().offset(3, byAdding: .day)!
         let targetCount: Int = posts.filter { $0.createDate == targetDate }.count
         
         let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()

--- a/ThingLogTests/ThingLogPostCategoryRequestTests.swift
+++ b/ThingLogTests/ThingLogPostCategoryRequestTests.swift
@@ -20,7 +20,7 @@ class ThingLogPostCategoryRequestTests: XCTestCase, DummyProtocol {
         deleteAllEntity()
     }
 
-    func test_년도와_9월로_Date타입으로_yyyMM_포멧으로는_만들_수_없다() {
+    func test_월이_한글자인_경우에_yyyyM_포멧이면_Date_타입을_만들_수_없다() {
         let year: String = "2021"
         let month: String = "9"
         let dateFormatter: DateFormatter = DateFormatter()
@@ -108,7 +108,7 @@ class ThingLogPostCategoryRequestTests: XCTestCase, DummyProtocol {
         }
     }
     
-    func test_특정_카테고리가_특정_문자열이_포함된_카테고리로_post들을_최신순으로_가져올_수_있다() throws {
+    func test_특정_문자열이_포함된_카테고리의_Post들을_최신순으로_가져올_수_있다() throws {
         let posts = dummyPost(10)
         
         posts.forEach {

--- a/ThingLogTests/ThingLogPostSearchRequestTests.swift
+++ b/ThingLogTests/ThingLogPostSearchRequestTests.swift
@@ -1,0 +1,130 @@
+//
+//  ThingLogPostSearchRequestTests.swift
+//  ThingLogTests
+//
+//  Created by hyunsu on 2021/10/07.
+//
+
+import XCTest
+@testable import ThingLog
+import CoreData
+
+/// 검색홈에서 검색에 따른 데이터를 보여주기 위한 NSFetchRequest 테스트 코드다.
+class ThingLogPostSearchTests: XCTestCase, DummyProtocol {
+    let context: NSManagedObjectContext = CoreDataStack.shared.mainContext
+    
+    var postRepository: PostRepository = PostRepository(fetchedResultsControllerDelegate: nil)
+    var categoryRepository: CategoryRepository = CategoryRepository(fetchedResultsControllerDelegate: nil)
+    
+    override func tearDown() {
+        deleteAllEntity()
+    }
+    
+    // 카테고리가 포함 된 모든 글을 노출해요. 카테고리 개수가 적은 순서로요.
+    // 카테고리가 복수인 경우( ‘문구’ ‘노트’ )는 단수로 존재하는 ‘문구’ 보다 밑에 위치하여 노출됩니다.
+    func test_특정_카테고리로_post들을_카테고리가개수가_적은순서대로_가져올_수_있다() {
+        let posts = dummyPost(20)
+        
+        posts.forEach {
+            create($0)
+        }
+        
+        let targetCategoryTitle: String = "문구"
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "ANY categories.title == %@", targetCategoryTitle)
+        request.sortDescriptors = [NSSortDescriptor(key: "categoryCount", ascending: true)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                list.forEach {
+                    ($0.categories?.allObjects as?  [CategoryEntity])?.forEach {
+                        print($0.title)
+                    }
+                    print()
+                }
+                XCTAssertTrue(list == list.sorted(by: { $0.categories!.count < $1.categories!.count}))
+            }
+        }
+    }
+    
+    func test_특정_물건이름으로_post들을_가져올_수_있다() {
+        let posts = dummyPost(20)
+        
+        posts.forEach {
+            create($0)
+        }
+        
+        let targetTitle: String = "아이패드"
+        let targetCount: Int = posts.filter { $0.title.contains(targetTitle)}.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "title CONTAINS %@", targetTitle)
+        request.sortDescriptors = [NSSortDescriptor(key: "createDate", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count, targetCount)
+                XCTAssertTrue(list.count == targetCount)
+            }
+        }
+    }
+    
+    func test_글내용에_특정_문자가_포함된_post들을_가져올_수_있다() {
+        let posts = dummyPost(20)
+        
+        posts.forEach {
+            create($0)
+        }
+        
+        let targetTitle: String = "아이패드"
+        let targetCount: Int = posts.filter { $0.contents!.contains(targetTitle)}.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "contents CONTAINS %@", targetTitle)
+        request.sortDescriptors = [NSSortDescriptor(key: "createDate", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count, targetCount)
+                list.forEach { print($0.contents)}
+                XCTAssertTrue(list.count == targetCount)
+            }
+        }
+    }
+    
+    func test_특정_선물준_사람으로_post들을_가져올_수_있다() {
+        
+    }
+    
+    func test_특정_구매처판매처로_post들을_가져올_수_있다() {
+        let posts = dummyPost(20)
+        
+        posts.forEach {
+            create($0)
+        }
+        
+        let targetTitle: String = "강남"
+        let targetCount: Int = posts.filter { $0.purchasePlace!.contains(targetTitle)}.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "purchasePlace CONTAINS %@", targetTitle)
+        request.sortDescriptors = [NSSortDescriptor(key: "createDate", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count, targetCount)
+                list.forEach { print($0.purchasePlace)}
+                XCTAssertTrue(list.count == targetCount)
+            }
+        }
+    }
+}

--- a/ThingLogTests/ThingLogPostSearchRequestTests.swift
+++ b/ThingLogTests/ThingLogPostSearchRequestTests.swift
@@ -100,7 +100,28 @@ class ThingLogPostSearchTests: XCTestCase, DummyProtocol {
     }
     
     func test_특정_선물준_사람으로_post들을_가져올_수_있다() {
+        let posts = dummyPost(20)
         
+        posts.forEach {
+            create($0)
+        }
+        
+        let targetGiver: String = "현수"
+        let targetCount: Int = posts.filter { $0.giftGiver == targetGiver }.count
+        
+        let request: NSFetchRequest<PostEntity> = PostEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "giftGiver CONTAINS %@", targetGiver)
+        request.sortDescriptors = [NSSortDescriptor(key: "createDate", ascending: false)]
+        
+        timeout(0.3) { exp in
+            context.perform {
+                let list = try! request.execute()
+                exp.fulfill()
+                print(list.count, targetCount)
+                list.forEach { print($0.purchasePlace)}
+                XCTAssertTrue(list.count == targetCount)
+            }
+        }
     }
     
     func test_특정_구매처판매처로_post들을_가져올_수_있다() {


### PR DESCRIPTION
## 개요
모아보기홈에서 실제 데이터가 나오도록 한다

## 시연 

![data](https://user-images.githubusercontent.com/48749182/136515422-7cf060e9-da30-46af-85da-8f869bb11785.gif)

## 작업 사항
크게, 모아보기홈에서 실제 데이터가 나오기 위하여, 우선적으로 테스트코드를 작성하고, 확인후에 실제 데이터가 나오기 위하여 리팩토링을 진행했다.
- 모아보기,검색 테스트코드 작성
    - `Date` 메서드 추가
    - Test코드 작성을 위한 프로토콜 추가
    - 모아보기홈에 필요한 테스트코드 작성 - `ThingLogPostCategoryReuqest`
    - 검색홈에 필요한 테스트코드 작성 - `THingLogPostSearchtests`

- 모아보기 `fetchResultsController` 바인딩 
    - `BaseContentsCollectionViewController`에 `NSFetchResultsController` 를 가지고 리팩토링
    - `HorizontalCollectionView`에 `NSFetchResultsController`를 가지고 리팩토링
    - `CategoryViewModel`에 각 조합에 따른 `NSFetchRequest` 작성
    - `Date`, `String` extension 메서드 추가
    - 더미 데이터 생성 및 삭제 메소드 추가 및 테스트 액션 `TabBarController-choiceView`에 작성 ( 다시 바꿀 예정 )
    - `CategoryViewController`에 실제로 데이터 보여주기 위해 리팩토링
    - `ContentsCollectionViewCell`에 실제 데이터 보여준지를 확인하기 위한 테스트 label 추가

## 테스트 방법 
- 탭바에서 + 버튼 누르면,
    - 샀다 -> 400개 Post 랜덤으로 생성 
    - 사고싶다, 선물받았따 -> 모든 데이터 삭제 
- 테스트 확인방법은 컨텐츠 셀에 label로 구분하기 위한 각 타입별로 값들을 찍히게 함. 

## 예외사항 
- 데이터가 없는 경우는 따로 뷰를 표시해야하는데 추가로 이슈로 만들어서 작업할 예정입니다. 

### Linked Issue

close #78 

