### PR TITLE
[#117] 뷰: 커스텀 얼럿 구현 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -63,13 +63,13 @@
 		DB05B03C271853CE0067DB17 /* LeftRightButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B03B271853CE0067DB17 /* LeftRightButtonView.swift */; };
 		DB05B03E27185B780067DB17 /* TrashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B03D27185B780067DB17 /* TrashViewController.swift */; };
 		DB05B04027185C500067DB17 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B03F27185C500067DB17 /* UIViewController+.swift */; };
-		DB05B058271FFEF80067DB17 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = DB05B057271FFEF80067DB17 /* Settings.bundle */; };
 		DB05B04C271F04E50067DB17 /* TextFieldWithLabelWithButtonCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B04B271F04E50067DB17 /* TextFieldWithLabelWithButtonCollectionCell.swift */; };
 		DB05B04E271F09260067DB17 /* LoginTopHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B04D271F09260067DB17 /* LoginTopHeaderView.swift */; };
 		DB05B050271F0AB00067DB17 /* LoginCollectionSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B04F271F0AB00067DB17 /* LoginCollectionSection.swift */; };
 		DB05B052271F0D4B0067DB17 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B051271F0D4B0067DB17 /* LoginViewController.swift */; };
 		DB05B054271FEABB0067DB17 /* LoginViewController+dequeueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B053271FEABB0067DB17 /* LoginViewController+dequeueCell.swift */; };
 		DB05B056271FEAFA0067DB17 /* LoginViewController+subscribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB05B055271FEAFA0067DB17 /* LoginViewController+subscribe.swift */; };
+		DB05B058271FFEF80067DB17 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = DB05B057271FFEF80067DB17 /* Settings.bundle */; };
 		DB148C2027043CFC00FDC48F /* DropBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C1F27043CFC00FDC48F /* DropBoxView.swift */; };
 		DB148C222704623200FDC48F /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C212704623200FDC48F /* InsetButton.swift */; };
 		DB148C26270469B300FDC48F /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB148C25270469B300FDC48F /* Date+.swift */; };
@@ -80,6 +80,7 @@
 		DB1745B927098E8A00EF083E /* RecentSearchDataViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1745B827098E8A00EF083E /* RecentSearchDataViewModel.swift */; };
 		DB22327E27183378002ED30D /* TwoLabelVerticalHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB22327D27183378002ED30D /* TwoLabelVerticalHeaderView.swift */; };
 		DB22B6BE270ECA20005F9971 /* PostContentsCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB22B6BD270ECA20005F9971 /* PostContentsCollectionViewController.swift */; };
+		DB2B8AFD272151A800A02090 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2B8AFC272151A800A02090 /* AlertViewController.swift */; };
 		DB331DA926FDD00A00A629F5 /* ColorsAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA626FDD00A00A629F5 /* ColorsAsset.swift */; };
 		DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA726FDD00A00A629F5 /* ImageAssets.swift */; };
 		DB331DAB26FDD00A00A629F5 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB331DA826FDD00A00A629F5 /* Fonts.swift */; };
@@ -232,13 +233,13 @@
 		DB05B03B271853CE0067DB17 /* LeftRightButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftRightButtonView.swift; sourceTree = "<group>"; };
 		DB05B03D27185B780067DB17 /* TrashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashViewController.swift; sourceTree = "<group>"; };
 		DB05B03F27185C500067DB17 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
-		DB05B057271FFEF80067DB17 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		DB05B04B271F04E50067DB17 /* TextFieldWithLabelWithButtonCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldWithLabelWithButtonCollectionCell.swift; sourceTree = "<group>"; };
 		DB05B04D271F09260067DB17 /* LoginTopHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTopHeaderView.swift; sourceTree = "<group>"; };
 		DB05B04F271F0AB00067DB17 /* LoginCollectionSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCollectionSection.swift; sourceTree = "<group>"; };
 		DB05B051271F0D4B0067DB17 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		DB05B053271FEABB0067DB17 /* LoginViewController+dequeueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginViewController+dequeueCell.swift"; sourceTree = "<group>"; };
 		DB05B055271FEAFA0067DB17 /* LoginViewController+subscribe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginViewController+subscribe.swift"; sourceTree = "<group>"; };
+		DB05B057271FFEF80067DB17 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		DB148C1F27043CFC00FDC48F /* DropBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropBoxView.swift; sourceTree = "<group>"; };
 		DB148C212704623200FDC48F /* InsetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetButton.swift; sourceTree = "<group>"; };
 		DB148C25270469B300FDC48F /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
@@ -249,6 +250,7 @@
 		DB1745B827098E8A00EF083E /* RecentSearchDataViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchDataViewModel.swift; sourceTree = "<group>"; };
 		DB22327D27183378002ED30D /* TwoLabelVerticalHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoLabelVerticalHeaderView.swift; sourceTree = "<group>"; };
 		DB22B6BD270ECA20005F9971 /* PostContentsCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostContentsCollectionViewController.swift; sourceTree = "<group>"; };
+		DB2B8AFC272151A800A02090 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		DB331DA626FDD00A00A629F5 /* ColorsAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorsAsset.swift; sourceTree = "<group>"; };
 		DB331DA726FDD00A00A629F5 /* ImageAssets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAssets.swift; sourceTree = "<group>"; };
 		DB331DA826FDD00A00A629F5 /* Fonts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
@@ -500,6 +502,7 @@
 		DB7C04DF26FB18F4009F5C0A /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				DB2B8AFC272151A800A02090 /* AlertViewController.swift */,
 				8738E1CA271705220069BB80 /* CategoryViewController.swift */,
 				DB7C04E026FB1900009F5C0A /* ContentsCollection */,
 				DB7C04F126FB1F36009F5C0A /* ContentsPageViewController.swift */,
@@ -898,6 +901,7 @@
 				DB7C04B626F8782B009F5C0A /* EasyLookViewController.swift in Sources */,
 				DB148C282704A1A600FDC48F /* IgnoreTouchView.swift in Sources */,
 				DB69095F2712C55F00BB54E4 /* SearchResultsViewModel.swift in Sources */,
+				DB2B8AFD272151A800A02090 /* AlertViewController.swift in Sources */,
 				DB05B052271F0D4B0067DB17 /* LoginViewController.swift in Sources */,
 				DB7C04B226F87548009F5C0A /* TabBarController.swift in Sources */,
 				DB7C04B926F87BE9009F5C0A /* ChoiceWritingView.swift in Sources */,

--- a/ThingLog/ViewController/AlertViewController.swift
+++ b/ThingLog/ViewController/AlertViewController.swift
@@ -1,0 +1,351 @@
+//
+//  AlertViewController.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/21.
+//
+import RxSwift
+import UIKit
+
+/// 커스텀 Alert 화면을 보여주는 뷰 컨트롤러다. 기본적으로 상단에는 `제목`, `내용`, `텍스트필드` 가 포함되어있고, 하단에는 양 쪽에 `두개의 버튼`이 존재한다. 그러므로 특정 뷰를 포함하고 싶지 않다면 `hide**()` 메서드를 이용하여 숨기도록 한다.[이미지](https://www.notion.so/AlertViewController-29eded0049c5427198b6f96b94295cdb)
+///
+/// ```swift
+/// // 얼럿 화면 띄우는 방법 - ⚠️animation은 false로 한다.
+/// let alert = AlertViewController()
+/// alert.modalPresentationStyle = .overFullScreen
+/// present(alert, animated: false, completion: nil)
+///
+/// // 얼럿 dismiss 하는 방법 - ⚠️ animation은 false로 한다.
+/// alert.leftButton.rx.tap.bind {
+///     alert.dismiss(animated: false, completion: nil)
+/// }
+///
+/// // 내용과 하나의 버튼만 보여주고 싶은 경우
+/// alert.hideTitleLabel()
+/// alert.hideRightButton() // ⚠️ 이 경우에 alert.leftButton만 이용하도록 한다.
+/// alert.hideTextField()
+///
+/// // 내용과 두개의 버튼 모두 보여주고 싶은 경우
+/// alert.hideTitleLabel()
+/// alert.hideTextField()
+///
+/// // 제목과 텍스트필드, 두 개의 버튼 보여주고 싶은 경우
+/// alert.hideContentsLabel()
+///
+/// // ⚠️ 내용의 텍스트를 변경하고 싶은 경우
+/// alert.changeContentsText("이미지는 최대 10개까지 첨부할 수 있어요")
+///
+/// // 그외, 버튼의 타이틀, 제목의 타이틀은 직접 프로퍼티에 접근하여 변경한다.
+/// alert.titleLabel.text = "카테고리 수정"
+/// alert.leftButton.setTitle("취소", for: .normal)
+/// alert.leftButton.setTitle("확인", for: .normal)
+/// 
+/// // 버튼의 액션은 직접 외부에서 바인딩하도록 한다.
+/// alert.leftButton.rx.tap.bind {
+///     alert.dismiss(animated: false, completion: nil)
+/// }
+/// ```
+
+final class AlertViewController: UIViewController {
+    // MARK: - Public View
+    
+    /// 상단의 강조된 문구를 포함하는 Label이다.
+    let titleLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.numberOfLines = 0
+        label.text = "카테고리 항목"
+        label.font = UIFont.Pretendard.title2
+        label.textColor = SwiftGenColors.black.color
+        label.textAlignment = .center
+        return label
+    }()
+    
+    /// 중간에 내용을 포함하는 label이다.
+    let contentsLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.numberOfLines = 0
+        label.text = "정말 삭제하시겠어요? \n이 동작은 취소할 수 없습니다"
+        label.font = UIFont.Pretendard.body1
+        label.textColor = SwiftGenColors.black.color
+        label.textAlignment = .center
+        return label
+    }()
+    
+    /// 좌측에 있는 강조되어 있는 button이다.
+    let leftButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.titleLabel?.font = UIFont.Pretendard.title1
+        button.setTitle("취소", for: .normal)
+        button.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        return button
+    }()
+    /// 우측에 강조되어 있지 않은 button이다.
+    let rightButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.titleLabel?.font = UIFont.Pretendard.body1
+        button.setTitle("삭제", for: .normal)
+        button.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        return button
+    }()
+    
+    /// 입력을 받을 수 있는 텍스트필드다.
+    let textField: UITextField = {
+        let textField: UITextField = UITextField()
+        textField.layer.borderWidth = 0.5
+        textField.layer.borderColor = SwiftGenColors.gray4.color.cgColor
+        textField.font = UIFont.Pretendard.body1
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        let paddingView: UIView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 5))
+        textField.leftView = paddingView
+        textField.leftViewMode = .always
+        return textField
+    }()
+    
+    // MARK: - Private View
+    private let borderLineBetweenButton: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = SwiftGenColors.gray4.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let borderLineOnButton: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = SwiftGenColors.gray4.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let topContentsPaddingView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let bottomContentsPaddingView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let topPaddingViewOnTextField: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let leadingContentsPaddingView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let trailingContentsPaddingView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private lazy var buttonStackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [
+                                                    leftButton,
+                                                    borderLineBetweenButton,
+                                                    rightButton])
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    lazy var contentStackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [
+                                                    topContentsPaddingView,
+                                                    titleLabel,
+                                                    contentsLabel,
+                                                    topPaddingViewOnTextField,
+                                                    textField,
+                                                    bottomContentsPaddingView])
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    lazy var contentPaddingStackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [
+                                                    leadingContentsPaddingView,
+                                                    contentStackView,
+                                                    trailingContentsPaddingView])
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    lazy var stackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [
+                                                    contentPaddingStackView,
+                                                    borderLineOnButton,
+                                                    buttonStackView])
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private lazy var alertView: UIView = {
+        var view: UIView = UIView()
+        view.layer.cornerRadius = 15
+        view.backgroundColor = SwiftGenColors.white.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    // MARK: - Properties
+    private let contentsHeight: CGFloat = 94
+    private let alertViewWidth: CGFloat = 270
+    private let buttonStackViewHeight: CGFloat = 52
+    private let paddingHeight: CGFloat = 14
+    private let paddingWidth: CGFloat = 20
+    private let textFieldHeight: CGFloat = 26
+    
+    var disposeBag: DisposeBag = DisposeBag()
+    
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        view.layoutIfNeeded()
+        
+        // 키보드 옵저빙
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillAppear), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+        subscribeTextFieldReturnKey()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // 나타날 때 애니메이션을 추가한다.
+        UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0, options: .curveEaseInOut) {
+            self.view.backgroundColor = .black.withAlphaComponent(0.6)
+            self.view.layoutIfNeeded()
+        } completion: { _  in
+            self.setupAlertView()
+            UIView.animate(withDuration: 0.2) {
+                self.alertView.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
+            } completion: { _ in
+                UIView.animate(withDuration: 0.2) {
+                    self.alertView.transform = .identity
+                }
+            }
+        }
+    }
+    
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        // 사라질 때 애니메이션을 추가한다.
+        UIView.animate(withDuration: 0.2) {
+            self.alertView.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
+        } completion: { _ in
+            UIView.animate(withDuration: 0.2) {
+                self.alertView.transform = .identity
+            } completion: { _ in
+                self.alertView.isHidden = true
+                UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0, options: .curveEaseInOut) {
+                    self.view.backgroundColor = .clear
+                    self.view.layoutIfNeeded()
+                } completion: { _ in
+                    super.dismiss(animated: flag, completion: completion)
+                }
+            }
+        }
+    }
+    
+    private func setupAlertView() {
+        view.addSubview(alertView)
+        alertView.addSubview(stackView)
+        NSLayoutConstraint.activate([
+            alertView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            alertView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            alertView.widthAnchor.constraint(equalToConstant: alertViewWidth),
+            
+            stackView.leadingAnchor.constraint(equalTo: alertView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: alertView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: alertView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: alertView.bottomAnchor),
+            
+            buttonStackView.heightAnchor.constraint(equalToConstant: buttonStackViewHeight),
+            borderLineOnButton.heightAnchor.constraint(equalToConstant: 0.5),
+            borderLineBetweenButton.widthAnchor.constraint(equalToConstant: 0.5),
+            
+            leftButton.widthAnchor.constraint(equalTo: rightButton.widthAnchor),
+            
+            bottomContentsPaddingView.heightAnchor.constraint(greaterThanOrEqualToConstant: paddingHeight),
+            topContentsPaddingView.heightAnchor.constraint(greaterThanOrEqualToConstant: paddingHeight),
+            bottomContentsPaddingView.heightAnchor.constraint(equalTo: topContentsPaddingView.heightAnchor),
+            
+            leadingContentsPaddingView.widthAnchor.constraint(equalToConstant: paddingWidth),
+            trailingContentsPaddingView.widthAnchor.constraint(equalToConstant: paddingWidth),
+            topPaddingViewOnTextField.heightAnchor.constraint(equalToConstant: paddingHeight),
+            
+            contentStackView.heightAnchor.constraint(equalToConstant: contentsHeight),
+            textField.heightAnchor.constraint(equalToConstant: textFieldHeight)
+        ])
+    }
+}
+
+// MARK: - Public Method
+extension AlertViewController {
+    func hideTextField() {
+        textField.isHidden = true
+        topPaddingViewOnTextField.isHidden = true
+    }
+    
+    func hideContentsLabel() {
+        contentsLabel.isHidden = true
+    }
+    
+    /// 상단의 제목 lable을 숨긴다.
+    func hideTitleLabel() {
+        titleLabel.isHidden = true
+    }
+    
+    /// 하나의 버튼만 사용하고자 할 때 우측 버튼을 숨긴다.
+    func hideRightButton() {
+        rightButton.isHidden = true
+        borderLineBetweenButton.isHidden = true
+    }
+    
+    /// contents의 텍스트를 변경한다. 줄바꿈이 되는 경우에 `간격을 조정`하는 로직이 추가됐다.
+    func changeContentsText(_ text: String) {
+        contentsLabel.numberOfLines = 0
+        let attrString: NSMutableAttributedString = NSMutableAttributedString(string: text)
+        let paragraphStyle: NSMutableParagraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 4
+        paragraphStyle.alignment = .center
+        attrString.addAttribute(NSAttributedString.Key.paragraphStyle,
+                                value: paragraphStyle,
+                                range: NSRange(location: 0, length: attrString.length))
+        contentsLabel.attributedText = attrString
+    }
+}
+
+// MARK: - Private Method
+extension AlertViewController {
+    private func subscribeTextFieldReturnKey() {
+        textField.rx.controlEvent(.editingDidEndOnExit)
+            .bind { [weak self] in
+                self?.textField.resignFirstResponder()
+            }
+            .disposed(by: disposeBag)
+    }
+
+    @objc
+    private func keyboardWillAppear(_ notification: NSNotification) {
+        if let keyboardSize: CGRect = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.3) {
+                self.alertView.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height / 2)
+            }
+        }
+    }
+    
+    @objc
+    private func keyboardWillHide(_ notification: NSNotification) {
+        alertView.transform = .identity
+    }
+}

--- a/ThingLog/ViewController/AlertViewController.swift
+++ b/ThingLog/ViewController/AlertViewController.swift
@@ -246,7 +246,7 @@ final class AlertViewController: UIViewController {
                 self.alertView.transform = .identity
             } completion: { _ in
                 self.alertView.isHidden = true
-                UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0, options: .curveEaseInOut) {
+                UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0, options: .curveEaseInOut) {
                     self.view.backgroundColor = .clear
                     self.view.layoutIfNeeded()
                 } completion: { _ in

--- a/ThingLog/ViewController/AlertViewController.swift
+++ b/ThingLog/ViewController/AlertViewController.swift
@@ -283,7 +283,7 @@ final class AlertViewController: UIViewController {
             trailingContentsPaddingView.widthAnchor.constraint(equalToConstant: paddingWidth),
             topPaddingViewOnTextField.heightAnchor.constraint(equalToConstant: paddingHeight),
             
-            contentStackView.heightAnchor.constraint(equalToConstant: contentsHeight),
+            contentStackView.heightAnchor.constraint(greaterThanOrEqualToConstant: contentsHeight),
             textField.heightAnchor.constraint(equalToConstant: textFieldHeight)
         ])
     }

--- a/ThingLog/ViewController/SettingViewController.swift
+++ b/ThingLog/ViewController/SettingViewController.swift
@@ -17,6 +17,9 @@ final class SettingViewController: UIViewController {
         case login = 3
         case addDummyData = 4
         case deleteDummyData = 5
+        case alert1 = 6
+        case alert2 = 7
+        case alert3 = 8
         
         var title: String {
             switch self {
@@ -32,6 +35,12 @@ final class SettingViewController: UIViewController {
                 return "랜덤 데이터 400개 추가"
             case .deleteDummyData:
                 return "랜덤 데이터 모두 삭제"
+            case .alert1:
+                return "기본 Alert"
+            case .alert2:
+                return "내용과 버튼 하나만 있는 Alert"
+            case .alert3:
+                return "제목과 텍스트필드, 두개의 버튼 있는 Alert"
             }
         }
     }
@@ -133,7 +142,7 @@ extension SettingViewController: UITableViewDataSource {
                     }
                     .disposed(by: cell.disposeBag)
                 
-            case .editCategory, .trash, .login, .addDummyData, .deleteDummyData:
+            case .editCategory, .trash, .login, .addDummyData, .deleteDummyData, .alert1, .alert2, .alert3:
                 cell.changeViewType(labelType: .withBody1,
                                     buttonType: .withChevronRight,
                                     borderLineHeight: .with1Height,
@@ -160,7 +169,51 @@ extension SettingViewController: UITableViewDelegate {
                 makeDummy()
             case .deleteDummyData:
                 deleteAllEntity()
+            case .alert1:
+                showAlert1()
+            case .alert2:
+                showAlert2()
+            case .alert3:
+                showAlert3()
+                
             }
+            
         }
     }
+    func showAlert1() {
+        let alert = AlertViewController()
+        alert.modalPresentationStyle = .overFullScreen
+        alert.leftButton.rx.tap.bind {
+            alert.dismiss(animated: false, completion: nil)
+        }
+        present(alert, animated: false, completion: nil)
+    }
+    
+    func showAlert2() {
+        let alert = AlertViewController()
+        alert.modalPresentationStyle = .overFullScreen
+        alert.hideTitleLabel()
+        alert.hideRightButton()
+        alert.hideTextField()
+        alert.changeContentsText("이미지는 최대 10개까지 첨부할 수 있어요")
+        alert.leftButton.setTitle("확인", for: .normal)
+        alert.leftButton.rx.tap.bind {
+            alert.dismiss(animated: false, completion: nil)
+        }
+        present(alert, animated: false, completion: nil)
+    }
+    
+    func showAlert3() {
+        let alert = AlertViewController()
+        alert.hideContentsLabel()
+        alert.titleLabel.text = "카테고리 수정"
+        alert.leftButton.setTitle("취소", for: .normal)
+        alert.rightButton.setTitle("확인", for: .normal)
+        alert.modalPresentationStyle = .overFullScreen
+        alert.leftButton.rx.tap.bind {
+            alert.dismiss(animated: false, completion: nil)
+        }
+        present(alert, animated: false, completion: nil)
+    }
 }
+


### PR DESCRIPTION
## 개요
커스텀 얼럿 구현 

## 시연 
![얼럿](https://user-images.githubusercontent.com/48749182/138284925-dfcedf0f-8889-4091-be9b-287d0fe9202d.gif)

## 구현 로직 
- `ViewController`를 상속받는 `AlertViewController`를 만들고,
- `AlertViewController`안에 Alert화면을 구성하는 뷰를 구현.
- 다양한 환경에서 특정 뷰만 필요한 Alert을 위해 `hide**`메서드 추가 

## 테스트 코드 
- 설정화면에 3개 유형의 얼럿을 추가했습니다. 
- `AlertViewController`의 주석에도 자세히 어떻게 사용하는지를 작성해놓았습니다. 

## 주의사항 
- 텍스트필드를 사용하고자 할때는 각 버튼에 `textField`의  `resignFirstResponder`를 적절히 로직을 추가해야합니다.  
- 최대한 뷰만을 보여주기 위해 구현했으며, 자유롭게 프로퍼티를 이용해서 인터렉션의 로직을 구현하시면 됩니다. 

### Linked Issue

close #117 

