### PR TITLE
[#109] 휴지통 화면 구현 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		87F2188E26FB8ACA00C3FBCA /* PostType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F2188D26FB8ACA00C3FBCA /* PostType.swift */; };
 		87F2189026FB8D6A00C3FBCA /* PostTypeEntity+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F2188F26FB8D6A00C3FBCA /* PostTypeEntity+.swift */; };
 		DB05B03C271853CE0067DB17 /* LeftRightButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B03B271853CE0067DB17 /* LeftRightButtonView.swift */; };
+		DB05B03E27185B780067DB17 /* TrashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B03D27185B780067DB17 /* TrashViewController.swift */; };
+		DB05B04027185C500067DB17 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B03F27185C500067DB17 /* UIViewController+.swift */; };
 		DB148C2027043CFC00FDC48F /* DropBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C1F27043CFC00FDC48F /* DropBoxView.swift */; };
 		DB148C222704623200FDC48F /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C212704623200FDC48F /* InsetButton.swift */; };
 		DB148C26270469B300FDC48F /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C25270469B300FDC48F /* Date+.swift */; };
@@ -199,6 +201,8 @@
 		87F2188D26FB8ACA00C3FBCA /* PostType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostType.swift; sourceTree = "<group>"; };
 		87F2188F26FB8D6A00C3FBCA /* PostTypeEntity+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostTypeEntity+.swift"; sourceTree = "<group>"; };
 		DB05B03B271853CE0067DB17 /* LeftRightButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftRightButtonView.swift; sourceTree = "<group>"; };
+		DB05B03D27185B780067DB17 /* TrashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashViewController.swift; sourceTree = "<group>"; };
+		DB05B03F27185C500067DB17 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		DB148C1F27043CFC00FDC48F /* DropBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropBoxView.swift; sourceTree = "<group>"; };
 		DB148C212704623200FDC48F /* InsetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetButton.swift; sourceTree = "<group>"; };
 		DB148C25270469B300FDC48F /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
@@ -467,6 +471,7 @@
 				DBD2244A27085DFB004C5184 /* SearchViewController.swift */,
 				DB6909602712DA8100BB54E4 /* SettingViewController.swift */,
 				DB7C04B126F87548009F5C0A /* TabBarController.swift */,
+				DB05B03D27185B780067DB17 /* TrashViewController.swift */,
 				87BB17A62709898F0088B847 /* WriteViewController.swift */,
 				87BB17AC27098F480088B847 /* WriteViewController+setup.swift */,
 			);
@@ -533,6 +538,7 @@
 				DBAB64A626FE2AFF006D95ED /* UIImage+.swift */,
 				DB7C04EB26FB1A04009F5C0A /* UIView+.swift */,
 				DB7C04C926F9E69D009F5C0A /* UserDefaults+.swift */,
+				DB05B03F27185C500067DB17 /* UIViewController+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -843,6 +849,8 @@
 				DBA0F825270B07D8009553FC /* LeftLabelRightButtonHeaderView.swift in Sources */,
 				873EC00B26D39055003C3525 /* SceneDelegate.swift in Sources */,
 				87BB17AD27098F480088B847 /* WriteViewController+setup.swift in Sources */,
+				DB05B04027185C500067DB17 /* UIViewController+.swift in Sources */,
+				DB05B03E27185B780067DB17 /* TrashViewController.swift in Sources */,
 				8736B3F426FDD55E000433E1 /* UIFont+.swift in Sources */,
 				DBD5454C27032C6600063C98 /* EasyLookViewModel.swift in Sources */,
 				DB7C04F026FB1EFF009F5C0A /* HomeViewController.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		DB148C302705863100FDC48F /* EasyLookTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C2F2705863100FDC48F /* EasyLookTabView.swift */; };
 		DB1745B72708700200EF083E /* SearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1745B62708700200EF083E /* SearchTextField.swift */; };
 		DB1745B927098E8A00EF083E /* RecentSearchDataViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1745B827098E8A00EF083E /* RecentSearchDataViewModel.swift */; };
+		DB22327E27183378002ED30D /* TwoLabelVerticalHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB22327D27183378002ED30D /* TwoLabelVerticalHeaderView.swift */; };
 		DB22B6BE270ECA20005F9971 /* PostContentsCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB22B6BD270ECA20005F9971 /* PostContentsCollectionViewController.swift */; };
 		DB331DA926FDD00A00A629F5 /* ColorsAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA626FDD00A00A629F5 /* ColorsAsset.swift */; };
 		DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA726FDD00A00A629F5 /* ImageAssets.swift */; };
@@ -204,6 +205,7 @@
 		DB148C2F2705863100FDC48F /* EasyLookTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EasyLookTabView.swift; sourceTree = "<group>"; };
 		DB1745B62708700200EF083E /* SearchTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextField.swift; sourceTree = "<group>"; };
 		DB1745B827098E8A00EF083E /* RecentSearchDataViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchDataViewModel.swift; sourceTree = "<group>"; };
+		DB22327D27183378002ED30D /* TwoLabelVerticalHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoLabelVerticalHeaderView.swift; sourceTree = "<group>"; };
 		DB22B6BD270ECA20005F9971 /* PostContentsCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostContentsCollectionViewController.swift; sourceTree = "<group>"; };
 		DB331DA626FDD00A00A629F5 /* ColorsAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorsAsset.swift; sourceTree = "<group>"; };
 		DB331DA726FDD00A00A629F5 /* ImageAssets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAssets.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 			isa = PBXGroup;
 			children = (
 				DBA0F824270B07D8009553FC /* LeftLabelRightButtonHeaderView.swift */,
+				DB22327D27183378002ED30D /* TwoLabelVerticalHeaderView.swift */,
 			);
 			path = HeaderView;
 			sourceTree = "<group>";
@@ -794,6 +797,7 @@
 				DBAB64A726FE2AFF006D95ED /* UIImage+.swift in Sources */,
 				DB3A516B27103DC4003B529D /* EmptyResultsView.swift in Sources */,
 				DB148C26270469B300FDC48F /* Date+.swift in Sources */,
+				DB22327E27183378002ED30D /* TwoLabelVerticalHeaderView.swift in Sources */,
 				873EC00D26D39055003C3525 /* ViewController.swift in Sources */,
 				DB6909632712DB0800BB54E4 /* SettingCoordinator.swift in Sources */,
 				DBD5455027033D9A00063C98 /* RoundButtonCollectionViewCell.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		87F2188926FB5E9500C3FBCA /* PostRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F2188826FB5E9500C3FBCA /* PostRepository.swift */; };
 		87F2188E26FB8ACA00C3FBCA /* PostType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F2188D26FB8ACA00C3FBCA /* PostType.swift */; };
 		87F2189026FB8D6A00C3FBCA /* PostTypeEntity+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F2188F26FB8D6A00C3FBCA /* PostTypeEntity+.swift */; };
+		DB05B03C271853CE0067DB17 /* LeftRightButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B03B271853CE0067DB17 /* LeftRightButtonView.swift */; };
 		DB148C2027043CFC00FDC48F /* DropBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C1F27043CFC00FDC48F /* DropBoxView.swift */; };
 		DB148C222704623200FDC48F /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C212704623200FDC48F /* InsetButton.swift */; };
 		DB148C26270469B300FDC48F /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C25270469B300FDC48F /* Date+.swift */; };
@@ -197,6 +198,7 @@
 		87F2188826FB5E9500C3FBCA /* PostRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRepository.swift; sourceTree = "<group>"; };
 		87F2188D26FB8ACA00C3FBCA /* PostType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostType.swift; sourceTree = "<group>"; };
 		87F2188F26FB8D6A00C3FBCA /* PostTypeEntity+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostTypeEntity+.swift"; sourceTree = "<group>"; };
+		DB05B03B271853CE0067DB17 /* LeftRightButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftRightButtonView.swift; sourceTree = "<group>"; };
 		DB148C1F27043CFC00FDC48F /* DropBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropBoxView.swift; sourceTree = "<group>"; };
 		DB148C212704623200FDC48F /* InsetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetButton.swift; sourceTree = "<group>"; };
 		DB148C25270469B300FDC48F /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
@@ -496,6 +498,7 @@
 				DBD545512703409300063C98 /* HorizontalCollectionView.swift */,
 				DB148C272704A1A500FDC48F /* IgnoreTouchView.swift */,
 				DB148C212704623200FDC48F /* InsetButton.swift */,
+				DB05B03B271853CE0067DB17 /* LeftRightButtonView.swift */,
 				DB8BF6782705D25700FD5FDB /* LogoView.swift */,
 				DB7C04BD26F9BE72009F5C0A /* ProfileView.swift */,
 				DBA0F81D2709BD41009553FC /* RecentSearchView.swift */,
@@ -783,6 +786,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB05B03C271853CE0067DB17 /* LeftRightButtonView.swift in Sources */,
 				87BB17A927098A720088B847 /* WriteCoordinator.swift in Sources */,
 				DBAB64A526FCC2F8006D95ED /* HomeCoordinator.swift in Sources */,
 				DBD545522703409300063C98 /* HorizontalCollectionView.swift in Sources */,

--- a/ThingLog/Coordinator/SettingCoordinator.swift
+++ b/ThingLog/Coordinator/SettingCoordinator.swift
@@ -19,10 +19,18 @@ final class SettingCoordinator: Coordinator {
     func start() {
         let settingViewController: SettingViewController = SettingViewController()
         settingViewController.coordinator = self
+        settingViewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(settingViewController, animated: true)
     }
     
     func back() {
         navigationController.popViewController(animated: true)
+    }
+    
+    func showTrashViewController() {
+        let trashViewController: TrashViewController = TrashViewController()
+        trashViewController.coordinator = self
+        trashViewController.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(trashViewController, animated: true)
     }
 }

--- a/ThingLog/Extension/UIView+.swift
+++ b/ThingLog/Extension/UIView+.swift
@@ -31,16 +31,14 @@ extension UIView {
                      startPoint: CGPoint,
                      endPoint: CGPoint) {
         if let sublayers: [CALayer] = layer.sublayers {
-            for sublayer in sublayers {
-                if sublayer.name == "customGradient" {
-                    return
-                }
+            for sublayer in sublayers where sublayer.name == "customGradient"{
+                return
             }
         }
  
         let gradient: CAGradientLayer = CAGradientLayer()
         gradient.colors = [startColor.cgColor, endColor.cgColor]
-        gradient.locations = [0.0 , 1.0]
+        gradient.locations = [0.0, 1.0]
         gradient.startPoint = startPoint
         gradient.endPoint = endPoint
         gradient.frame = bounds

--- a/ThingLog/Extension/UIView+.swift
+++ b/ThingLog/Extension/UIView+.swift
@@ -11,4 +11,40 @@ extension UIView {
     static var reuseIdentifier: String {
         String(describing: Self.self)
     }
+    
+    /// 뷰위에 그라데이션 layer를 추가하는 메서드입니다.
+    /// - Parameters:
+    ///   - startColor: 시작하는 컬러를 지정합니다.
+    ///   - endColor: 끝나는 컬러를 지정합니다.
+    ///   - startPoint: 시작하고자 하는 위치를 지정합니다.
+    ///   - endPoint: 끝나는 위치를 지정합니다.
+    ///
+    /// ```swift
+    /// // 하단에서 상단으로 주고싶을떄
+    /// setGradient(startColor: .black,
+    ///             endColor: .white,
+    ///             startPoint: CGPoint(x: 0.0, y: 1.0),
+    ///             endPoint: CGPoint(x: 0.0, y: 0.0)
+    /// ```
+    func setGradient(startColor: UIColor,
+                     endColor: UIColor,
+                     startPoint: CGPoint,
+                     endPoint: CGPoint) {
+        if let sublayers: [CALayer] = layer.sublayers {
+            for sublayer in sublayers {
+                if sublayer.name == "customGradient" {
+                    return
+                }
+            }
+        }
+ 
+        let gradient: CAGradientLayer = CAGradientLayer()
+        gradient.colors = [startColor.cgColor, endColor.cgColor]
+        gradient.locations = [0.0 , 1.0]
+        gradient.startPoint = startPoint
+        gradient.endPoint = endPoint
+        gradient.frame = bounds
+        gradient.name = "customGradient"
+        layer.addSublayer(gradient)
+    }
 }

--- a/ThingLog/Extension/UIViewController+.swift
+++ b/ThingLog/Extension/UIViewController+.swift
@@ -1,0 +1,28 @@
+//
+//  UIViewController+.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/14.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    /// 상단의 네비게이션바의  경계선을 없애는 코드이며 iOS15의 대응하는 코드가 같이 있다.
+    func setupBaseNavigationBar() {
+        if #available(iOS 15, *) {
+            let appearance: UINavigationBarAppearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = SwiftGenColors.white.color
+            appearance.shadowColor = .clear
+            navigationController?.navigationBar.standardAppearance = appearance
+            navigationController?.navigationBar.scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
+        } else {
+            navigationController?.navigationBar.isTranslucent = false
+            navigationController?.navigationBar.barTintColor = SwiftGenColors.white.color
+            navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
+        }
+    }
+}
+ 

--- a/ThingLog/View/EmptyResultsView.swift
+++ b/ThingLog/View/EmptyResultsView.swift
@@ -16,7 +16,7 @@ final class EmptyResultsView: UIView {
         return view
     }()
     
-    private let label: UILabel = {
+    let label: UILabel = {
         let label: UILabel = UILabel()
         label.font = UIFont.Pretendard.body2
         label.textColor = SwiftGenColors.black.color

--- a/ThingLog/View/HeaderView/TwoLabelVerticalHeaderView.swift
+++ b/ThingLog/View/HeaderView/TwoLabelVerticalHeaderView.swift
@@ -1,0 +1,97 @@
+//
+//  TwoLabelVerticalHeaderView.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/14.
+//
+
+import UIKit
+
+/// 상단에 titleLabel과 하단에subTitleLabel을 가지는 Collection HeaderView다.
+///
+/// 사용되는 곳 : 휴지통화면의 HeaderView
+class TwoLabelVerticalHeaderView: UICollectionReusableView {
+    // MARK: - View
+    private let titleLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.font = UIFont.Pretendard.title2
+        label.textColor = SwiftGenColors.black.color
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setContentHuggingPriority(.required, for: .vertical)
+        label.text = "**개의 게시물"
+        return label
+    }()
+    
+    private let subTitleLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.font = UIFont.Pretendard.body3
+        label.textColor = SwiftGenColors.black.color
+        label.setContentHuggingPriority(.required, for: .vertical)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.text = "게시물이 삭제되기까지 남은 날짜를 보여줍니다. 해당 기간이 지나면 항목이 영구적으로 삭제됩니다. 최대 30일이 소요될 수 있습니다"
+        return label
+    }()
+    
+    private let emptyTopView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.setContentHuggingPriority(.defaultLow, for: .vertical)
+        return view
+    }()
+    
+    private let emptyBottomView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.setContentHuggingPriority(.defaultLow, for: .vertical)
+        return view
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [
+                                                    emptyTopView,
+                                                    titleLabel,
+                                                    subTitleLabel,
+                                                    emptyBottomView])
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private let paddingConstraint: CGFloat = 30
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setupView() {
+        addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: paddingConstraint),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -paddingConstraint),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            emptyTopView.heightAnchor.constraint(equalTo: emptyBottomView.heightAnchor)
+        ])
+    }
+    
+    /// 상단의 제목을 변경하기 위한 메소드다
+    /// - Parameter title: 변경하고자 하는 상단의 제목을 주입한다.
+    func updateTitle(by title: String?) {
+        titleLabel.text = title
+    }
+    
+    /// 하단의 부제목을 변경하기 위한 메소드다
+    /// - Parameter subTitle: 변경하고자 하는 하단의 부제목을 주입한다.
+    func updateSubTitle(by subTitle: String?) {
+        subTitleLabel.text = subTitle
+    }
+}

--- a/ThingLog/View/HeaderView/TwoLabelVerticalHeaderView.swift
+++ b/ThingLog/View/HeaderView/TwoLabelVerticalHeaderView.swift
@@ -83,13 +83,13 @@ class TwoLabelVerticalHeaderView: UICollectionReusableView {
         ])
     }
     
-    /// 상단의 제목을 변경하기 위한 메소드다
+    /// 상단의 제목을 변경하기 위한 메소드다.
     /// - Parameter title: 변경하고자 하는 상단의 제목을 주입한다.
     func updateTitle(by title: String?) {
         titleLabel.text = title
     }
     
-    /// 하단의 부제목을 변경하기 위한 메소드다
+    /// 하단의 부제목을 변경하기 위한 메소드다.
     /// - Parameter subTitle: 변경하고자 하는 하단의 부제목을 주입한다.
     func updateSubTitle(by subTitle: String?) {
         subTitleLabel.text = subTitle

--- a/ThingLog/View/LeftRightButtonView.swift
+++ b/ThingLog/View/LeftRightButtonView.swift
@@ -1,0 +1,78 @@
+//
+//  LeftRightButtonView.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/14.
+//
+
+import UIKit
+
+/// 왼쪽, 오른쪽 각각 버튼을 가지는 뷰다. 왼쪽 버튼이 강조되어 있다 ( 휴지통에서 주로 사용된다 )
+class LeftRightButtonView: UIView {
+    let leftButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.setTitle("모두 삭제", for: .normal)
+        button.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        button.titleLabel?.font = UIFont.Pretendard.title1
+        return button
+    }()
+    
+    let rightButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.setTitle("모두 복구", for: .normal)
+        button.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        button.titleLabel?.font = UIFont.Pretendard.body2
+        return button
+    }()
+    
+    private let borderLine: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = SwiftGenColors.gray4.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [leftButton,
+                                                                    borderLine,
+                                                                    rightButton])
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private let topLineView: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = SwiftGenColors.gray4.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    func setupView() {
+        addSubview(stackView)
+        addSubview(topLineView)
+        NSLayoutConstraint.activate([
+            topLineView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            topLineView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topLineView.heightAnchor.constraint(equalToConstant: 0.5),
+            topLineView.topAnchor.constraint(equalTo: topAnchor),
+            
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topLineView.bottomAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            borderLine.widthAnchor.constraint(equalToConstant: 0.5),
+            leftButton.widthAnchor.constraint(equalTo: rightButton.widthAnchor)
+        ])
+    }
+}

--- a/ThingLog/View/LeftRightButtonView.swift
+++ b/ThingLog/View/LeftRightButtonView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-/// 왼쪽, 오른쪽 각각 버튼을 가지는 뷰다. 왼쪽 버튼이 강조되어 있다 ( 휴지통에서 주로 사용된다 )
+/// 왼쪽, 오른쪽 각각 버튼을 가지는 뷰다. 왼쪽 버튼이 강조되어 있다. ( 휴지통에서 주로 사용된다. )
 class LeftRightButtonView: UIView {
     let leftButton: UIButton = {
         let button: UIButton = UIButton()

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -48,7 +48,7 @@ class ContentsCollectionViewCell: UICollectionViewCell {
     }()
     
     // 하단에 그라데이션을 강조하기 위한 뷰다 ( 주로 휴지통 화면에서 사용된다 )
-    private let bottomGradientView: UIView = {
+    let bottomGradientView: UIView = {
         let view: UIView = UIView()
         view.alpha = 0.6
         view.isHidden = true
@@ -93,6 +93,8 @@ class ContentsCollectionViewCell: UICollectionViewCell {
     }
     
     func setupView() {
+        clipsToBounds = true
+        
         contentView.addSubview(imageView)
         contentView.addSubview(smallIconView)
         contentView.addSubview(bottomGradientView)

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -7,6 +7,18 @@
 import CoreData
 import UIKit
 
+/// 기본적인 이미지만을 보여주기 위한 cell이다.
+///
+/// 기본적인 구성으로는 imageView, smallIconView 로 구성된다. smallIconView는 이미지가 여러개인 경우에 표시한다.
+///
+/// 추가적으로 하단의 그라데이션뷰와, 하단의 label, 우측상단의 체크버튼이 존재한다. ( 이는 휴지통 화면에서 재사용하기 위해 존재한다 )
+/// ```swift
+/// // 휴지통 화면에서 사용하고자 하는 경우
+/// cell.smallIconView.isHidden = true
+/// cell.bottomGradientView.isHidden = false
+/// cell.bottomLabel.isHidden = false
+/// cell.checkButton.isHidden = false
+/// ```
 class ContentsCollectionViewCell: UICollectionViewCell {
     let imageView: UIImageView = {
         let imageview: UIImageView = UIImageView()
@@ -16,7 +28,7 @@ class ContentsCollectionViewCell: UICollectionViewCell {
     }()
     
     var testLabel: UILabel = {
-        var label: UILabel = UILabel()
+        let label: UILabel = UILabel()
         label.textColor = SwiftGenColors.systemBlue.color
         label.font = UIFont.systemFont(ofSize: 9)
         label.backgroundColor = .clear
@@ -25,7 +37,8 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
-    private let smallIconView: UIImageView = {
+    // smallIconView는 이미지가 여러개인 경우에 표시한다.
+    let smallIconView: UIImageView = {
         let image: UIImage? = UIImage(systemName: "square.on.square.fill")
         let imageView: UIImageView = UIImageView(image: image)
         imageView.transform = CGAffineTransform(rotationAngle: .pi)
@@ -33,6 +46,42 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()
+    
+    // 하단에 그라데이션을 강조하기 위한 뷰다 ( 주로 휴지통 화면에서 사용된다 )
+    private let bottomGradientView: UIView = {
+        let view: UIView = UIView()
+        view.alpha = 0.6
+        view.isHidden = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    // 하단에 정보를 표시하기 위한 Label이다 ( 주로 휴지통 화면에서 몇일 남았는지를 알려주기 위해 사용된다 )
+    let bottomLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.textColor = SwiftGenColors.white.color
+        label.font = UIFont.Pretendard.body3
+        label.backgroundColor = .clear
+        label.numberOfLines = 0
+        label.text = "20일"
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.isHidden = true
+        return label
+    }()
+    
+    /// 우측 상단에 체크하기 위한 버튼이다. ( 주로 휴지통 화면에서 삭제 또는 복구하기 위해 사용되는 버튼이다 )
+    let checkButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.layer.borderWidth = 1
+        button.layer.borderColor = SwiftGenColors.white.color.cgColor
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isHidden = true
+        return button
+    }()
+    
+    private let paddingCheckButton: CGFloat = 8
+    private let checkButtonSize: CGFloat = 20
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,6 +95,11 @@ class ContentsCollectionViewCell: UICollectionViewCell {
     func setupView() {
         contentView.addSubview(imageView)
         contentView.addSubview(smallIconView)
+        contentView.addSubview(bottomGradientView)
+        contentView.addSubview(bottomLabel)
+        contentView.addSubview(checkButton)
+        checkButton.layer.cornerRadius = checkButtonSize / 2
+        
         NSLayoutConstraint.activate([
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
@@ -57,7 +111,21 @@ class ContentsCollectionViewCell: UICollectionViewCell {
             smallIconView.widthAnchor.constraint(equalToConstant: 10),
             smallIconView.heightAnchor.constraint(equalToConstant: 10),
             imageView.heightAnchor.constraint(equalToConstant: 124),
-            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor)
+            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor),
+            
+            bottomGradientView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            bottomGradientView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            bottomGradientView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            bottomGradientView.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 1 / 5),
+            
+            bottomLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            bottomLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            bottomLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -7),
+            
+            checkButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingCheckButton),
+            checkButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -paddingCheckButton),
+            checkButton.widthAnchor.constraint(equalToConstant: checkButtonSize),
+            checkButton.heightAnchor.constraint(equalToConstant: checkButtonSize)
         ])
         testSetupLabel()
     }
@@ -82,6 +150,18 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         text += "\n" + (postEntity.isLike ? "좋아요" : "싫어요")
         text += "\n날짜: " + (postEntity.createDate!.toString(.year)) + "." + (postEntity.createDate!.toString(.month)) + "." + (postEntity.createDate!.toString(.day))
         text += "\n만족도: " + String(postEntity.rating!.score)
+        imageView.image = UIImage(data: (postEntity.attachments?.allObjects as? [AttachmentEntity])![0].thumbnail!)
         testLabel.text = text
+    }
+    
+    /// 그라데이션 뷰의 크기를 결정하기 위해 구현한다.
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        bottomGradientView.frame = contentView.bounds
+        bottomGradientView.frame.size.height = contentView.bounds.height / 4
+        bottomGradientView.setGradient(startColor: SwiftGenColors.black.color,
+                                       endColor: .clear,
+                                       startPoint: CGPoint(x: 0.0, y: 1.0),
+                                       endPoint: CGPoint(x: 0.0, y: 0.0))
     }
 }

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -11,7 +11,7 @@ import UIKit
 ///
 /// 기본적인 구성으로는 imageView, smallIconView 로 구성된다. smallIconView는 이미지가 여러개인 경우에 표시한다.
 ///
-/// 추가적으로 하단의 그라데이션뷰와, 하단의 label, 우측상단의 체크버튼이 존재한다. ( 이는 휴지통 화면에서 재사용하기 위해 존재한다 )
+/// 추가적으로 하단의 그라데이션뷰와, 하단의 label, 우측상단의 체크버튼이 존재한다. ( 이는 휴지통 화면에서 재사용하기 위해 존재한다. )
 /// ```swift
 /// // 휴지통 화면에서 사용하고자 하는 경우
 /// cell.smallIconView.isHidden = true
@@ -47,7 +47,7 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         return imageView
     }()
     
-    // 하단에 그라데이션을 강조하기 위한 뷰다 ( 주로 휴지통 화면에서 사용된다 )
+    // 하단에 그라데이션을 강조하기 위한 뷰다. ( 주로 휴지통 화면에서 사용된다. )
     let bottomGradientView: UIView = {
         let view: UIView = UIView()
         view.alpha = 0.6
@@ -56,7 +56,7 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         return view
     }()
     
-    // 하단에 정보를 표시하기 위한 Label이다 ( 주로 휴지통 화면에서 몇일 남았는지를 알려주기 위해 사용된다 )
+    // 하단에 정보를 표시하기 위한 Label이다. ( 주로 휴지통 화면에서 몇일 남았는지를 알려주기 위해 사용된다. )
     let bottomLabel: UILabel = {
         let label: UILabel = UILabel()
         label.textColor = SwiftGenColors.white.color
@@ -70,7 +70,7 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
-    /// 우측 상단에 체크하기 위한 버튼이다. ( 주로 휴지통 화면에서 삭제 또는 복구하기 위해 사용되는 버튼이다 )
+    /// 우측 상단에 체크하기 위한 버튼이다. ( 주로 휴지통 화면에서 삭제 또는 복구하기 위해 사용되는 버튼이다. )
     let checkButton: UIButton = {
         let button: UIButton = UIButton()
         button.layer.borderWidth = 1
@@ -92,7 +92,7 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         super.init(coder: coder)
     }
     
-    func setupView() {
+    private func setupView() {
         clipsToBounds = true
         
         contentView.addSubview(imageView)
@@ -165,5 +165,14 @@ class ContentsCollectionViewCell: UICollectionViewCell {
                                        endColor: .clear,
                                        startPoint: CGPoint(x: 0.0, y: 1.0),
                                        endPoint: CGPoint(x: 0.0, y: 0.0))
+    }
+}
+
+extension ContentsCollectionViewCell {
+    /// 휴지통화면에서 사용하고자 하는 경우에 내부 뷰들을 보여주거나 숨김처리 하는 메서드다.
+    func setupForTrashView() {
+        smallIconView.isHidden = true
+        bottomGradientView.isHidden = false
+        bottomLabel.isHidden = false
     }
 }

--- a/ThingLog/ViewController/EasyLookViewController+setup.swift
+++ b/ThingLog/ViewController/EasyLookViewController+setup.swift
@@ -63,18 +63,7 @@ extension EasyLookViewController {
     }
     
     func setupNavigationBar() {
-        if #available(iOS 15, *) {
-            let appearance: UINavigationBarAppearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = SwiftGenColors.white.color
-            appearance.shadowColor = .clear
-            navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
-        } else {
-            navigationController?.navigationBar.isTranslucent = false
-            navigationController?.navigationBar.barTintColor = SwiftGenColors.white.color
-            navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
-        }
+        setupBaseNavigationBar()
         
         let logoView: LogoView = LogoView("모아보기")
         let logoBarButtonItem: UIBarButtonItem = UIBarButtonItem(customView: logoView)

--- a/ThingLog/ViewController/HomeViewController.swift
+++ b/ThingLog/ViewController/HomeViewController.swift
@@ -102,18 +102,7 @@ final class HomeViewController: UIViewController {
     }
     
     func setupNavigationBar() {
-        if #available(iOS 15, *) {
-            let appearance: UINavigationBarAppearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = SwiftGenColors.white.color
-            appearance.shadowColor = .clear
-            navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
-        } else {
-            navigationController?.navigationBar.isTranslucent = false
-            navigationController?.navigationBar.barTintColor = SwiftGenColors.white.color
-            navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
-        }
+        setupBaseNavigationBar()
         
         let logoView: LogoView = LogoView("띵로그")
         let logoBarButtonItem: UIBarButtonItem = UIBarButtonItem(customView: logoView)

--- a/ThingLog/ViewController/SettingViewController.swift
+++ b/ThingLog/ViewController/SettingViewController.swift
@@ -72,21 +72,11 @@ final class SettingViewController: UIViewController {
             tableView.topAnchor.constraint(equalTo: topBorderLineView.bottomAnchor)
         ])
         tableView.dataSource = self
+        tableView.delegate = self
     }
     
     func setupNavigationBar() {
-        if #available(iOS 15, *) {
-            let appearance: UINavigationBarAppearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = SwiftGenColors.white.color
-            appearance.shadowColor = .clear
-            navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
-        } else {
-            navigationController?.navigationBar.isTranslucent = false
-            navigationController?.navigationBar.barTintColor = SwiftGenColors.white.color
-            navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
-        }
+        setupBaseNavigationBar()
         
         let logoView: LogoView = LogoView("설정", font: UIFont.Pretendard.headline4)
         navigationItem.titleView = logoView
@@ -140,5 +130,20 @@ extension SettingViewController: UITableViewDataSource {
             }
         }
         return cell
+    }
+}
+
+extension SettingViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if let cellType: TableViewCellType = TableViewCellType(rawValue: indexPath.row) {
+            switch cellType {
+            case .darkMode:
+                return
+            case .editCategory:
+                return
+            case .trash:
+                coordinator?.showTrashViewController()
+            }
+        }
     }
 }

--- a/ThingLog/ViewController/TrashViewController.swift
+++ b/ThingLog/ViewController/TrashViewController.swift
@@ -43,7 +43,7 @@ final class TrashViewController: UIViewController {
         return stackView
     }()
     
-    // 휴지통에 데이터가 없는 경우에 보여주는 뷰다
+    // 휴지통에 데이터가 없는 경우에 보여주는 뷰다.
     private var emptyView: EmptyResultsView = {
         let view: EmptyResultsView = EmptyResultsView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -59,7 +59,7 @@ final class TrashViewController: UIViewController {
             fetchResultController?.delegate = self
         }
     }
-    // CoreData가 외부에서 변경될 때 호출하는 클로저다
+    // CoreData가 외부에서 변경될 때 호출하는 클로저다.
     var completionBlock: ((Int) -> Void)?
     
     /// 현재 휴지통에서 복구또는 삭제 기능을 활성화한 상태인지를 확인하기 위한 프로퍼티다. 활성화한 상태는 true이다.
@@ -166,9 +166,7 @@ extension TrashViewController: UICollectionViewDataSource {
         }
         
         // 휴지통에서 사용할 경우, ContentsCollectionViewCell의 뷰를 약간 조정한다.
-        cell.smallIconView.isHidden = true
-        cell.bottomGradientView.isHidden = false
-        cell.bottomLabel.isHidden = false
+        cell.setupForTrashView()
         cell.checkButton.isHidden = !isEditMode
         
         cell.backgroundColor = .systemGray

--- a/ThingLog/ViewController/TrashViewController.swift
+++ b/ThingLog/ViewController/TrashViewController.swift
@@ -1,0 +1,191 @@
+//
+//  TrashViewController.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/14.
+//
+import CoreData
+import RxSwift
+import UIKit
+
+/// 휴지통 화면을 구성하는 뷰컨트롤러이다.
+final class TrashViewController: UIViewController {
+    var coordinator: SettingCoordinator?
+    
+    private let collectionView: UICollectionView = {
+        let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
+        flowLayout.minimumInteritemSpacing = 1
+        flowLayout.minimumLineSpacing = 1
+        flowLayout.itemSize = CGSize(width: (UIScreen.main.bounds.width - 2) / 3, height: (UIScreen.main.bounds.width - 2) / 3)
+        flowLayout.sectionHeadersPinToVisibleBounds = false
+        flowLayout.headerReferenceSize = CGSize(width: UIScreen.main.bounds.width, height: 100)
+        let collection: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collection.register(ContentsCollectionViewCell.self, forCellWithReuseIdentifier: ContentsCollectionViewCell.reuseIdentifier)
+        collection.register(TwoLabelVerticalHeaderView.self, forSupplementaryViewOfKind: TwoLabelVerticalHeaderView.reuseIdentifier, withReuseIdentifier: TwoLabelVerticalHeaderView.reuseIdentifier)
+        
+        collection.translatesAutoresizingMaskIntoConstraints = false
+        return collection
+    }()
+    
+    /// 네비게이션 우측 선택 버튼을 클릭시 나타나는  **삭제 또는 **복구 버튼이 포함된 뷰다.
+    private let deleteButtonView: LeftRightButtonView = {
+        let deleteView: LeftRightButtonView = LeftRightButtonView()
+        deleteView.isHidden = true
+        deleteView.backgroundColor = SwiftGenColors.white.color
+        deleteView.translatesAutoresizingMaskIntoConstraints = false
+        return deleteView
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [collectionView, deleteButtonView])
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    // 휴지통에 데이터가 없는 경우에 보여주는 뷰다
+    private var emptyView: EmptyResultsView = {
+        let view: EmptyResultsView = EmptyResultsView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
+        view.backgroundColor = SwiftGenColors.white.color
+        view.label.text = "휴지통이 비었습니다"
+        return view
+    }()
+    
+    // MARK: - Properties
+    var fetchResultController: NSFetchedResultsController<PostEntity>? {
+        didSet {
+            fetchResultController?.delegate = self
+        }
+    }
+    // CoreData가 외부에서 변경될 때 호출하는 클로저다
+    var completionBlock: ((Int) -> Void)?
+    
+    /// 현재 휴지통에서 복구또는 삭제 기능을 활성화한 상태인지를 확인하기 위한 프로퍼티다. 활성화한 상태는 true이다.
+    private var isEditMode: Bool = false
+    
+    private let deleteButtonViewHeight: CGFloat = 54
+    var disposeBag: DisposeBag = DisposeBag()
+    
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupStackView()
+        setupBaseCollectionView()
+        setupEmptyView()
+        setupNavigationBar()
+        setupRightNavigationBarItem()
+    }
+    
+    // MARK: - Setup
+    private func setupStackView() {
+        view.addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            
+            deleteButtonView.heightAnchor.constraint(equalToConstant: deleteButtonViewHeight)
+        ])
+    }
+    private func setupBaseCollectionView() {
+        collectionView.backgroundColor = SwiftGenColors.white.color
+        collectionView.dataSource = self
+    }
+    
+    private func setupEmptyView() {
+        view.addSubview(emptyView)
+        NSLayoutConstraint.activate([
+            emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            emptyView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            emptyView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    private func setupNavigationBar() {
+        setupBaseNavigationBar()
+        
+        let logoView: LogoView = LogoView("휴지통", font: UIFont.Pretendard.headline4)
+        navigationItem.titleView = logoView
+        
+        let backButton: UIButton = UIButton()
+        backButton.setImage(SwiftGenAssets.paddingBack.image, for: .normal)
+        backButton.tintColor = SwiftGenColors.black.color
+        backButton.rx.tap
+            .bind { [weak self] in
+                self?.coordinator?.back()
+            }
+            .disposed(by: disposeBag)
+        let backBarButton: UIBarButtonItem = UIBarButtonItem(customView: backButton)
+        navigationItem.leftBarButtonItem = backBarButton
+    }
+    
+    func setupRightNavigationBarItem() {
+        let editButton: UIButton = UIButton()
+        editButton.setTitle("선택", for: .normal)
+        editButton.titleLabel?.font = UIFont.Pretendard.body1
+        editButton.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        editButton.rx.tap
+            .bind { [weak self] in
+                editButton.setTitle( (self?.isEditMode == true) ? "선택" : "취소", for: .normal)
+                self?.deleteButtonView.isHidden = self?.isEditMode == true
+                self?.isEditMode.toggle()
+                self?.collectionView.reloadData()
+            }
+            .disposed(by: disposeBag)
+        let editBarButton: UIBarButtonItem = UIBarButtonItem(customView: editButton)
+        let fixedSpace: UIBarButtonItem = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
+        fixedSpace.width = 24
+        navigationItem.rightBarButtonItems = [fixedSpace, editBarButton]
+    }
+}
+
+extension TrashViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+//                let numberOfItems: Int = fetchResultController?.fetchedObjects?.count ?? 0
+//                emptyView.isHidden = numberOfItems != 0
+//                return numberOfItems
+        return 15 // Test Code
+    }
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell: ContentsCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: ContentsCollectionViewCell.reuseIdentifier, for: indexPath)as? ContentsCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        
+        if let item: PostEntity = fetchResultController?.fetchedObjects?[indexPath.item],
+           let data: Data = (item.attachments?.allObjects as? [AttachmentEntity])?.first?.thumbnail {
+            cell.updateView(item)
+        }
+        
+        // 휴지통에서 사용할 경우, ContentsCollectionViewCell의 뷰를 약간 조정한다.
+        cell.smallIconView.isHidden = true
+        cell.bottomGradientView.isHidden = false
+        cell.bottomLabel.isHidden = false
+        cell.checkButton.isHidden = !isEditMode
+        
+        cell.backgroundColor = .systemGray
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: TwoLabelVerticalHeaderView.reuseIdentifier, withReuseIdentifier: TwoLabelVerticalHeaderView.reuseIdentifier, for: indexPath) as? TwoLabelVerticalHeaderView else {
+            return UICollectionReusableView()
+        }
+        return headerView
+    }
+}
+
+extension TrashViewController: NSFetchedResultsControllerDelegate {
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        collectionView.reloadData()
+        completionBlock?(controller.fetchedObjects?.count ?? 0)
+    }
+}


### PR DESCRIPTION
## 개요

휴지통 화면 구현 

## 시연 
![삭제](https://user-images.githubusercontent.com/48749182/137321553-57b91e68-b8c0-448a-8f19-3c85c90d4289.gif)

## 작업 사항
크게, 휴지통화면에 필요한 뷰들 순서대로 구현하여 커밋을 진행했습니다.
1. 휴지통화면 셀 구현
    - `ContentsCollectionViewCell`를 리팩토링하여 휴지통화면에 필요한 뷰들을 추가했다
    -  ![image](https://user-images.githubusercontent.com/48749182/137322054-e50fe021-f6db-472c-82cd-edf597e57bed.png)


2. 휴지통 화면의 상단 헤더뷰 구현 ( `TwoLabelVerticalHeaderView`)
    - **개의 게시물, 게시물삭제 관련 내용을 포함하는 뷰다. 
    -  ![image](https://user-images.githubusercontent.com/48749182/137322035-1ca2a281-6143-4dca-ad7a-e0a7452df210.png)


3. 휴지통 화면의 하단에 나타나는 삭제 or 복구 버튼 구현
    - `LeftRightButtonView` - 좌측, 우측에 각각 버튼을 가지는 뷰다
    -  ![image](https://user-images.githubusercontent.com/48749182/137322076-00168913-afe3-4368-bd03-b6379f380058.png)


4. 휴지통 화면 구현 ( ViewController에 배치 ) 
    - `TrashViewController` 를 만들어, 휴지퉁화면에 필요한 뷰들을 배치
    - `SettingCoordinator`에 `TrashViewController` 전환하는 메소드 추가
    - 각 뷰컨트롤러마다 네비게이션바를 초기화하는 메서드가 있으므로 이를 extension으로 리팩토링 진행

## 테스트 
- 테스트코드는 따로 없으며, 설정 - 휴지통에서 확인할 수 있습니다.

## 예외 사항 
- 단순히 휴지통화면에 필요한 최소한의 뷰들과 배치만을 구현했습니다.
- 그러므로 삭제 또는 복구하기 위해 셀들을 터치하는 로직은 구현하지 않았습니다. 뿐만 아니라 그후에 발생할 수 있는 상황 또는 로직들을 구현하지 않았습니다. 

### Linked Issue

close #109 

