### PR TITLE
글쓰기: 화면 구현

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		87A86C8D271414D2008FB3F0 /* WriteRatingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */; };
 		87A86C8F27141507008FB3F0 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8E27141507008FB3F0 /* RatingView.swift */; };
 		87A86C9127141576008FB3F0 /* WriteTextViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C9027141576008FB3F0 /* WriteTextViewCell.swift */; };
+		87ACB0B227229A3000C78C86 /* CenterTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ACB0B127229A3000C78C86 /* CenterTextButton.swift */; };
 		87B1B6552715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B1B6542715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift */; };
 		87B1B6572715E2F0001EA889 /* WriteCategoryTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B1B6562715E2F0001EA889 /* WriteCategoryTableCell.swift */; };
 		87BB17A72709898F0088B847 /* WriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BB17A62709898F0088B847 /* WriteViewController.swift */; };
@@ -216,6 +217,7 @@
 		87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteRatingCell.swift; sourceTree = "<group>"; };
 		87A86C8E27141507008FB3F0 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		87A86C9027141576008FB3F0 /* WriteTextViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTextViewCell.swift; sourceTree = "<group>"; };
+		87ACB0B127229A3000C78C86 /* CenterTextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterTextButton.swift; sourceTree = "<group>"; };
 		87B1B6542715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelWithButtonRoundCollectionCell.swift; sourceTree = "<group>"; };
 		87B1B6562715E2F0001EA889 /* WriteCategoryTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteCategoryTableCell.swift; sourceTree = "<group>"; };
 		87BB17A62709898F0088B847 /* WriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteViewController.swift; sourceTree = "<group>"; };
@@ -536,6 +538,7 @@
 		DB7C04E626FB1990009F5C0A /* View */ = {
 			isa = PBXGroup;
 			children = (
+				87ACB0B127229A3000C78C86 /* CenterTextButton.swift */,
 				DB7C04B826F87BE9009F5C0A /* ChoiceWritingView.swift */,
 				DB7C04E726FB199A009F5C0A /* CollectionViewCell */,
 				DB7C04ED26FB1ACE009F5C0A /* ContentsTabView.swift */,
@@ -882,6 +885,7 @@
 				DB7C04EC26FB1A04009F5C0A /* UIView+.swift in Sources */,
 				DB7C04FC26FB27A6009F5C0A /* TemplateImageButton.swift in Sources */,
 				DB05B050271F0AB00067DB17 /* LoginCollectionSection.swift in Sources */,
+				87ACB0B227229A3000C78C86 /* CenterTextButton.swift in Sources */,
 				876243E22708704800BDA1DC /* WriteTypeButton.swift in Sources */,
 				8738E1CF271709660069BB80 /* RoundLabelWithButtonTableCell.swift in Sources */,
 				DB37EC77270C307C00030D9A /* RecentSearchView+update.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		87A86C8F27141507008FB3F0 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8E27141507008FB3F0 /* RatingView.swift */; };
 		87A86C9127141576008FB3F0 /* WriteTextViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C9027141576008FB3F0 /* WriteTextViewCell.swift */; };
 		87ACB0B227229A3000C78C86 /* CenterTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ACB0B127229A3000C78C86 /* CenterTextButton.swift */; };
+		87ACB0B427229E2B00C78C86 /* WriteImageTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ACB0B327229E2B00C78C86 /* WriteImageTableCell.swift */; };
 		87B1B6552715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B1B6542715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift */; };
 		87B1B6572715E2F0001EA889 /* WriteCategoryTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B1B6562715E2F0001EA889 /* WriteCategoryTableCell.swift */; };
 		87BB17A72709898F0088B847 /* WriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BB17A62709898F0088B847 /* WriteViewController.swift */; };
@@ -54,7 +55,7 @@
 		87BB17AB27098D760088B847 /* WriteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BB17AA27098D760088B847 /* WriteViewModel.swift */; };
 		87BB17AD27098F480088B847 /* WriteViewController+setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BB17AC27098F480088B847 /* WriteViewController+setup.swift */; };
 		87BEF07B2705C80D00797ECD /* ThingLogCategoryRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BEF07A2705C80D00797ECD /* ThingLogCategoryRepositoryTests.swift */; };
-		87DAEB1B270BEAE50038C487 /* CameraButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DAEB1A270BEAE50038C487 /* CameraButtonCell.swift */; };
+		87DAEB1B270BEAE50038C487 /* CameraButtonCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DAEB1A270BEAE50038C487 /* CameraButtonCollectionCell.swift */; };
 		87DAEB1D270BEC170038C487 /* ThumbnailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DAEB1C270BEC170038C487 /* ThumbnailCell.swift */; };
 		87F2188326FB5B4100C3FBCA /* ThingLogPostRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F2188226FB5B4100C3FBCA /* ThingLogPostRepositoryTests.swift */; };
 		87F2188626FB5DFB00C3FBCA /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F2188526FB5DFB00C3FBCA /* Post.swift */; };
@@ -218,6 +219,7 @@
 		87A86C8E27141507008FB3F0 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		87A86C9027141576008FB3F0 /* WriteTextViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTextViewCell.swift; sourceTree = "<group>"; };
 		87ACB0B127229A3000C78C86 /* CenterTextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterTextButton.swift; sourceTree = "<group>"; };
+		87ACB0B327229E2B00C78C86 /* WriteImageTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteImageTableCell.swift; sourceTree = "<group>"; };
 		87B1B6542715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelWithButtonRoundCollectionCell.swift; sourceTree = "<group>"; };
 		87B1B6562715E2F0001EA889 /* WriteCategoryTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteCategoryTableCell.swift; sourceTree = "<group>"; };
 		87BB17A62709898F0088B847 /* WriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteViewController.swift; sourceTree = "<group>"; };
@@ -225,7 +227,7 @@
 		87BB17AA27098D760088B847 /* WriteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteViewModel.swift; sourceTree = "<group>"; };
 		87BB17AC27098F480088B847 /* WriteViewController+setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WriteViewController+setup.swift"; sourceTree = "<group>"; };
 		87BEF07A2705C80D00797ECD /* ThingLogCategoryRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogCategoryRepositoryTests.swift; sourceTree = "<group>"; };
-		87DAEB1A270BEAE50038C487 /* CameraButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraButtonCell.swift; sourceTree = "<group>"; };
+		87DAEB1A270BEAE50038C487 /* CameraButtonCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraButtonCollectionCell.swift; sourceTree = "<group>"; };
 		87DAEB1C270BEC170038C487 /* ThumbnailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailCell.swift; sourceTree = "<group>"; };
 		87F2188226FB5B4100C3FBCA /* ThingLogPostRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostRepositoryTests.swift; sourceTree = "<group>"; };
 		87F2188526FB5DFB00C3FBCA /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
@@ -572,11 +574,11 @@
 		DB7C04E726FB199A009F5C0A /* CollectionViewCell */ = {
 			isa = PBXGroup;
 			children = (
-				87DAEB1A270BEAE50038C487 /* CameraButtonCell.swift */,
+				DBD5454F27033D9A00063C98 /* ButtonRoundCollectionCell.swift */,
+				87DAEB1A270BEAE50038C487 /* CameraButtonCollectionCell.swift */,
 				DB7C04E826FB19AE009F5C0A /* ContentsCollectionViewCell.swift */,
 				DBA0F821270AF656009553FC /* ContentsDetailCollectionViewCell.swift */,
 				87B1B6542715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift */,
-				DBD5454F27033D9A00063C98 /* ButtonRoundCollectionCell.swift */,
 				DB05B04B271F04E50067DB17 /* TextFieldWithLabelWithButtonCollectionCell.swift */,
 				87DAEB1C270BEC170038C487 /* ThumbnailCell.swift */,
 			);
@@ -600,11 +602,12 @@
 		DBA0F81A2709B37C009553FC /* TableVeiwCell */ = {
 			isa = PBXGroup;
 			children = (
-				8738E1CE271709660069BB80 /* RoundLabelWithButtonTableCell.swift */,
 				DBA0F81B2709B390009553FC /* LeftLabelRightButtonTableCell.swift */,
+				8738E1CE271709660069BB80 /* RoundLabelWithButtonTableCell.swift */,
 				87B1B6562715E2F0001EA889 /* WriteCategoryTableCell.swift */,
-				87A86C8A2714139F008FB3F0 /* WriteTextFieldCell.swift */,
+				87ACB0B327229E2B00C78C86 /* WriteImageTableCell.swift */,
 				87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */,
+				87A86C8A2714139F008FB3F0 /* WriteTextFieldCell.swift */,
 				87A86C9027141576008FB3F0 /* WriteTextViewCell.swift */,
 			);
 			path = TableVeiwCell;
@@ -917,7 +920,7 @@
 				87078B5B26EA44B5007AE242 /* ThingLog.xcdatamodeld in Sources */,
 				873EC00926D39055003C3525 /* AppDelegate.swift in Sources */,
 				87A86C8B2714139F008FB3F0 /* WriteTextFieldCell.swift in Sources */,
-				87DAEB1B270BEAE50038C487 /* CameraButtonCell.swift in Sources */,
+				87DAEB1B270BEAE50038C487 /* CameraButtonCollectionCell.swift in Sources */,
 				DBD2244B27085DFB004C5184 /* SearchViewController.swift in Sources */,
 				DB7C04C726F9E693009F5C0A /* UserInformationViewModel.swift in Sources */,
 				DB8BF6832706DA7900FD5FDB /* EasyLookTopView.swift in Sources */,
@@ -941,6 +944,7 @@
 				8736B3EF26FDC1AD000433E1 /* Comment.swift in Sources */,
 				8736B3E326FCB9F3000433E1 /* Rating.swift in Sources */,
 				87BB17AB27098D760088B847 /* WriteViewModel.swift in Sources */,
+				87ACB0B427229E2B00C78C86 /* WriteImageTableCell.swift in Sources */,
 				8736B3E926FCBE28000433E1 /* Category.swift in Sources */,
 				DB3A516927103B3E003B529D /* EmptyPostView.swift in Sources */,
 				87F2188E26FB8ACA00C3FBCA /* PostType.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -1150,7 +1150,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = WVLV77R6X7;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ThingLog/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1171,7 +1171,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = WVLV77R6X7;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ThingLog/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ThingLog/Coordinator/WriteCoordinator.swift
+++ b/ThingLog/Coordinator/WriteCoordinator.swift
@@ -25,9 +25,9 @@ final class WriteCoordinator: Coordinator {
     /// WriteViewController로 이동한다.
     /// - Parameter type: WriteType에 따라 ViewModel을 생성하기 위해 필요하다.
     func showWriteViewController(with type: WriteType) {
-        let writeViewController: WriteViewController = WriteViewController()
+        let viewModel: WriteViewModel = WriteViewModel(writeType: type)
+        let writeViewController: WriteViewController = WriteViewController(viewModel: viewModel)
         writeViewController.coordinator = self
-        writeViewController.viewModel = WriteViewModel(writeType: type)
         navigationController.modalPresentationStyle = .fullScreen
         navigationController.pushViewController(writeViewController, animated: true)
         parentViewController?.present(navigationController, animated: true)
@@ -38,5 +38,12 @@ final class WriteCoordinator: Coordinator {
         let categoryViewController: CategoryViewController = CategoryViewController()
         categoryViewController.coordinator = self
         navigationController.pushViewController(categoryViewController, animated: true)
+    }
+
+    /// naviagtionController를 dismiss 한다.
+    func dismissViewController() {
+        navigationController.dismiss(animated: true) {
+            self.navigationController.viewControllers.removeAll()
+        }
     }
 }

--- a/ThingLog/SupportingFiles/Info.plist
+++ b/ThingLog/SupportingFiles/Info.plist
@@ -2,12 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIAppFonts</key>
-	<array>
-		<string>Pretendard-SemiBold.otf</string>
-		<string>Pretendard-Regular.otf</string>
-		<string>Pretendard-Bold.otf</string>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -24,8 +18,16 @@
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>5</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Pretendard-SemiBold.otf</string>
+		<string>Pretendard-Regular.otf</string>
+		<string>Pretendard-Bold.otf</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -64,7 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 </dict>
 </plist>

--- a/ThingLog/SwiftGen/ColorsAsset.swift
+++ b/ThingLog/SwiftGen/ColorsAsset.swift
@@ -51,6 +51,17 @@ internal final class ColorSwiftGen {
     return color
   }()
 
+  #if os(iOS) || os(tvOS)
+  @available(iOS 11.0, tvOS 11.0, *)
+  internal func color(compatibleWith traitCollection: UITraitCollection) -> Color {
+    let bundle = BundleToken.bundle
+    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }

--- a/ThingLog/SwiftGen/Fonts.swift
+++ b/ThingLog/SwiftGen/Fonts.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
-#if os(OSX)
+#if os(macOS)
   import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
@@ -38,7 +38,7 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
-  #if os(OSX)
+  #if os(macOS)
   internal typealias Font = NSFont
   #elseif os(iOS) || os(tvOS) || os(watchOS)
   internal typealias Font = UIFont
@@ -69,7 +69,7 @@ internal extension FontConvertible.Font {
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
-    #elseif os(OSX)
+    #elseif os(macOS)
     if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }

--- a/ThingLog/SwiftGen/ImageAssets.swift
+++ b/ThingLog/SwiftGen/ImageAssets.swift
@@ -53,6 +53,7 @@ internal struct ImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -68,9 +69,21 @@ internal struct ImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension ImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the ImageSwiftGen.image property")
   convenience init?(asset: ImageSwiftGen) {

--- a/ThingLog/View/CenterTextButton.swift
+++ b/ThingLog/View/CenterTextButton.swift
@@ -1,0 +1,34 @@
+//
+//  CenterTextButton.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/10/22.
+//
+
+import UIKit
+
+/// 로그인, 글쓰기, 게시물>사고싶다 화면 하단에 들어가는 버튼
+/// ![이미지](https://www.notion.so/CenterTextButton-6be63ac5586348669a2559f0774eb4fb)
+final class CenterTextButton: UIButton {
+    private var buttonHeight: CGFloat
+
+    init(buttonHeight: CGFloat, title: String?) {
+        self.buttonHeight = buttonHeight
+
+        super.init(frame: .zero)
+        setTitle(title, for: .normal)
+        backgroundColor = SwiftGenColors.black.color
+        setTitleColor(SwiftGenColors.white.color, for: .normal)
+        titleLabel?.font = UIFont.Pretendard.button
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var size: CGSize = super.intrinsicContentSize
+        size.height = buttonHeight
+        return size
+    }
+}

--- a/ThingLog/View/CollectionViewCell/CameraButtonCollectionCell.swift
+++ b/ThingLog/View/CollectionViewCell/CameraButtonCollectionCell.swift
@@ -17,6 +17,7 @@ final class CameraButtonCollectionCell: UICollectionViewCell {
         imageView.contentMode = .scaleAspectFit
         imageView.sizeToFit()
         imageView.setContentHuggingPriority(.required, for: .vertical)
+        imageView.setContentHuggingPriority(.required, for: .horizontal)
         return imageView
     }()
 
@@ -28,6 +29,7 @@ final class CameraButtonCollectionCell: UICollectionViewCell {
         label.textColor = SwiftGenColors.black.color
         label.sizeToFit()
         label.setContentHuggingPriority(.required, for: .vertical)
+        label.setContentHuggingPriority(.required, for: .horizontal)
         return label
     }()
 
@@ -107,6 +109,7 @@ extension CameraButtonCollectionCell {
             emptyBottomView.heightAnchor.constraint(equalToConstant: emptyViewHeight),
             emptyTopView.widthAnchor.constraint(equalToConstant: emptyViewWidth),
             emptyBottomView.widthAnchor.constraint(equalToConstant: emptyViewWidth),
+            iconImageView.heightAnchor.constraint(equalToConstant: 18)
         ])
     }
 }

--- a/ThingLog/View/CollectionViewCell/CameraButtonCollectionCell.swift
+++ b/ThingLog/View/CollectionViewCell/CameraButtonCollectionCell.swift
@@ -1,5 +1,5 @@
 //
-//  CameraButtonCell.swift
+//  CameraButtonCollectionCell.swift
 //  ThingLog
 //
 //  Created by 이지원 on 2021/10/05.
@@ -8,7 +8,8 @@
 import UIKit
 
 /// 글쓰기 화면에 들어가는 사진 등록 버튼
-final class CameraButtonCell: UICollectionViewCell {
+/// ![이미지](https://www.notion.so/CameraButtonCollectionCell-72aa2d9a582c4bea9d60f66d4eb8dc34)
+final class CameraButtonCollectionCell: UICollectionViewCell {
     private let iconImageView: UIImageView = {
         let imageView: UIImageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -71,7 +72,7 @@ final class CameraButtonCell: UICollectionViewCell {
     }
 }
 
-extension CameraButtonCell {
+extension CameraButtonCollectionCell {
     private func setupView() {
         let backgroundView: UIView = {
             let view: UIView = UIView()

--- a/ThingLog/View/RatingView.swift
+++ b/ThingLog/View/RatingView.swift
@@ -21,11 +21,13 @@ final class RatingView: UIView {
     private let fillImage: UIImage = SwiftGenAssets.rating.image.withTintColor(SwiftGenColors.black.color)
     private let emptyImage: UIImage = SwiftGenAssets.rating.image
 
-    // Mark: Properties
+    // MARK: - Properties
     var maxCount: Int = 5 {
         didSet { setupRatingButton() }
     }
     var currentRating: Int = 0
+    /// 버튼을 선택했을 때 호출할 클로저
+    var didTapButtonBlock: (() -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -64,6 +66,8 @@ extension RatingView {
 
     @objc
     private func didTapButton(_ sender: UIButton) {
+        didTapButtonBlock?()
+
         let end: Int = sender.tag
 
         (0...end).forEach { buttons[$0].setImage(fillImage, for: .normal) }

--- a/ThingLog/View/TableVeiwCell/WriteCategoryTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteCategoryTableCell.swift
@@ -50,6 +50,8 @@ final class WriteCategoryTableCell: UITableViewCell {
     private let paddingLeading: CGFloat = 26.0
     private let paddingTrailing: CGFloat = 28.0
     private let paddingTopBottom: CGFloat = 20.0
+    private let indicatorButtonSize: CGFloat = 40.0
+    private let indicatorButtonTopBottom: CGFloat = 8.0
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -72,9 +74,9 @@ final class WriteCategoryTableCell: UITableViewCell {
             categoryLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingTopBottom),
             categoryLabel.trailingAnchor.constraint(equalTo: indicatorButton.leadingAnchor),
             categoryLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingTopBottom),
-            indicatorButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingTopBottom),
+            indicatorButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: indicatorButtonTopBottom),
             indicatorButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -paddingTrailing),
-            indicatorButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingTopBottom)
+            indicatorButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -indicatorButtonTopBottom)
         ])
 
         indicatorButton.addTarget(self, action: #selector(tappedIndicatorButton), for: .touchUpInside)
@@ -89,7 +91,7 @@ final class WriteCategoryTableCell: UITableViewCell {
             collectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: paddingLeading),
             collectionView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingTopBottom),
             collectionView.trailingAnchor.constraint(equalTo: indicatorButton.leadingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingTopBottom)
+            collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -indicatorButtonTopBottom)
         ])
 
         collectionView.dataSource = self

--- a/ThingLog/View/TableVeiwCell/WriteImageTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteImageTableCell.swift
@@ -1,0 +1,105 @@
+//
+//  WriteImageTableCell.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/10/18.
+//
+
+import UIKit
+
+/// 글쓰기 화면에서 이미지 등록 항목을 표시하기 위한 테이블뷰 셀, CollectionView를 가지고 있다.
+/// ![이미지](https://www.notion.so/WriteImageTableCell-78b4a7fe55564fa380c554d17bee49e0)
+final class WriteImageTableCell: UITableViewCell {
+    private lazy var collectionView: UICollectionView = {
+        let collectionView: UICollectionView = .init(frame: .zero,
+                                                     collectionViewLayout: UICollectionViewFlowLayout())
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.collectionViewLayout = createLayout()
+        collectionView.backgroundColor = SwiftGenColors.white.color
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.showsHorizontalScrollIndicator = false
+        return collectionView
+    }()
+
+    private let thumbnailCellSize: CGFloat = 62.0
+    private let collectionViewHeight: CGFloat = 64.0
+    private let paddingLeadingConstaint: CGFloat = 18.0
+    private let paddingTopConstaint: CGFloat = 12.0
+    private let paddingBottomConstaint: CGFloat = 20.0
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension WriteImageTableCell {
+    private func setupView() {
+        selectionStyle = .none
+
+        contentView.addSubview(collectionView)
+
+        NSLayoutConstraint.activate([
+            collectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: paddingLeadingConstaint),
+            collectionView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingTopConstaint),
+            collectionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingBottomConstaint),
+            collectionView.heightAnchor.constraint(equalToConstant: thumbnailCellSize)
+        ])
+
+        collectionView.register(CameraButtonCollectionCell.self, forCellWithReuseIdentifier: CameraButtonCollectionCell.reuseIdentifier)
+        collectionView.register(ThumbnailCell.self, forCellWithReuseIdentifier: ThumbnailCell.reuseIdentifier)
+        collectionView.dataSource = self
+    }
+
+    private func createLayout() -> UICollectionViewCompositionalLayout {
+        let itemSize: NSCollectionLayoutSize = .init(widthDimension: .absolute(thumbnailCellSize),
+                                                     heightDimension: .absolute(thumbnailCellSize))
+        let item: NSCollectionLayoutItem = .init(layoutSize: itemSize)
+
+        let groupSize: NSCollectionLayoutSize = .init(widthDimension: .estimated(1.0),
+                                                      heightDimension: .fractionalHeight(1))
+        let group: NSCollectionLayoutGroup = .horizontal(layoutSize: groupSize, subitems: [item])
+
+        let section: NSCollectionLayoutSection = .init(group: group)
+        section.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
+        section.interGroupSpacing = 14
+        section.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 10)
+
+        let layout: UICollectionViewCompositionalLayout = .init(section: section)
+        return layout
+    }
+}
+
+// MARK: - DataSource
+extension WriteImageTableCell: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        // TODO: 1(카메라 버튼 셀) + 추가된 이미지 개수를 반환한다.
+        11
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        if indexPath.row == 0 {
+            guard let cell: CameraButtonCollectionCell = collectionView.dequeueReusableCell(withReuseIdentifier: CameraButtonCollectionCell.reuseIdentifier, for: indexPath) as? CameraButtonCollectionCell else {
+                return CameraButtonCollectionCell()
+            }
+
+            return cell
+        } else {
+            guard let cell: ThumbnailCell = collectionView.dequeueReusableCell(withReuseIdentifier: ThumbnailCell.reuseIdentifier, for: indexPath) as? ThumbnailCell else {
+                return ThumbnailCell()
+            }
+
+            // TODO: 추가한 이미지 삭제 구현
+            cell.closeButtonDidTappedCallback = {
+                print("tapped \(indexPath.row)")
+            }
+
+            return cell
+        }
+    }
+}

--- a/ThingLog/View/TableVeiwCell/WriteRatingCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteRatingCell.swift
@@ -27,7 +27,14 @@ final class WriteRatingCell: UITableViewCell {
         return ratingView
     }()
 
+    /// 현재 선택한 만족도를 숫자로 반환한다.
     var currentRating: Int { ratingView.currentRating }
+    /// 만족도 버튼을 선택했을 때 호출할 클로저
+    var selectRatingBlock: (() -> Void)? {
+        didSet {
+            ratingView.didTapButtonBlock = selectRatingBlock
+        }
+    }
     private let paddingLabelMinLeading: CGFloat = 10.0
     private let paddingLabelLeading: CGFloat = 26.0
     private let paddingLabelTrailing: CGFloat = 60.0

--- a/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
@@ -86,18 +86,18 @@ extension WriteTextFieldCell {
     private func setupToolbar() {
         let keyboardToolBar: UIToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
         keyboardToolBar.barStyle = .default
-        let cancleButton: UIButton = {
+        let successButton: UIButton = {
             let button: UIButton = UIButton()
             button.titleLabel?.font = UIFont.Pretendard.title2
-            button.setTitle("취소", for: .normal)
+            button.setTitle("완료", for: .normal)
             button.setTitleColor(SwiftGenColors.systemBlue.color, for: .normal)
             button.addTarget(self, action: #selector(dismissKeyboard), for: .touchUpInside)
             return button
         }()
-        let cancleBarButton: UIBarButtonItem = UIBarButtonItem(customView: cancleButton)
-        cancleBarButton.tintColor = SwiftGenColors.black.color
+        let successBarButton: UIBarButtonItem = UIBarButtonItem(customView: successButton)
+        successBarButton.tintColor = SwiftGenColors.black.color
         keyboardToolBar.barTintColor = SwiftGenColors.gray6.color
-        keyboardToolBar.items = [cancleBarButton, UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)]
+        keyboardToolBar.items = [UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil), successBarButton]
         keyboardToolBar.sizeToFit()
         textField.inputAccessoryView = keyboardToolBar
     }

--- a/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
@@ -114,7 +114,7 @@ extension WriteTextFieldCell {
                 self?.clearTextField()
             }.disposed(by: disposeBag)
 
-        textField.rx.controlEvent(.editingDidBegin)
+        textField.rx.controlEvent([.editingDidBegin, .touchUpInside])
             .bind { [weak self] _ in
                 self?.isEditingSubject.onNext(true)
             }.disposed(by: disposeBag)
@@ -135,7 +135,7 @@ extension WriteTextFieldCell {
 
     @objc
     private func dismissKeyboard() {
-        textField.endEditing(true)
+        textField.resignFirstResponder()
     }
 
     @objc

--- a/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
@@ -118,6 +118,19 @@ extension WriteTextFieldCell {
             .bind { [weak self] _ in
                 self?.isEditingSubject.onNext(true)
             }.disposed(by: disposeBag)
+
+        textField.rx.controlEvent(.editingDidEnd)
+            .bind { [weak self] _ in
+                self?.textField.rightViewMode = .never
+            }.disposed(by: disposeBag)
+
+        textField.rx.controlEvent([.editingDidBegin, .editingChanged, .valueChanged])
+            .withLatestFrom(textField.rx.text.orEmpty)
+            .map { $0.isEmpty }
+            .bind { [weak self] isEmpty in
+                self?.textField.rightViewMode = isEmpty ? .never : .always
+            }
+            .disposed(by: disposeBag)
     }
 
     @objc
@@ -152,6 +165,7 @@ extension WriteTextFieldCell: UITextFieldDelegate {
         if string.isEmpty {
             if removeCharacter.count == 1 {
                 textField.text = ""
+                textField.sendActions(for: .valueChanged)
                 return false
             }
             let startIndex: String.Index = removeCharacter.index(removeCharacter.startIndex, offsetBy: 0)

--- a/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
@@ -43,10 +43,16 @@ final class WriteTextFieldCell: UITableViewCell {
     }
 
     var text: String? { textField.text }
+    var isEditingSubject: PublishSubject<Bool> = PublishSubject<Bool>()
 
-    private let disposeBag: DisposeBag = DisposeBag()
+    private(set) var disposeBag: DisposeBag = DisposeBag()
     private let paddingLeadingTrailing: CGFloat = 26.0
     private let paddingTopBottom: CGFloat = 20.0
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+    }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -101,12 +107,16 @@ extension WriteTextFieldCell {
             .map { $0.isEmpty }
             .bind { [weak self] isEmpty in
                 self?.textField.rightViewMode = isEmpty ? .never : .always
-            }
-            .disposed(by: disposeBag)
+            }.disposed(by: disposeBag)
 
         (textField.rightView as? UIButton)?.rx.tap
             .bind { [weak self] _ in
                 self?.clearTextField()
+            }.disposed(by: disposeBag)
+
+        textField.rx.controlEvent(.editingDidBegin)
+            .bind { [weak self] _ in
+                self?.isEditingSubject.onNext(true)
             }.disposed(by: disposeBag)
     }
 

--- a/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
@@ -94,7 +94,7 @@ extension WriteTextViewCell {
 
     @objc
     private func dismissKeyboard() {
-        textView.endEditing(true)
+        textView.resignFirstResponder()
     }
 }
 

--- a/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
@@ -29,7 +29,6 @@ final class WriteTextViewCell: UITableViewCell {
     weak var delegate: WriteTextViewCellDelegate?
     private let paddingLeadingTrailing: CGFloat = 23.0
     private let paddingTopBottom: CGFloat = 24.0
-    private let minHeight: CGFloat = 975.0
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -53,8 +52,7 @@ extension WriteTextViewCell {
             textView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: paddingLeadingTrailing),
             textView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingTopBottom),
             textView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -paddingLeadingTrailing),
-            textView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingTopBottom),
-            textView.heightAnchor.constraint(greaterThanOrEqualToConstant: minHeight)
+            textView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingTopBottom)
         ])
 
         textView.delegate = self

--- a/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
@@ -12,12 +12,12 @@ import RxSwift
 
 /// 글쓰기 화면에서 WriteTextViewCell의 높이를 동적으로 변경하기 위한 프로토콜
 protocol WriteTextViewCellDelegate: AnyObject {
-    func updateTextViewHeight(_ cell: WriteTextViewCell, _ textView: UITextView)
+    func updateTextViewHeight()
 }
 
 /// 글쓰기 화면에서 자유 글쓰기를 입력할 때 사용하는 셀
 final class WriteTextViewCell: UITableViewCell {
-    private let textView: UITextView = {
+    let textView: UITextView = {
         let textView: UITextView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.isEditable = true
@@ -34,6 +34,7 @@ final class WriteTextViewCell: UITableViewCell {
     private(set) var disposeBag: DisposeBag = DisposeBag()
     private let paddingLeadingTrailing: CGFloat = 23.0
     private let paddingTopBottom: CGFloat = 24.0
+    private let minHeight: CGFloat = 380.0
 
     override func prepareForReuse() {
         super.prepareForReuse()
@@ -55,6 +56,7 @@ final class WriteTextViewCell: UITableViewCell {
 extension WriteTextViewCell {
     private func setupView() {
         selectionStyle = .none
+        separatorInset = .zero
 
         contentView.addSubview(textView)
 
@@ -62,15 +64,11 @@ extension WriteTextViewCell {
             textView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: paddingLeadingTrailing),
             textView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingTopBottom),
             textView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -paddingLeadingTrailing),
-            textView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingTopBottom)
+            textView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingTopBottom),
+            textView.heightAnchor.constraint(equalToConstant: minHeight)
         ])
 
         textView.delegate = self
-
-        textView.rx.didBeginEditing
-            .bind { [weak self] in
-                self?.isEditingSubject.onNext(true)
-            }.disposed(by: disposeBag)
     }
 
     private func setupToolbar() {
@@ -115,7 +113,7 @@ extension WriteTextViewCell: UITextViewDelegate {
 
     func textViewDidChange(_ textView: UITextView) {
         if let delegate: WriteTextViewCellDelegate = delegate {
-            delegate.updateTextViewHeight(self, textView)
+            delegate.updateTextViewHeight()
         }
     }
 }

--- a/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
+
 /// 글쓰기 화면에서 WriteTextViewCell의 높이를 동적으로 변경하기 위한 프로토콜
 protocol WriteTextViewCellDelegate: AnyObject {
     func updateTextViewHeight(_ cell: WriteTextViewCell, _ textView: UITextView)
@@ -26,9 +29,16 @@ final class WriteTextViewCell: UITableViewCell {
         return textView
     }()
 
+    var isEditingSubject: PublishSubject<Bool> = PublishSubject<Bool>()
     weak var delegate: WriteTextViewCellDelegate?
+    private(set) var disposeBag: DisposeBag = DisposeBag()
     private let paddingLeadingTrailing: CGFloat = 23.0
     private let paddingTopBottom: CGFloat = 24.0
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+    }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -56,6 +66,11 @@ extension WriteTextViewCell {
         ])
 
         textView.delegate = self
+
+        textView.rx.didBeginEditing
+            .bind { [weak self] in
+                self?.isEditingSubject.onNext(true)
+            }.disposed(by: disposeBag)
     }
 
     private func setupToolbar() {

--- a/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
@@ -76,18 +76,18 @@ extension WriteTextViewCell {
     private func setupToolbar() {
         let keyboardToolBar: UIToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
         keyboardToolBar.barStyle = .default
-        let cancleButton: UIButton = {
+        let successButton: UIButton = {
             let button: UIButton = UIButton()
             button.titleLabel?.font = UIFont.Pretendard.title2
-            button.setTitle("취소", for: .normal)
+            button.setTitle("완료", for: .normal)
             button.setTitleColor(SwiftGenColors.systemBlue.color, for: .normal)
             button.addTarget(self, action: #selector(dismissKeyboard), for: .touchUpInside)
             return button
         }()
-        let cancleBarButton: UIBarButtonItem = UIBarButtonItem(customView: cancleButton)
-        cancleBarButton.tintColor = SwiftGenColors.black.color
+        let successBarButton: UIBarButtonItem = UIBarButtonItem(customView: successButton)
+        successBarButton.tintColor = SwiftGenColors.black.color
         keyboardToolBar.barTintColor = SwiftGenColors.gray6.color
-        keyboardToolBar.items = [cancleBarButton, UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)]
+        keyboardToolBar.items = [UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil), successBarButton]
         keyboardToolBar.sizeToFit()
         textView.inputAccessoryView = keyboardToolBar
     }

--- a/ThingLog/ViewController/WriteViewController+setup.swift
+++ b/ThingLog/ViewController/WriteViewController+setup.swift
@@ -75,36 +75,21 @@ extension WriteViewController {
             .bind { [weak self] _ in
                 guard let self = self else { return }
                 DispatchQueue.main.async {
-                    self.removeTableViewBottomInset()
+                    self.setupTableViewBottomInset(0)
                 }
             }.disposed(by: disposeBag)
     }
 
-    /// TableView 하단에 여백을 추가한다.
-    /// - Parameter height: 테이블 뷰 하단에 들어간 높이
+    /// TableView 하단에 여백을 지정한다.
+    /// - Parameter height: 테이블 뷰 하단에 들어갈 높이
     private func setupTableViewBottomInset(_ height: CGFloat) {
         var inset: UIEdgeInsets = self.tableView.contentInset
         inset.bottom = height
         UIView.animate(withDuration: 0.3) {
             self.tableView.contentInset = inset
         }
-        inset = self.tableView.verticalScrollIndicatorInsets
-        inset.bottom = height
-        UIView.animate(withDuration: 0.3) {
-            self.tableView.scrollIndicatorInsets = inset
-        }
-    }
-
-    /// TableView 하단에 있는 여백을 삭제한다.
-    private func removeTableViewBottomInset() {
-        var inset: UIEdgeInsets = tableView.contentInset
-        inset.bottom = 0
-        UIView.animate(withDuration: 0.3) {
-            self.tableView.contentInset = inset
-        }
-
         inset = tableView.verticalScrollIndicatorInsets
-        inset.bottom = 0
+        inset.bottom = height
         UIView.animate(withDuration: 0.3) {
             self.tableView.scrollIndicatorInsets = inset
         }

--- a/ThingLog/ViewController/WriteViewController+setup.swift
+++ b/ThingLog/ViewController/WriteViewController+setup.swift
@@ -51,7 +51,7 @@ extension WriteViewController {
             tableView.bottomAnchor.constraint(equalTo: doneButton.topAnchor),
             doneButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             doneButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            doneButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            doneButton.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
         tableView.estimatedRowHeight = UITableView.automaticDimension

--- a/ThingLog/ViewController/WriteViewController+setup.swift
+++ b/ThingLog/ViewController/WriteViewController+setup.swift
@@ -61,6 +61,8 @@ extension WriteViewController {
         tableView.register(WriteTextFieldCell.self, forCellReuseIdentifier: WriteTextFieldCell.reuseIdentifier)
         tableView.register(WriteRatingCell.self, forCellReuseIdentifier: WriteRatingCell.reuseIdentifier)
         tableView.register(WriteTextViewCell.self, forCellReuseIdentifier: WriteTextViewCell.reuseIdentifier)
+
+        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(endEditing(sender:))))
     }
 
     func setupBind() {
@@ -86,5 +88,13 @@ extension WriteViewController {
                 self.tableView.contentInset = insets
             }
             .disposed(by: disposeBag)
+    }
+
+    @objc
+    func endEditing(sender: UITapGestureRecognizer) {
+        if sender.state == .ended {
+            view.endEditing(true)
+        }
+        sender.cancelsTouchesInView = false
     }
 }

--- a/ThingLog/ViewController/WriteViewController+setup.swift
+++ b/ThingLog/ViewController/WriteViewController+setup.swift
@@ -8,26 +8,6 @@
 import UIKit
 
 extension WriteViewController {
-    /// WriteType 값이 넘어왔는 지 확인하기 위한 뷰를 구성하는 메서드.
-    /// 이후 화면 구성에서 삭제할 예정
-    func setupTestView() {
-        guard let viewModel = viewModel else {
-            return
-        }
-
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "\(viewModel.writeType)"
-        label.textColor = SwiftGenColors.black.color
-
-        view.addSubview(label)
-
-        NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-        ])
-    }
-
     func setupNavigationBar() {
         if #available(iOS 15, *) {
             let appearance: UINavigationBarAppearance = UINavigationBarAppearance()
@@ -58,5 +38,53 @@ extension WriteViewController {
         }.disposed(by: disposeBag)
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: closeButton)
+    }
+
+    func setupView() {
+        view.addSubview(tableView)
+        view.addSubview(doneButton)
+
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: doneButton.topAnchor),
+            doneButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            doneButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            doneButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        tableView.estimatedRowHeight = UITableView.automaticDimension
+
+        tableView.dataSource = self
+        tableView.register(WriteImageTableCell.self, forCellReuseIdentifier: WriteImageTableCell.reuseIdentifier)
+        tableView.register(WriteTextFieldCell.self, forCellReuseIdentifier: WriteTextFieldCell.reuseIdentifier)
+        tableView.register(WriteRatingCell.self, forCellReuseIdentifier: WriteRatingCell.reuseIdentifier)
+        tableView.register(WriteTextViewCell.self, forCellReuseIdentifier: WriteTextViewCell.reuseIdentifier)
+    }
+
+    func setupBind() {
+        // 키보드가 올라왔을 때 키보드 높이만큼 하단 여백 추가
+        NotificationCenter.default.rx
+            .notification(UIResponder.keyboardWillShowNotification, object: nil)
+            .map { notification -> CGFloat in
+                (notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue.height ?? 0
+            }
+            .bind { [weak self] height in
+                guard let self = self else { return }
+                let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: height, right: 0)
+                self.tableView.contentInset = insets
+            }
+            .disposed(by: disposeBag)
+
+        // 키보드가 내려갔을 때 하단 여백 삭제
+        NotificationCenter.default.rx
+            .notification(UIResponder.keyboardWillHideNotification, object: nil)
+            .bind { [weak self] _ in
+                guard let self = self else { return }
+                let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+                self.tableView.contentInset = insets
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/ThingLog/ViewController/WriteViewController+setup.swift
+++ b/ThingLog/ViewController/WriteViewController+setup.swift
@@ -58,6 +58,7 @@ extension WriteViewController {
 
         tableView.dataSource = self
         tableView.register(WriteImageTableCell.self, forCellReuseIdentifier: WriteImageTableCell.reuseIdentifier)
+        tableView.register(WriteCategoryTableCell.self, forCellReuseIdentifier: WriteCategoryTableCell.reuseIdentifier)
         tableView.register(WriteTextFieldCell.self, forCellReuseIdentifier: WriteTextFieldCell.reuseIdentifier)
         tableView.register(WriteRatingCell.self, forCellReuseIdentifier: WriteRatingCell.reuseIdentifier)
         tableView.register(WriteTextViewCell.self, forCellReuseIdentifier: WriteTextViewCell.reuseIdentifier)

--- a/ThingLog/ViewController/WriteViewController.swift
+++ b/ThingLog/ViewController/WriteViewController.swift
@@ -17,13 +17,13 @@ final class WriteViewController: UIViewController {
         let tableView: UITableView = UITableView(frame: .zero, style: .plain)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
-
+        
         let headerLabel: UILabel = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 29.0))
         headerLabel.font = UIFont.Pretendard.body2
         headerLabel.textColor = SwiftGenColors.gray3.color
         headerLabel.text = "\(Date().toString(.year))년 \(Date().toString(.month))월 \(Date().toString(.day))일"
         headerLabel.textAlignment = .center
-
+        
         tableView.tableHeaderView = headerLabel
         tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 1))
         if #available(iOS 15.0, *) {
@@ -31,50 +31,54 @@ final class WriteViewController: UIViewController {
         }
         return tableView
     }()
-
+    
     let doneButton: CenterTextButton = {
         let button: CenterTextButton = CenterTextButton(buttonHeight: 54.0, title: "작성 완료")
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
-
+    
     // MARK: - Properties
     var coordinator: Coordinator?
     var viewModel: WriteViewModel?
     let disposeBag: DisposeBag = DisposeBag()
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = SwiftGenColors.white.color
-
+        
         setupNavigationBar()
         setupView()
         setupBind()
     }
-
+    
     @objc
     /// 글쓰기 화면을 닫는다.
     /// 글쓰기 화면을 닫기 전에 alert 팝업을 띄워 다시 한 번 사용자에게 묻는다.
     /// 글쓰기 화면을 닫으면서 navigationController.viewControllers를 초기화한다.
     func close() {
-        let alertController: UIAlertController = UIAlertController(title: "Title Here",
-                                                                   message: "Alert description",
-                                                                   preferredStyle: .alert)
-
-        let cancleAction: UIAlertAction = UIAlertAction(title: "cancle",
-                                                        style: .cancel,
-                                                        handler: nil)
-        let saveAction: UIAlertAction = UIAlertAction(title: "save",
-                                                      style: .default,
-                                                      handler: { [weak self] _ in
-            self?.navigationController?.dismiss(animated: true, completion: {
-                self?.navigationController?.viewControllers.removeAll()
-            })
-        })
-
-        alertController.addAction(cancleAction)
-        alertController.addAction(saveAction)
-        present(alertController, animated: true, completion: nil)
+        let alertController: AlertViewController = AlertViewController()
+        
+        alertController.hideTitleLabel()
+        alertController.changeContentsText("글이 저장되지 않고 삭제됩니다.\n나가시겠어요?")
+        alertController.hideTextField()
+        alertController.leftButton.setTitle("아니요", for: .normal)
+        alertController.rightButton.setTitle("네", for: .normal)
+        
+        alertController.leftButton.rx.tap.bind {
+            alertController.dismiss(animated: false, completion: nil)
+        }.disposed(by: disposeBag)
+        
+        alertController.rightButton.rx.tap.bind { [weak self] in
+            alertController.dismiss(animated: false) {
+                self?.navigationController?.dismiss(animated: true, completion: {
+                    self?.navigationController?.viewControllers.removeAll()
+                })
+            }
+        }.disposed(by: disposeBag)
+        
+        alertController.modalPresentationStyle = .overFullScreen
+        present(alertController, animated: false, completion: nil)
     }
 }
 
@@ -83,34 +87,34 @@ extension WriteViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         WriteViewModel.Section.allCases.count
     }
-
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         viewModel?.itemCount[section] ?? 0
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let section: WriteViewModel.Section? = .init(rawValue: indexPath.section)
-
+        
         switch section {
         case .image:
             guard let cell: WriteImageTableCell = tableView.dequeueReusableCell(withIdentifier: WriteImageTableCell.reuseIdentifier, for: indexPath) as? WriteImageTableCell else {
                 return UITableViewCell()
             }
-
+            
             return cell
         case .type:
             guard let cell: WriteTextFieldCell = tableView.dequeueReusableCell(withIdentifier: WriteTextFieldCell.reuseIdentifier, for: indexPath) as? WriteTextFieldCell else {
                 return WriteTextFieldCell()
             }
-
+            
             cell.keyboardType = viewModel?.typeInfo[indexPath.row].keyboardType ?? .default
             cell.placeholder = viewModel?.typeInfo[indexPath.row].placeholder
-
+            
             cell.isEditingSubject
                 .bind { _ in
                     tableView.scrollToRow(at: indexPath, at: .top, animated: true)
                 }.disposed(by: cell.disposeBag)
-
+            
             return cell
         case .rating:
             guard let cell: WriteRatingCell = tableView.dequeueReusableCell(withIdentifier: WriteRatingCell.reuseIdentifier, for: indexPath) as? WriteRatingCell else {
@@ -121,14 +125,14 @@ extension WriteViewController: UITableViewDataSource {
             guard let cell: WriteTextViewCell = tableView.dequeueReusableCell(withIdentifier: WriteTextViewCell.reuseIdentifier, for: indexPath) as? WriteTextViewCell else {
                 return WriteTextViewCell()
             }
-
+            
             cell.delegate = self
-
+            
             cell.isEditingSubject
                 .bind { _ in
                     tableView.scrollToRow(at: indexPath, at: .top, animated: true)
                 }.disposed(by: cell.disposeBag)
-
+            
             return cell
         default:
             return UITableViewCell()

--- a/ThingLog/ViewController/WriteViewController.swift
+++ b/ThingLog/ViewController/WriteViewController.swift
@@ -17,13 +17,13 @@ final class WriteViewController: UIViewController {
         let tableView: UITableView = UITableView(frame: .zero, style: .plain)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
-        
+
         let headerLabel: UILabel = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 29.0))
         headerLabel.font = UIFont.Pretendard.body2
         headerLabel.textColor = SwiftGenColors.gray3.color
         headerLabel.text = "\(Date().toString(.year))년 \(Date().toString(.month))월 \(Date().toString(.day))일"
         headerLabel.textAlignment = .center
-        
+
         tableView.tableHeaderView = headerLabel
         tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 1))
         if #available(iOS 15.0, *) {
@@ -31,44 +31,44 @@ final class WriteViewController: UIViewController {
         }
         return tableView
     }()
-    
+
     let doneButton: CenterTextButton = {
         let button: CenterTextButton = CenterTextButton(buttonHeight: 54.0, title: "작성 완료")
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
-    
+
     // MARK: - Properties
     var coordinator: Coordinator?
     var viewModel: WriteViewModel?
     let disposeBag: DisposeBag = DisposeBag()
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = SwiftGenColors.white.color
-        
+
         setupNavigationBar()
         setupView()
         setupBind()
     }
-    
+
     @objc
     /// 글쓰기 화면을 닫는다.
     /// 글쓰기 화면을 닫기 전에 alert 팝업을 띄워 다시 한 번 사용자에게 묻는다.
     /// 글쓰기 화면을 닫으면서 navigationController.viewControllers를 초기화한다.
     func close() {
         let alertController: AlertViewController = AlertViewController()
-        
+
         alertController.hideTitleLabel()
         alertController.changeContentsText("글이 저장되지 않고 삭제됩니다.\n나가시겠어요?")
         alertController.hideTextField()
         alertController.leftButton.setTitle("아니요", for: .normal)
         alertController.rightButton.setTitle("네", for: .normal)
-        
+
         alertController.leftButton.rx.tap.bind {
             alertController.dismiss(animated: false, completion: nil)
         }.disposed(by: disposeBag)
-        
+
         alertController.rightButton.rx.tap.bind { [weak self] in
             alertController.dismiss(animated: false) {
                 self?.navigationController?.dismiss(animated: true, completion: {
@@ -76,7 +76,7 @@ final class WriteViewController: UIViewController {
                 })
             }
         }.disposed(by: disposeBag)
-        
+
         alertController.modalPresentationStyle = .overFullScreen
         present(alertController, animated: false, completion: nil)
     }
@@ -87,34 +87,39 @@ extension WriteViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         WriteViewModel.Section.allCases.count
     }
-    
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         viewModel?.itemCount[section] ?? 0
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let section: WriteViewModel.Section? = .init(rawValue: indexPath.section)
-        
+
         switch section {
         case .image:
             guard let cell: WriteImageTableCell = tableView.dequeueReusableCell(withIdentifier: WriteImageTableCell.reuseIdentifier, for: indexPath) as? WriteImageTableCell else {
                 return UITableViewCell()
             }
-            
+
+            return cell
+        case .category:
+            guard let cell: WriteCategoryTableCell = tableView.dequeueReusableCell(withIdentifier: WriteCategoryTableCell.reuseIdentifier, for: indexPath) as? WriteCategoryTableCell else {
+                return UITableViewCell()
+            }
             return cell
         case .type:
             guard let cell: WriteTextFieldCell = tableView.dequeueReusableCell(withIdentifier: WriteTextFieldCell.reuseIdentifier, for: indexPath) as? WriteTextFieldCell else {
                 return WriteTextFieldCell()
             }
-            
+
             cell.keyboardType = viewModel?.typeInfo[indexPath.row].keyboardType ?? .default
             cell.placeholder = viewModel?.typeInfo[indexPath.row].placeholder
-            
+
             cell.isEditingSubject
                 .bind { _ in
                     tableView.scrollToRow(at: indexPath, at: .top, animated: true)
                 }.disposed(by: cell.disposeBag)
-            
+
             return cell
         case .rating:
             guard let cell: WriteRatingCell = tableView.dequeueReusableCell(withIdentifier: WriteRatingCell.reuseIdentifier, for: indexPath) as? WriteRatingCell else {
@@ -125,14 +130,14 @@ extension WriteViewController: UITableViewDataSource {
             guard let cell: WriteTextViewCell = tableView.dequeueReusableCell(withIdentifier: WriteTextViewCell.reuseIdentifier, for: indexPath) as? WriteTextViewCell else {
                 return WriteTextViewCell()
             }
-            
+
             cell.delegate = self
-            
+
             cell.isEditingSubject
                 .bind { _ in
                     tableView.scrollToRow(at: indexPath, at: .top, animated: true)
                 }.disposed(by: cell.disposeBag)
-            
+
             return cell
         default:
             return UITableViewCell()

--- a/ThingLog/ViewController/WriteViewController.swift
+++ b/ThingLog/ViewController/WriteViewController.swift
@@ -52,6 +52,13 @@ final class WriteViewController: UIViewController {
         setupBind()
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        doneButton.heightAnchor.constraint(equalToConstant: doneButton.frame.height + view.safeAreaInsets.bottom).isActive = true
+        doneButton.titleEdgeInsets = UIEdgeInsets(top: -view.safeAreaInsets.bottom, left: 0, bottom: 0, right: 0)
+    }
+
     @objc
     /// 글쓰기 화면을 닫는다.
     /// 글쓰기 화면을 닫기 전에 alert 팝업을 띄워 다시 한 번 사용자에게 묻는다.
@@ -126,7 +133,7 @@ extension WriteViewController: UITableViewDataSource {
                 return WriteRatingCell()
             }
             return cell
-        case .free:
+        case .contents:
             guard let cell: WriteTextViewCell = tableView.dequeueReusableCell(withIdentifier: WriteTextViewCell.reuseIdentifier, for: indexPath) as? WriteTextViewCell else {
                 return WriteTextViewCell()
             }

--- a/ThingLog/ViewController/WriteViewController.swift
+++ b/ThingLog/ViewController/WriteViewController.swift
@@ -26,9 +26,11 @@ final class WriteViewController: UIViewController {
 
         tableView.tableHeaderView = headerLabel
         tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 1))
+        /* iOS 15.0 에서 tableFooterView 에 생기는 separator 제거 코드
         if #available(iOS 15.0, *) {
             tableView.sectionHeaderTopPadding = 0
         }
+         */
         return tableView
     }()
 

--- a/ThingLog/ViewController/WriteViewController.swift
+++ b/ThingLog/ViewController/WriteViewController.swift
@@ -12,6 +12,32 @@ import RxSwift
 
 /// 글쓰기 화면(샀다, 사고싶다, 선물받았다)를 담당하는 ViewController
 final class WriteViewController: UIViewController {
+    // MARK: - View Properties
+    let tableView: UITableView = {
+        let tableView: UITableView = UITableView(frame: .zero, style: .plain)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+
+        let headerLabel: UILabel = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 29.0))
+        headerLabel.font = UIFont.Pretendard.body2
+        headerLabel.textColor = SwiftGenColors.gray3.color
+        headerLabel.text = "\(Date().toString(.year))년 \(Date().toString(.month))월 \(Date().toString(.day))일"
+        headerLabel.textAlignment = .center
+
+        tableView.tableHeaderView = headerLabel
+        tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 1))
+        if #available(iOS 15.0, *) {
+            tableView.sectionHeaderTopPadding = 0
+        }
+        return tableView
+    }()
+
+    let doneButton: CenterTextButton = {
+        let button: CenterTextButton = CenterTextButton(buttonHeight: 54.0, title: "작성 완료")
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
     // MARK: - Properties
     var coordinator: Coordinator?
     var viewModel: WriteViewModel?
@@ -22,7 +48,8 @@ final class WriteViewController: UIViewController {
         view.backgroundColor = SwiftGenColors.white.color
 
         setupNavigationBar()
-        setupTestView()
+        setupView()
+        setupBind()
     }
 
     @objc
@@ -48,5 +75,63 @@ final class WriteViewController: UIViewController {
         alertController.addAction(cancleAction)
         alertController.addAction(saveAction)
         present(alertController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - DataSource
+extension WriteViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        WriteViewModel.Section.allCases.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        viewModel?.itemCount[section] ?? 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let section: WriteViewModel.Section? = .init(rawValue: indexPath.section)
+
+        switch section {
+        case .image:
+            guard let cell: WriteImageTableCell = tableView.dequeueReusableCell(withIdentifier: WriteImageTableCell.reuseIdentifier, for: indexPath) as? WriteImageTableCell else {
+                return UITableViewCell()
+            }
+
+            return cell
+        case .type:
+            guard let cell: WriteTextFieldCell = tableView.dequeueReusableCell(withIdentifier: WriteTextFieldCell.reuseIdentifier, for: indexPath) as? WriteTextFieldCell else {
+                return WriteTextFieldCell()
+            }
+
+            cell.keyboardType = viewModel?.typeInfo[indexPath.row].keyboardType ?? .default
+            cell.placeholder = viewModel?.typeInfo[indexPath.row].placeholder
+
+            return cell
+        case .rating:
+            guard let cell: WriteRatingCell = tableView.dequeueReusableCell(withIdentifier: WriteRatingCell.reuseIdentifier, for: indexPath) as? WriteRatingCell else {
+                return WriteRatingCell()
+            }
+            return cell
+        case .free:
+            guard let cell: WriteTextViewCell = tableView.dequeueReusableCell(withIdentifier: WriteTextViewCell.reuseIdentifier, for: indexPath) as? WriteTextViewCell else {
+                return WriteTextViewCell()
+            }
+
+            cell.delegate = self
+
+            return cell
+        default:
+            return UITableViewCell()
+        }
+    }
+}
+
+// MARK: - Delegate
+extension WriteViewController: WriteTextViewCellDelegate, UITextViewDelegate {
+    func updateTextViewHeight(_ cell: WriteTextViewCell, _ textView: UITextView) {
+        DispatchQueue.main.async { [weak tableView] in
+            tableView?.beginUpdates()
+            tableView?.endUpdates()
+        }
     }
 }

--- a/ThingLog/ViewController/WriteViewController.swift
+++ b/ThingLog/ViewController/WriteViewController.swift
@@ -137,7 +137,7 @@ extension WriteViewController: UITableViewDataSource {
 }
 
 // MARK: - Delegate
-extension WriteViewController: WriteTextViewCellDelegate, UITextViewDelegate {
+extension WriteViewController: WriteTextViewCellDelegate {
     func updateTextViewHeight(_ cell: WriteTextViewCell, _ textView: UITextView) {
         DispatchQueue.main.async { [weak tableView] in
             tableView?.beginUpdates()

--- a/ThingLog/ViewController/WriteViewController.swift
+++ b/ThingLog/ViewController/WriteViewController.swift
@@ -106,6 +106,11 @@ extension WriteViewController: UITableViewDataSource {
             cell.keyboardType = viewModel?.typeInfo[indexPath.row].keyboardType ?? .default
             cell.placeholder = viewModel?.typeInfo[indexPath.row].placeholder
 
+            cell.isEditingSubject
+                .bind { _ in
+                    tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+                }.disposed(by: cell.disposeBag)
+
             return cell
         case .rating:
             guard let cell: WriteRatingCell = tableView.dequeueReusableCell(withIdentifier: WriteRatingCell.reuseIdentifier, for: indexPath) as? WriteRatingCell else {
@@ -118,6 +123,11 @@ extension WriteViewController: UITableViewDataSource {
             }
 
             cell.delegate = self
+
+            cell.isEditingSubject
+                .bind { _ in
+                    tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+                }.disposed(by: cell.disposeBag)
 
             return cell
         default:

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -10,6 +10,7 @@ import UIKit
 final class WriteViewModel {
     enum Section: Int, CaseIterable {
         case image
+        case category
         case type
         case rating
         case free
@@ -29,7 +30,7 @@ final class WriteViewModel {
         }
     }
     // Section 마다 표시할 항목의 개수
-    lazy var itemCount: [Int] = [1, typeInfo.count, 1, 1]
+    lazy var itemCount: [Int] = [1, 1, typeInfo.count, 1, 1]
 
     init(writeType: WriteType) {
         self.writeType = writeType

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -11,14 +11,15 @@ final class WriteViewModel {
     enum Section: Int, CaseIterable {
         case image
         case category
+        /// 물건 이름, 가격 등 WriteTextField를 사용하는 항목을 나타내는 섹션
         case type
         case rating
-        case free
+        case contents
     }
 
     // MARK: - Properties
     var writeType: WriteType
-    // WriteTextFieldCell을 표시할 때 필요한 keyboardType, placeholder 구성
+    /// WriteTextFieldCell을 표시할 때 필요한 keyboardType, placeholder 구성. writeType에 따라 개수가 다르다.
     var typeInfo: [(keyboardType: UIKeyboardType, placeholder: String)] {
         switch writeType {
         case .bought:

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -5,10 +5,31 @@
 //  Created by 이지원 on 2021/10/03.
 //
 
-import Foundation
+import UIKit
 
 final class WriteViewModel {
+    enum Section: Int, CaseIterable {
+        case image
+        case type
+        case rating
+        case free
+    }
+
+    // MARK: - Properties
     var writeType: WriteType
+    // WriteTextFieldCell을 표시할 때 필요한 keyboardType, placeholder 구성
+    var typeInfo: [(keyboardType: UIKeyboardType, placeholder: String)] {
+        switch writeType {
+        case .bought:
+            return [(.default, "물건 이름"), (.numberPad, "가격"), (.default, "구매처")]
+        case .wish:
+            return [(.default, "물건 이름"), (.numberPad, "가격"), (.default, "판매처")]
+        case .gift:
+            return [(.default, "물건 이름"), (.default, "선물 준 사람")]
+        }
+    }
+    // Section 마다 표시할 항목의 개수
+    lazy var itemCount: [Int] = [1, typeInfo.count, 1, 1]
 
     init(writeType: WriteType) {
         self.writeType = writeType


### PR DESCRIPTION
## 개요

<img src="https://user-images.githubusercontent.com/15073405/138447406-95cf835c-c6be-4f42-b39f-ce1d79e1bc6a.png" width="25%" /><img src="https://user-images.githubusercontent.com/15073405/138447411-22d8d95b-d092-4dd9-bad5-a1ae649ff478.png" width="25%" /><img src="https://user-images.githubusercontent.com/15073405/138447402-b4e03ff8-aa94-47f4-9519-0cbeca1b92f4.png" width="25%" /><img src="https://user-images.githubusercontent.com/15073405/138447392-c8999acc-91db-44b1-a409-b77631852efd.png" width="25%" />

글쓰기 화면(샀다, 사고싶다, 선물받았다) 화면 구현

## 작업 사항

- `CenterTextButton` 구현
- `WriteViewController` 구성
  - 전체를 TableView로 구성했습니다. 
- `WriteImageTableCell` 구현
  - 사진 추가, 추가한 사진 썸네일 표시를 위한 TableCell
  - CollectionView를 가지고 있음
- `UIAlertViewController`를 `AlertViewController`로 대체
- 입력 중일 때만 clearButton 표시

## 예외 사항 (미구현)
- 사진 추가, 썸네일 삭제 등 이미지 관련한 로직
- 글 저장 기능
- 카테고리 관련 로직
  - 현재는 인디케이터 버튼을 누르면 #107 과 동일하게 카테고리가 선택되었을 때 모습으로 보여집니다.

### Linked Issue

close #32 
close #128

