### PR TITLE
[#125] Feat: 휴지통 삭제 인터렉션 구현 

### DIFF
--- a/ThingLog/View/LeftRightButtonView.swift
+++ b/ThingLog/View/LeftRightButtonView.swift
@@ -61,8 +61,8 @@ class LeftRightButtonView: UIView {
         addSubview(stackView)
         addSubview(topLineView)
         
-        let window = UIApplication.shared.windows.first
-        let bottomPadding = window?.safeAreaInsets.bottom ?? 0.0
+        let window: UIWindow? = UIApplication.shared.windows.first
+        let bottomPadding: CGFloat = window?.safeAreaInsets.bottom ?? 0.0
         
         let topLineConstraint: NSLayoutConstraint = topLineView.heightAnchor.constraint(equalToConstant: 0.5)
         topLineConstraint.isActive = true

--- a/ThingLog/View/LeftRightButtonView.swift
+++ b/ThingLog/View/LeftRightButtonView.swift
@@ -60,18 +60,29 @@ class LeftRightButtonView: UIView {
     func setupView() {
         addSubview(stackView)
         addSubview(topLineView)
+        
+        let window = UIApplication.shared.windows.first
+        let bottomPadding = window?.safeAreaInsets.bottom ?? 0.0
+        
+        let topLineConstraint: NSLayoutConstraint = topLineView.heightAnchor.constraint(equalToConstant: 0.5)
+        topLineConstraint.isActive = true
+        topLineConstraint.priority = .defaultHigh
+        
+        let borderLineConstraint: NSLayoutConstraint = borderLine.widthAnchor.constraint(equalToConstant: 0.5)
+        borderLineConstraint.isActive = true
+        borderLineConstraint.priority = .defaultHigh
+                    
         NSLayoutConstraint.activate([
             topLineView.leadingAnchor.constraint(equalTo: leadingAnchor),
             topLineView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            topLineView.heightAnchor.constraint(equalToConstant: 0.5),
+            
             topLineView.topAnchor.constraint(equalTo: topAnchor),
             
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             stackView.topAnchor.constraint(equalTo: topLineView.bottomAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            borderLine.widthAnchor.constraint(equalToConstant: 0.5),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -bottomPadding),
+ 
             leftButton.widthAnchor.constraint(equalTo: rightButton.widthAnchor)
         ])
     }

--- a/ThingLog/View/ProfileView.swift
+++ b/ThingLog/View/ProfileView.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+/// 홈화면 상단에 유저 `닉네임`, 유저 `한 줄 소개` 및 `벳지` 이미지를 보여주는 뷰다. [이미지](https://www.notion.so/ProfileView-2ec81d3153944a198ed01320a070cf63)
+///
+/// `HomeViewController`에서 사용
 final class ProfileView: UIView {
     var userAliasNameButton: UIButton = {
         let button: UIButton = UIButton()
@@ -17,7 +20,7 @@ final class ProfileView: UIView {
         button.semanticContentAttribute = .forceRightToLeft
         button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: -8)
         button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8)
-        button.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+        button.setContentCompressionResistancePriority(.required, for: .vertical)
         return button
     }()
     
@@ -29,6 +32,12 @@ final class ProfileView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         return label
+    }()
+    
+    private let paddingViewBetweenLabel: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
     }()
     
     var userBadgeImageView: UIImageView = {
@@ -61,9 +70,10 @@ final class ProfileView: UIView {
     }()
     
     private lazy var verticalStackView: UIStackView = {
-        let stackView: UIStackView = UIStackView(arrangedSubviews: [userAliasNameButton, userOneLineIntroductionLabel])
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [userAliasNameButton,
+                                                                    paddingViewBetweenLabel,
+                                                                    userOneLineIntroductionLabel])
         stackView.axis = .vertical
-        stackView.spacing = 4
         stackView.alignment = .leading
         return stackView
     }()
@@ -90,6 +100,7 @@ final class ProfileView: UIView {
     private let imageHeight: CGFloat = 44
     private let emptyWidth: CGFloat = 44
     private let emptyHeight: CGFloat = 16
+    private let paddingViewHeight: CGFloat = 4
     
     // 배지이미지를 저장하기 위한 프로퍼티
     private var badgeImage: UIImage?
@@ -109,6 +120,13 @@ final class ProfileView: UIView {
         addSubview(totalView)
         
         userBadgeImageView.layer.cornerRadius = imageHeight / 2
+        let emptyVerticalConstraint: NSLayoutConstraint = emptyVerticalView.heightAnchor.constraint(equalToConstant: emptyHeight)
+        emptyVerticalConstraint.isActive =  true
+        emptyVerticalConstraint.priority = .defaultHigh
+        
+        let paddingViewConstraint: NSLayoutConstraint = paddingViewBetweenLabel.heightAnchor.constraint(equalToConstant: paddingViewHeight)
+        paddingViewConstraint.isActive = true
+        paddingViewConstraint.priority = .defaultHigh
         
         NSLayoutConstraint.activate([
             userBadgeImageView.heightAnchor.constraint(lessThanOrEqualToConstant: imageHeight),
@@ -120,9 +138,7 @@ final class ProfileView: UIView {
             totalView.leadingAnchor.constraint(equalTo: leadingAnchor),
             totalView.trailingAnchor.constraint(equalTo: trailingAnchor),
             totalView.topAnchor.constraint(equalTo: topAnchor),
-            totalView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            emptyVerticalView.heightAnchor.constraint(equalToConstant: emptyHeight)
+            totalView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
 }

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -76,7 +76,9 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         button.layer.borderWidth = 1
         button.layer.borderColor = SwiftGenColors.white.color.cgColor
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.titleLabel?.font = UIFont.Pretendard.overline
         button.isHidden = true
+        button.isUserInteractionEnabled = false
         return button
     }()
     
@@ -102,6 +104,10 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         contentView.addSubview(checkButton)
         checkButton.layer.cornerRadius = checkButtonSize / 2
         
+        let imageViewHeight: NSLayoutConstraint = imageView.heightAnchor.constraint(equalToConstant: 124)
+        imageViewHeight.isActive = true
+        imageViewHeight.priority = .defaultHigh
+        
         NSLayoutConstraint.activate([
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
@@ -112,7 +118,7 @@ class ContentsCollectionViewCell: UICollectionViewCell {
             smallIconView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -7),
             smallIconView.widthAnchor.constraint(equalToConstant: 10),
             smallIconView.heightAnchor.constraint(equalToConstant: 10),
-            imageView.heightAnchor.constraint(equalToConstant: 124),
+            
             imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor),
             
             bottomGradientView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
@@ -174,5 +180,11 @@ extension ContentsCollectionViewCell {
         smallIconView.isHidden = true
         bottomGradientView.isHidden = false
         bottomLabel.isHidden = false
+    }
+    
+    /// 체크버튼을 숫자가 포함되도록 변경하거나 빈칸으로 변경하는 메서드다
+    func changeCheckButton(isSelected: Bool) {
+        checkButton.layer.borderColor = isSelected ? SwiftGenColors.black.color.cgColor : SwiftGenColors.white.color.cgColor
+        checkButton.backgroundColor = isSelected ? SwiftGenColors.black.color : .clear
     }
 }

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -182,7 +182,8 @@ extension ContentsCollectionViewCell {
         bottomLabel.isHidden = false
     }
     
-    /// 체크버튼을 숫자가 포함되도록 변경하거나 빈칸으로 변경하는 메서드다
+    // TODO: - ⚠️버튼 색이나 디자인 변경예정
+    /// 체크버튼을 강조하거나 강조하지 않도록 변경하는 메서드다
     func changeCheckButton(isSelected: Bool) {
         checkButton.layer.borderColor = isSelected ? SwiftGenColors.black.color.cgColor : SwiftGenColors.white.color.cgColor
         checkButton.backgroundColor = isSelected ? SwiftGenColors.black.color : .clear

--- a/ThingLog/ViewController/TrashViewController.swift
+++ b/ThingLog/ViewController/TrashViewController.swift
@@ -40,7 +40,9 @@ final class TrashViewController: UIViewController {
     }()
     
     private lazy var stackView: UIStackView = {
-        let stackView: UIStackView = UIStackView(arrangedSubviews: [collectionView, deleteButtonView])
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [
+                                                    collectionView,
+                                                    deleteButtonView])
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
@@ -171,17 +173,18 @@ extension TrashViewController {
         editButton.rx.tap
             .bind { [weak self] in
                 self?.changeEditButton(isCurrentEditMode: self?.isEditMode ?? true)
-                if self?.isEditMode == true {
-                    self?.deleteStorage.removeAll()
-                }
+
                 // 하단에 삭제버튼의 높이를 애니메이션 준다.
                 UIView.animate(withDuration: 0.3) {
                     self?.deleteButtonHeightConstraint?.constant = (self?.isEditMode == true) ? 0.0 : (self?.deleteButtonViewHeight ?? 0.0)
                     self?.view.layoutIfNeeded()
+                } completion: { _ in
+                    if self?.isEditMode == true {
+                        self?.deleteStorage.removeAll()
+                    }
+                    self?.isEditMode.toggle()
+                    self?.collectionView.reloadData()
                 }
-                
-                self?.isEditMode.toggle()
-                self?.collectionView.reloadData()
             }
             .disposed(by: disposeBag)
     }
@@ -199,12 +202,13 @@ extension TrashViewController {
                 alert.titleLabel.text = text
                 alert.changeContentsText("정말 삭제 하시겠어요?\n이 동작은 취소할 수 없습니다")
                 
+                // 취소버튼
                 alert.leftButton.rx.tap.bind {
-                    self?.changeEditButton(isCurrentEditMode: false)
                     alert.dismiss(animated: false, completion: nil)
                 }
                 .disposed(by: alert.disposeBag)
                 
+                // 삭제버튼
                 alert.rightButton.rx.tap.bind { [weak self] in
                     // TODO: - ⚠️n개일 때 또는 전체일 때 삭제 로직 변경
                     self?.items.removeAll()

--- a/ThingLog/ViewController/TrashViewController.swift
+++ b/ThingLog/ViewController/TrashViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 /// 휴지통 화면을 구성하는 뷰컨트롤러이다.
 final class TrashViewController: UIViewController {
     var coordinator: SettingCoordinator?
-
+    
     /// 네비게이션바 우측에 있는 선택or취소 버튼이다
     let editButton: UIButton = UIButton()
     
@@ -24,7 +24,7 @@ final class TrashViewController: UIViewController {
         flowLayout.headerReferenceSize = CGSize(width: UIScreen.main.bounds.width, height: 100)
         let collection: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         collection.register(ContentsCollectionViewCell.self, forCellWithReuseIdentifier: ContentsCollectionViewCell.reuseIdentifier)
-        collection.register(TwoLabelVerticalHeaderView.self, forSupplementaryViewOfKind: TwoLabelVerticalHeaderView.reuseIdentifier, withReuseIdentifier: TwoLabelVerticalHeaderView.reuseIdentifier)
+        collection.register(TwoLabelVerticalHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: TwoLabelVerticalHeaderView.reuseIdentifier)
         
         collection.translatesAutoresizingMaskIntoConstraints = false
         return collection
@@ -200,7 +200,7 @@ extension TrashViewController {
                 alert.changeContentsText("정말 삭제 하시겠어요?\n이 동작은 취소할 수 없습니다")
                 
                 alert.leftButton.rx.tap.bind {
-                    self?.changeEditButton(isCurrentEditMode: true)
+                    self?.changeEditButton(isCurrentEditMode: false)
                     alert.dismiss(animated: false, completion: nil)
                 }
                 .disposed(by: alert.disposeBag)
@@ -258,7 +258,7 @@ extension TrashViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: TwoLabelVerticalHeaderView.reuseIdentifier, withReuseIdentifier: TwoLabelVerticalHeaderView.reuseIdentifier, for: indexPath) as? TwoLabelVerticalHeaderView else {
+        guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: TwoLabelVerticalHeaderView.reuseIdentifier, for: indexPath) as? TwoLabelVerticalHeaderView else {
             return UICollectionReusableView()
         }
         return headerView
@@ -277,7 +277,7 @@ extension TrashViewController: UICollectionViewDelegate {
                 deleteStorage.append(indexPath.item)
                 cell.changeCheckButton(isSelected: true)
             }
-
+            
             var deleteStorageCount: String = String(deleteStorage.count)
             if deleteStorageCount == "0" {
                 deleteStorageCount = ""

--- a/ThingLog/ViewController/TrashViewController.swift
+++ b/ThingLog/ViewController/TrashViewController.swift
@@ -11,6 +11,9 @@ import UIKit
 /// 휴지통 화면을 구성하는 뷰컨트롤러이다.
 final class TrashViewController: UIViewController {
     var coordinator: SettingCoordinator?
+
+    /// 네비게이션바 우측에 있는 선택or취소 버튼이다
+    let editButton: UIButton = UIButton()
     
     private let collectionView: UICollectionView = {
         let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
@@ -27,10 +30,10 @@ final class TrashViewController: UIViewController {
         return collection
     }()
     
-    /// 네비게이션 우측 선택 버튼을 클릭시 나타나는  **삭제 또는 **복구 버튼이 포함된 뷰다.
+    /// 네비게이션 우측 선택 버튼을 클릭시 나타나는  `삭제` 또는 `복구` 버튼이 포함된 뷰다.
     private let deleteButtonView: LeftRightButtonView = {
         let deleteView: LeftRightButtonView = LeftRightButtonView()
-        deleteView.isHidden = true
+        deleteView.clipsToBounds = true
         deleteView.backgroundColor = SwiftGenColors.white.color
         deleteView.translatesAutoresizingMaskIntoConstraints = false
         return deleteView
@@ -59,13 +62,31 @@ final class TrashViewController: UIViewController {
             fetchResultController?.delegate = self
         }
     }
+    // Test 아이템 개수
+    var items: [Int] = Array(repeating: 1, count: 40)
+    
     // CoreData가 외부에서 변경될 때 호출하는 클로저다.
     var completionBlock: ((Int) -> Void)?
     
     /// 현재 휴지통에서 복구또는 삭제 기능을 활성화한 상태인지를 확인하기 위한 프로퍼티다. 활성화한 상태는 true이다.
     private var isEditMode: Bool = false
     
-    private let deleteButtonViewHeight: CGFloat = 54
+    /// 삭제하고자 할 때 잠시 저장해두는 프로퍼티입니다.
+    private var deleteStorage: [Int] = [] {
+        didSet {
+            deleteButtonView.leftButton.setTitle(deleteStorage.isEmpty ? "모두 삭제" : "삭제", for: .normal)
+            deleteButtonView.rightButton.setTitle(deleteStorage.isEmpty ? "모두 복구" : "복구", for: .normal)
+        }
+    }
+    
+    /// 하단의 세이프에리아를 포함한 높이를 반환한다.
+    private var deleteButtonViewHeight: CGFloat {
+        let window: UIWindow? = UIApplication.shared.windows.first
+        let bottomPadding: CGFloat = window?.safeAreaInsets.bottom ?? 00
+        return bottomPadding + 54
+    }
+    
+    private var deleteButtonHeightConstraint: NSLayoutConstraint?
     var disposeBag: DisposeBag = DisposeBag()
     
     // MARK: - Life Cycle
@@ -76,23 +97,28 @@ final class TrashViewController: UIViewController {
         setupEmptyView()
         setupNavigationBar()
         setupRightNavigationBarItem()
+        
+        subscribeEditButton()
+        subscribeDeleteButton()
     }
     
     // MARK: - Setup
     private func setupStackView() {
         view.addSubview(stackView)
+        deleteButtonHeightConstraint = deleteButtonView.heightAnchor.constraint(equalToConstant: 0)
+        deleteButtonHeightConstraint?.isActive = true
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            
-            deleteButtonView.heightAnchor.constraint(equalToConstant: deleteButtonViewHeight)
+            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
+    
     private func setupBaseCollectionView() {
         collectionView.backgroundColor = SwiftGenColors.white.color
         collectionView.dataSource = self
+        collectionView.delegate = self
     }
     
     private func setupEmptyView() {
@@ -101,14 +127,14 @@ final class TrashViewController: UIViewController {
             emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             emptyView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            emptyView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
     
     private func setupNavigationBar() {
         setupBaseNavigationBar()
-        
         let logoView: LogoView = LogoView("휴지통", font: UIFont.Pretendard.headline4)
+        logoView.textAlignment = .center
         navigationItem.titleView = logoView
         
         let backButton: UIButton = UIButton()
@@ -123,32 +149,83 @@ final class TrashViewController: UIViewController {
         navigationItem.leftBarButtonItem = backBarButton
     }
     
-    func setupRightNavigationBarItem() {
-        let editButton: UIButton = UIButton()
+    private func setupRightNavigationBarItem() {
         editButton.setTitle("선택", for: .normal)
         editButton.titleLabel?.font = UIFont.Pretendard.body1
         editButton.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        let editBarButton: UIBarButtonItem = UIBarButtonItem(customView: editButton)
+        let fixedSpace: UIBarButtonItem = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
+        fixedSpace.width = 17
+        navigationItem.rightBarButtonItems = [fixedSpace, editBarButton]
+    }
+    
+    /// 네비게이션 바 우측에 있는 버튼의 타이틀을 변경한다.
+    private func changeEditButton(isCurrentEditMode: Bool) {
+        editButton.setTitle( isCurrentEditMode ? "선택" : "취소", for: .normal)
+    }
+}
+
+extension TrashViewController {
+    /// 네비게이션 바 우측에 있는 버튼을 바인딩한다.
+    private func subscribeEditButton() {
         editButton.rx.tap
             .bind { [weak self] in
-                editButton.setTitle( (self?.isEditMode == true) ? "선택" : "취소", for: .normal)
-                self?.deleteButtonView.isHidden = self?.isEditMode == true
+                self?.changeEditButton(isCurrentEditMode: self?.isEditMode ?? true)
+                if self?.isEditMode == true {
+                    self?.deleteStorage.removeAll()
+                }
+                // 하단에 삭제버튼의 높이를 애니메이션 준다.
+                UIView.animate(withDuration: 0.3) {
+                    self?.deleteButtonHeightConstraint?.constant = (self?.isEditMode == true) ? 0.0 : (self?.deleteButtonViewHeight ?? 0.0)
+                    self?.view.layoutIfNeeded()
+                }
+                
                 self?.isEditMode.toggle()
                 self?.collectionView.reloadData()
             }
             .disposed(by: disposeBag)
-        let editBarButton: UIBarButtonItem = UIBarButtonItem(customView: editButton)
-        let fixedSpace: UIBarButtonItem = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
-        fixedSpace.width = 24
-        navigationItem.rightBarButtonItems = [fixedSpace, editBarButton]
+    }
+    
+    /// 하단의 **삭제 버튼을 바인딩하여, 얼럿뷰를 띄우는 메서드다.
+    private func subscribeDeleteButton() {
+        deleteButtonView.leftButton.rx.tap
+            .bind { [weak self] in
+                let alert: AlertViewController = AlertViewController()
+                alert.modalPresentationStyle = .overFullScreen
+                alert.hideTextField()
+                alert.leftButton.setTitle("취소", for: .normal)
+                alert.rightButton.setTitle("삭제", for: .normal)
+                let text: String = self?.deleteStorage.isEmpty == true ? "전체 게시물 선택" : "\(self?.deleteStorage.count ?? 0)개의 게시물 선택"
+                alert.titleLabel.text = text
+                alert.changeContentsText("정말 삭제 하시겠어요?\n이 동작은 취소할 수 없습니다")
+                
+                alert.leftButton.rx.tap.bind {
+                    self?.changeEditButton(isCurrentEditMode: true)
+                    alert.dismiss(animated: false, completion: nil)
+                }
+                .disposed(by: alert.disposeBag)
+                
+                alert.rightButton.rx.tap.bind { [weak self] in
+                    // TODO: - ⚠️n개일 때 또는 전체일 때 삭제 로직 변경
+                    self?.items.removeAll()
+                    self?.emptyView.isHidden = false
+                    self?.changeEditButton(isCurrentEditMode: true)
+                    alert.dismiss(animated: false, completion: nil)
+                }
+                .disposed(by: alert.disposeBag)
+                
+                self?.present(alert, animated: false)
+            }
+            .disposed(by: disposeBag)
     }
 }
 
 extension TrashViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-//                let numberOfItems: Int = fetchResultController?.fetchedObjects?.count ?? 0
-//                emptyView.isHidden = numberOfItems != 0
-//                return numberOfItems
-        return 15 // Test Code
+        //                let numberOfItems: Int = fetchResultController?.fetchedObjects?.count ?? 0
+        //                emptyView.isHidden = numberOfItems != 0
+        //                return numberOfItems
+        return items.count  // Test Code
     }
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
@@ -168,6 +245,13 @@ extension TrashViewController: UICollectionViewDataSource {
         // 휴지통에서 사용할 경우, ContentsCollectionViewCell의 뷰를 약간 조정한다.
         cell.setupForTrashView()
         cell.checkButton.isHidden = !isEditMode
+        if isEditMode {
+            if deleteStorage.contains(indexPath.item) {
+                cell.changeCheckButton(isSelected: true)
+            } else {
+                cell.changeCheckButton(isSelected: false)
+            }
+        }
         
         cell.backgroundColor = .systemGray
         return cell
@@ -178,6 +262,29 @@ extension TrashViewController: UICollectionViewDataSource {
             return UICollectionReusableView()
         }
         return headerView
+    }
+}
+
+extension TrashViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if isEditMode {
+            guard let cell = collectionView.cellForItem(at: indexPath) as? ContentsCollectionViewCell else { return }
+            
+            if let index: Int = deleteStorage.firstIndex(of: indexPath.item) {
+                deleteStorage.remove(at: index)
+                cell.changeCheckButton(isSelected: false)
+            } else {
+                deleteStorage.append(indexPath.item)
+                cell.changeCheckButton(isSelected: true)
+            }
+
+            var deleteStorageCount: String = String(deleteStorage.count)
+            if deleteStorageCount == "0" {
+                deleteStorageCount = ""
+            }
+            editButton.setTitle(deleteStorageCount + " 취소", for: .normal)
+            editButton.sizeToFit()
+        }
     }
 }
 


### PR DESCRIPTION
## 개요

휴지통에서 삭제하는 과정을 구현함 

## 작업 사항
![trash](https://user-images.githubusercontent.com/48749182/138459386-723cb8c9-802a-44fd-85a1-f6ec12cbd241.gif)
- 네비게이션 바 우측 선택 버튼 클릭시, 삭제가 가능한 상태로 변경. 
    - 이 상태에서 사진들을 여러개 선택할 수 있음.
    - 선택된 개수에 따라 카운팅.
    - 여러개 선택시, 하단의 `모두 삭제` 버튼에서 `삭제` 버튼으로 변경 
    - `**삭제`버튼 클릭시, `Alert` 보여줌 
    - 삭제 시 우선 빈 화면으로 보여줌 
- 추가적으로 홈화면에서 발생하는 오토레이아웃 수정 - `ProfileView` 


## 예외사항 
* 실제 데이터를 삭제하는 로직은 구현하지 않음.
    - 삭제 버튼 누르면 테스트로 무조건 빈화면으로 보여지게 함. 
* 셀들을 선택할 시 체크 버튼 추후에 변경될 예정 
* 노치있는 디바이스 경우에서 처음에 StackView의 오토레이아웃 워닝이 뜨는데 잘 모르겠습니다. 

### Linked Issue

close #125 

