### PR TITLE
[#93, #94] Post데이터가 없는 경우 뷰 구현 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA726FDD00A00A629F5 /* ImageAssets.swift */; };
 		DB331DAB26FDD00A00A629F5 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA826FDD00A00A629F5 /* Fonts.swift */; };
 		DB37EC77270C307C00030D9A /* RecentSearchView+update.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB37EC76270C307C00030D9A /* RecentSearchView+update.swift */; };
+		DB3A516927103B3E003B529D /* EmptyPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A516827103B3E003B529D /* EmptyPostView.swift */; };
+		DB3A516B27103DC4003B529D /* EmptyResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A516A27103DC4003B529D /* EmptyResultsView.swift */; };
 		DB7C04AA26F5F308009F5C0A /* CategoryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04A926F5F308009F5C0A /* CategoryCoordinator.swift */; };
 		DB7C04B226F87548009F5C0A /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04B126F87548009F5C0A /* TabBarController.swift */; };
 		DB7C04B626F8782B009F5C0A /* CategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04B526F8782B009F5C0A /* CategoryViewController.swift */; };
@@ -202,6 +204,8 @@
 		DB331DA726FDD00A00A629F5 /* ImageAssets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAssets.swift; sourceTree = "<group>"; };
 		DB331DA826FDD00A00A629F5 /* Fonts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
 		DB37EC76270C307C00030D9A /* RecentSearchView+update.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentSearchView+update.swift"; sourceTree = "<group>"; };
+		DB3A516827103B3E003B529D /* EmptyPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPostView.swift; sourceTree = "<group>"; };
+		DB3A516A27103DC4003B529D /* EmptyResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResultsView.swift; sourceTree = "<group>"; };
 		DB7C04A526F5F281009F5C0A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		DB7C04A726F5F2BB009F5C0A /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		DB7C04A926F5F308009F5C0A /* CategoryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCoordinator.swift; sourceTree = "<group>"; };
@@ -483,6 +487,8 @@
 				876243E12708704800BDA1DC /* WriteTypeButton.swift */,
 				DBA0F81D2709BD41009553FC /* RecentSearchView.swift */,
 				DB37EC76270C307C00030D9A /* RecentSearchView+update.swift */,
+				DB3A516A27103DC4003B529D /* EmptyResultsView.swift */,
+				DB3A516827103B3E003B529D /* EmptyPostView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -772,6 +778,7 @@
 				876243E02708701B00BDA1DC /* WriteType.swift in Sources */,
 				DBD5454727032B1C00063C98 /* FilterType.swift in Sources */,
 				DBAB64A726FE2AFF006D95ED /* UIImage+.swift in Sources */,
+				DB3A516B27103DC4003B529D /* EmptyResultsView.swift in Sources */,
 				DB148C26270469B300FDC48F /* Date+.swift in Sources */,
 				873EC00D26D39055003C3525 /* ViewController.swift in Sources */,
 				DBD5455027033D9A00063C98 /* RoundButtonCollectionViewCell.swift in Sources */,
@@ -825,6 +832,7 @@
 				8736B3E326FCB9F3000433E1 /* Rating.swift in Sources */,
 				87BB17AB27098D760088B847 /* WriteViewModel.swift in Sources */,
 				8736B3E926FCBE28000433E1 /* Category.swift in Sources */,
+				DB3A516927103B3E003B529D /* EmptyPostView.swift in Sources */,
 				87F2188E26FB8ACA00C3FBCA /* PostType.swift in Sources */,
 				87DAEB1D270BEC170038C487 /* ThumbnailCell.swift in Sources */,
 				876C157B27044DFF000C1C84 /* CategoryEntity.swift in Sources */,

--- a/ThingLog/Resource/Colors.xcassets/systemRed.colorset/Contents.json
+++ b/ThingLog/Resource/Colors.xcassets/systemRed.colorset/Contents.json
@@ -1,0 +1,41 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.227",
+          "green" : "0.286",
+          "red" : "0.867"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.239",
+          "green" : "0.298",
+          "red" : "0.898"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/ThingLog/SwiftGen/ColorsAsset.swift
+++ b/ThingLog/SwiftGen/ColorsAsset.swift
@@ -27,6 +27,7 @@ internal enum SwiftGenColors {
   internal static let gray5 = ColorSwiftGen(name: "gray5")
   internal static let gray6 = ColorSwiftGen(name: "gray6")
   internal static let systemBlue = ColorSwiftGen(name: "systemBlue")
+  internal static let systemRed = ColorSwiftGen(name: "systemRed")
   internal static let white = ColorSwiftGen(name: "white")
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name

--- a/ThingLog/View/EmptyPostView.swift
+++ b/ThingLog/View/EmptyPostView.swift
@@ -1,0 +1,61 @@
+//
+//  EmptyPostView.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/08.
+//
+
+import UIKit
+
+/// Post가 없는 경우에 게시물 없음을 나타내는 뷰다.
+final class EmptyPostView: UIView {
+    private let topBorderLine: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = SwiftGenColors.gray5.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.setContentHuggingPriority(.required, for: .vertical)
+        return view
+    }()
+    
+    private let label: UILabel = {
+        let label: UILabel = UILabel()
+        label.font = UIFont.Pretendard.body1
+        label.textColor = SwiftGenColors.gray4.color
+        label.text = "게시물 없음"
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentHuggingPriority(.defaultLow, for: .vertical)
+        return label
+    }()
+    
+    lazy var stackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [
+                                                    topBorderLine,
+                                                    label])
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setupView() {
+        addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            topBorderLine.heightAnchor.constraint(equalToConstant: 0.5)
+        ])
+    }
+}

--- a/ThingLog/View/EmptyResultsView.swift
+++ b/ThingLog/View/EmptyResultsView.swift
@@ -1,0 +1,74 @@
+//
+//  EmptyPostView.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/08.
+//
+
+import UIKit
+
+/// 검색결과가 없는 경우에  `키워드 + 검색결과 없음`을 나타내는 뷰다.
+final class EmptyResultsView: UIView {
+    private let emptyView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.setContentHuggingPriority(.required, for: .vertical)
+        return view
+    }()
+    
+    private let label: UILabel = {
+        let label: UILabel = UILabel()
+        label.font = UIFont.Pretendard.body2
+        label.textColor = SwiftGenColors.black.color
+        label.text = "게시물 없음"
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        label.setContentHuggingPriority(.defaultLow, for: .vertical)
+        return label
+    }()
+    
+    lazy var stackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [
+                                                    label,
+                                                    emptyView])
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setupView() {
+        addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            emptyView.heightAnchor.constraint(equalTo: stackView.heightAnchor,
+                                              multiplier: 0.6)
+        ])
+    }
+}
+
+extension EmptyResultsView {
+    // 검색결과 없습니다를 title과 함께 붙여 업데이트하는 메서드다
+    func updateTitle(_ title: String ) {
+        let text: String = title + "의 검색결과가 없습니다"
+        label.text = text
+        let attributedStr: NSMutableAttributedString = NSMutableAttributedString(string: text)
+        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor,
+                                   value: SwiftGenColors.systemRed.color,
+                                   range: (text as NSString).range(of: title) )
+        label.attributedText = attributedStr
+    }
+}

--- a/ThingLog/ViewController/ContentsCollection/BaseContentsCollectionViewController.swift
+++ b/ThingLog/ViewController/ContentsCollection/BaseContentsCollectionViewController.swift
@@ -28,6 +28,14 @@ class BaseContentsCollectionViewController: UIViewController {
         return view
     }()
     
+    // Post가 없는 경우에 보여주는 뷰다 
+    var emptyView: EmptyPostView = {
+        let view: EmptyPostView = EmptyPostView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
+        return view
+    }()
+    
     var scrollOffsetYSubject: PublishSubject = PublishSubject<CGFloat>()
     var disposeBag: DisposeBag = DisposeBag()
     var recentScrollOffsetY: CGFloat = 0
@@ -51,6 +59,7 @@ class BaseContentsCollectionViewController: UIViewController {
         view.backgroundColor = SwiftGenColors.white.color
         setupResultFilterView()
         setupBaseCollectionView()
+        setupEmptyView()
         
         // 드롭박스가 가장 상단에 나타나야하기 때문에 collectionView 세팅 이후에 추가해야한다. 
         resultsFilterView.updateDropBoxView(.total, superView: view)
@@ -79,11 +88,22 @@ class BaseContentsCollectionViewController: UIViewController {
             collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
+    
+    func setupEmptyView() {
+        view.addSubview(emptyView)
+        NSLayoutConstraint.activate([
+            emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            emptyView.topAnchor.constraint(equalTo: view.topAnchor),
+            emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
 }
 
 extension BaseContentsCollectionViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        100
+        emptyView.isHidden = false 
+        return 0
     }
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {

--- a/ThingLog/ViewController/SearchViewController.swift
+++ b/ThingLog/ViewController/SearchViewController.swift
@@ -30,6 +30,15 @@ final class SearchViewController: UIViewController {
         return containerView
     }()
     
+    // 검색결과가 없는 경우에 보여주는 뷰다
+    private let emptyView: EmptyResultsView = {
+        let view: EmptyResultsView = EmptyResultsView()
+        view.isHidden = true
+        view.backgroundColor = SwiftGenColors.white.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     private let searchResultsViewController: SearchResultsViewController = SearchResultsViewController()
     
     // MARK: - Properties
@@ -46,6 +55,7 @@ final class SearchViewController: UIViewController {
         setupContainerView()
         setupRecentSearchView()
         setupSearchResultsViewContorller()
+        setupEmptyView()
         
         subscribeBackButton()
         subscribeTableViewSelectIndex()
@@ -119,6 +129,18 @@ final class SearchViewController: UIViewController {
         searchTextField.delegate = self
     }
     
+    func setupEmptyView() {
+        view.addSubview(emptyView)
+        let safeLayout: UILayoutGuide = view.safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+            emptyView.leadingAnchor.constraint(equalTo: safeLayout.leadingAnchor),
+            emptyView.trailingAnchor.constraint(equalTo: safeLayout.trailingAnchor),
+            emptyView.bottomAnchor.constraint(equalTo: safeLayout.bottomAnchor),
+            emptyView.topAnchor.constraint(equalTo: safeLayout.topAnchor)
+        ])
+        
+    }
+    
     // MARK: - Subscribe
     /// CustomTextField에 BackButton을 subscribe 한다.
     private func subscribeBackButton() {
@@ -187,7 +209,9 @@ extension SearchViewController: SearchTextFieldDelegate {
             }
             // TODO: - ⚠️ 키워드를 통해서 NSFetchRequest + NSFetchResultsController 생성하여 업데이트
             print(text)
-            showSearchResultsViewController(true)
+            emptyView.isHidden = false
+            emptyView.updateTitle(text) // TODO: ⚠️ 테스트 
+//            showSearchResultsViewController(true)
         }
         hideKeyboard()
         return true


### PR DESCRIPTION

## 개요
Post데이터가 없는 경우에 보여주는 뷰 구현 
![image](https://user-images.githubusercontent.com/48749182/136530657-614debf4-c979-4571-822e-300820a78113.png)
![image](https://user-images.githubusercontent.com/48749182/136530690-604d5bbc-2742-44ea-89f9-8d36a846b7a2.png)


## 작업 사항
- `EmptyPostView` 구현 - Post가 없는 경우에 보여주는 뷰다
- `EmptyResultsView` 구현 - 검색결과가 없는 경우에 보여주는 뷰다
- `systemRed` 컬러 추가
- `BaseContentsCollectionViewController`에 `EmptyPostView` 추가
- `SearchViewController`에 `EmptyResultsView` 추가 ( 로직은 테스트코드입니다 )

### Linked Issue

## 테스트 
`EmptyPostView`는 홈화면 - 선물받았다 탭을 누르면 나옵니다
`EmptyResultsView`는 검색화면에서 검색후 enter누른 경우에만 나옵니다 

close #93
close #94 

