### PR TITLE
[#90] UserInformationViewModel 바인딩

### DIFF
--- a/ThingLog/View/ProfileView.swift
+++ b/ThingLog/View/ProfileView.swift
@@ -15,8 +15,8 @@ final class ProfileView: UIView {
         button.titleLabel?.font = UIFont.Pretendard.headline3
         button.setImage(SwiftGenAssets.modifyText.image, for: .normal)
         button.semanticContentAttribute = .forceRightToLeft
+        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: -8)
         button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8)
-        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
         button.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         return button
     }()

--- a/ThingLog/ViewController/HomeViewController.swift
+++ b/ThingLog/ViewController/HomeViewController.swift
@@ -51,6 +51,7 @@ final class HomeViewController: UIViewController {
         subscribePageVeiwControllerTransition()
         subscribeContentsTabButton()
         subscribePageViewControllerScrollOffset()
+        subscribeInformationViewModel()
         
         fetchAllPost()
     }
@@ -194,6 +195,21 @@ extension HomeViewController {
                 }
             })
             .disposed(by: pageViewController.disposeBag)
+    }
+    
+    /// 사용자의 정보 ( 이름, 한줄 소개 ) 를 subscribe한다. 
+    func subscribeInformationViewModel() {
+        UserInformationViewModel.shared.userAliasNameSubject
+            .bind { [weak self] name in
+                self?.profileView.userAliasNameButton.setTitle(name ?? "분더카머", for: .normal)
+            }
+            .disposed(by: disposeBag)
+        
+        UserInformationViewModel.shared.userOneLineIntroductionSubject
+            .bind { [weak self] introduction in
+                self?.profileView.userOneLineIntroductionLabel.text = introduction ?? "나를 찾는 여정 나를 찾는 여정"
+            }
+            .disposed(by: disposeBag)
     }
     
     /// 콘텐츠 개수가 많은 상황에서 아래로 스크롤한 상태에서 콘텐츠 개수가 적은 페이지로 전환할 시 containerView의 높이를 줄여주는 메소드다.

--- a/ThingLog/ViewController/SettingViewController.swift
+++ b/ThingLog/ViewController/SettingViewController.swift
@@ -127,6 +127,13 @@ extension SettingViewController: UITableViewDataSource {
                                     buttonType: .withToggleButton,
                                     borderLineHeight: .with1Height,
                                     borderLineColor: .withGray5)
+                cell.rightToggleButton.setOn(UserInformationViewModel.shared.isAutomatedDarkMode, animated: false)
+                cell.rightToggleButton.rx.isOn
+                    .bind { bool in
+                        UserInformationViewModel.shared.isAutomatedDarkMode = bool
+                    }
+                    .disposed(by: cell.disposeBag)
+                
             case .editCategory:
                 cell.changeViewType(labelType: .withBody1,
                                     buttonType: .withChevronRight,


### PR DESCRIPTION
## 개요
홈화면 및 설정하면 UserInformationViewModel 바인딩 

## 작업 사항
- 홈화면에서 별명 및 한 줄 소개를 `UserInformationViewModel`과 바인딩
- 설정화면에서 다크모드 여부 `UserInformationViewModel`과 바인딩

## 테스트코드
- 테스트코드는 따로 없습니다.
- 현재 별명과 한 줄 소개는 저장된 데이터가 없기 때문에 Default값으로 표시하고 있습니다. 
- 다크모드는 반영됩니다. 

### Linked Issue

close #90 
close #121 

