### PR TITLE
[#113] 카테고리: 글쓰기 화면 → 카테고리 화면 이동 구현

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		8736B3F226FDC281000433E1 /* Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8736B3F126FDC281000433E1 /* Attachment.swift */; };
 		8736B3F426FDD55E000433E1 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8736B3F326FDD55E000433E1 /* UIFont+.swift */; };
 		8736B3F626FE245A000433E1 /* PostEntity+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8736B3F526FE245A000433E1 /* PostEntity+.swift */; };
+		8738E1CB271705220069BB80 /* CategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8738E1CA271705220069BB80 /* CategoryViewController.swift */; };
 		873EC00926D39055003C3525 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873EC00826D39055003C3525 /* AppDelegate.swift */; };
 		873EC00B26D39055003C3525 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873EC00A26D39055003C3525 /* SceneDelegate.swift */; };
 		873EC00D26D39055003C3525 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873EC00C26D39055003C3525 /* ViewController.swift */; };
@@ -159,6 +160,7 @@
 		8736B3F126FDC281000433E1 /* Attachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attachment.swift; sourceTree = "<group>"; };
 		8736B3F326FDD55E000433E1 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		8736B3F526FE245A000433E1 /* PostEntity+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEntity+.swift"; sourceTree = "<group>"; };
+		8738E1CA271705220069BB80 /* CategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewController.swift; sourceTree = "<group>"; };
 		873EC00526D39055003C3525 /* ThingLog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThingLog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		873EC00826D39055003C3525 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		873EC00A26D39055003C3525 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 		DB7C04DF26FB18F4009F5C0A /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				8738E1CA271705220069BB80 /* CategoryViewController.swift */,
 				DB7C04E026FB1900009F5C0A /* ContentsCollection */,
 				DB7C04F126FB1F36009F5C0A /* ContentsPageViewController.swift */,
 				DB7C04B526F8782B009F5C0A /* EasyLookViewController.swift */,
@@ -786,6 +789,7 @@
 				DBAB64A426FCC2C5006D95ED /* Coordinator.swift in Sources */,
 				DBA0F81E2709BD41009553FC /* RecentSearchView.swift in Sources */,
 				DBD2244727085671004C5184 /* EasyLookViewController+subscribe.swift in Sources */,
+				8738E1CB271705220069BB80 /* CategoryViewController.swift in Sources */,
 				DB7C04EE26FB1ACE009F5C0A /* ContentsTabView.swift in Sources */,
 				DBA0F820270AF0A4009553FC /* ResultCollectionSection.swift in Sources */,
 				DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */,

--- a/ThingLog/Coordinator/WriteCoordinator.swift
+++ b/ThingLog/Coordinator/WriteCoordinator.swift
@@ -32,4 +32,11 @@ final class WriteCoordinator: Coordinator {
         navigationController.pushViewController(writeViewController, animated: true)
         parentViewController?.present(navigationController, animated: true)
     }
+
+    /// CategoryViewController로 이동한다.
+    func showCategoryViewController() {
+        let categoryViewController: CategoryViewController = CategoryViewController()
+        categoryViewController.coordinator = self
+        navigationController.pushViewController(categoryViewController, animated: true)
+    }
 }

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -1,0 +1,18 @@
+//
+//  CategoryViewController.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/10/13.
+//
+
+import UIKit
+
+final class CategoryViewController: UIViewController {
+    var coordinator: Coordinator?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = SwiftGenColors.white.color
+    }
+}

--- a/ThingLog/ViewController/TabBarController.swift
+++ b/ThingLog/ViewController/TabBarController.swift
@@ -106,12 +106,12 @@ final class TabBarController: UITabBarController {
                 self.touchDimmedView()
                 
                 // Test Code
-                if type == .bought {
-                    makeDummy()
-                } else {
-                    deleteAllEntity()
-                }
-//                self.writeCoordinator.showWriteViewController(with: type)
+//                if type == .bought {
+//                    makeDummy()
+//                } else {
+//                    deleteAllEntity()
+//                }
+                self.writeCoordinator.showWriteViewController(with: type)
             }
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 개요

글쓰기 화면에서 카테고리 화면 이동 구현

## 작업 사항

- `CategoryViewController` 생성
- `WriteCoordinator`에서 `CategoryViewController`로 이동하는 메서드 구현

## 테스트 코드

현재 현수님이 작성해놓으신 더미 데이터 생성/삭제하는 부분은 건들이지 않았습니당. 그래서 테스트 하시려면 WriteViewController 이동하는 코드를 다시 활성화하고 아래 코드를 추가하면 됩니다. 이후에는 카테고리 셀 선택시 이동하게 변경할 예정입니다.

`WriteViewController+setup.swift`

```swift
func setupNavigationBar() {
  /* 기존 코드 생략 */

  let categoryButton: UIButton = {
    let button: UIButton = UIButton()
    button.setTitle("카테고리 이동", for: .normal)
    button.setTitleColor(SwiftGenColors.black.color, for: .normal)
    return button
  }()

  categoryButton.rx.tap.bind { [weak self] in
      guard let coordinator: WriteCoordinator = self?.coordinator as? WriteCoordinator else {
          return
      }
      coordinator.showCategoryViewController()
  }.disposed(by: disposeBag)

  navigationItem.leftBarButtonItem = UIBarButtonItem(customView: categoryButton)
}
```


### Linked Issue

close #113 

