### PR TITLE
[#140] 로그인: 첫 화면 로그인화면으로 설정 및 로그인 버튼 추가 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		DBC45A9C270F24B800AB9499 /* DummyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9B270F24B800AB9499 /* DummyProtocol.swift */; };
 		DBC45A9E270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9D270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift */; };
 		DBC45AA0270F266800AB9499 /* ThingLogPostSearchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9F270F266800AB9499 /* ThingLogPostSearchRequestTests.swift */; };
+		DBD1054D2729560600632168 /* RootCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD1054C2729560600632168 /* RootCoordinator.swift */; };
 		DBD2244527085651004C5184 /* EasyLookViewController+setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244427085651004C5184 /* EasyLookViewController+setup.swift */; };
 		DBD2244727085671004C5184 /* EasyLookViewController+subscribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244627085671004C5184 /* EasyLookViewController+subscribe.swift */; };
 		DBD2244B27085DFB004C5184 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244A27085DFB004C5184 /* SearchViewController.swift */; };
@@ -305,6 +306,7 @@
 		DBC45A9B270F24B800AB9499 /* DummyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyProtocol.swift; sourceTree = "<group>"; };
 		DBC45A9D270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostCategoryRequestTests.swift; sourceTree = "<group>"; };
 		DBC45A9F270F266800AB9499 /* ThingLogPostSearchRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostSearchRequestTests.swift; sourceTree = "<group>"; };
+		DBD1054C2729560600632168 /* RootCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.swift; sourceTree = "<group>"; };
 		DBD2244427085651004C5184 /* EasyLookViewController+setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EasyLookViewController+setup.swift"; sourceTree = "<group>"; };
 		DBD2244627085671004C5184 /* EasyLookViewController+subscribe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EasyLookViewController+subscribe.swift"; sourceTree = "<group>"; };
 		DBD2244A27085DFB004C5184 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
@@ -484,6 +486,7 @@
 				DB7C04A526F5F281009F5C0A /* Coordinator.swift */,
 				DB7C04A926F5F308009F5C0A /* EasyLookCoordinator.swift */,
 				DB7C04A726F5F2BB009F5C0A /* HomeCoordinator.swift */,
+				DBD1054C2729560600632168 /* RootCoordinator.swift */,
 				DB6909622712DB0800BB54E4 /* SettingCoordinator.swift */,
 				87BB17A827098A720088B847 /* WriteCoordinator.swift */,
 			);
@@ -918,6 +921,7 @@
 				DB8BF6792705D25700FD5FDB /* LogoView.swift in Sources */,
 				DBA0F829270B26A0009553FC /* SearchResultsViewController.swift in Sources */,
 				87078B5B26EA44B5007AE242 /* ThingLog.xcdatamodeld in Sources */,
+				DBD1054D2729560600632168 /* RootCoordinator.swift in Sources */,
 				873EC00926D39055003C3525 /* AppDelegate.swift in Sources */,
 				87A86C8B2714139F008FB3F0 /* WriteTextFieldCell.swift in Sources */,
 				87DAEB1B270BEAE50038C487 /* CameraButtonCollectionCell.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		DBC45A9E270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9D270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift */; };
 		DBC45AA0270F266800AB9499 /* ThingLogPostSearchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9F270F266800AB9499 /* ThingLogPostSearchRequestTests.swift */; };
 		DBD1054D2729560600632168 /* RootCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD1054C2729560600632168 /* RootCoordinator.swift */; };
+		DBD105512729726400632168 /* RoundCenterTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD105502729726400632168 /* RoundCenterTextButton.swift */; };
 		DBD2244527085651004C5184 /* EasyLookViewController+setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244427085651004C5184 /* EasyLookViewController+setup.swift */; };
 		DBD2244727085671004C5184 /* EasyLookViewController+subscribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244627085671004C5184 /* EasyLookViewController+subscribe.swift */; };
 		DBD2244B27085DFB004C5184 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244A27085DFB004C5184 /* SearchViewController.swift */; };
@@ -307,6 +308,7 @@
 		DBC45A9D270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostCategoryRequestTests.swift; sourceTree = "<group>"; };
 		DBC45A9F270F266800AB9499 /* ThingLogPostSearchRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostSearchRequestTests.swift; sourceTree = "<group>"; };
 		DBD1054C2729560600632168 /* RootCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.swift; sourceTree = "<group>"; };
+		DBD105502729726400632168 /* RoundCenterTextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundCenterTextButton.swift; sourceTree = "<group>"; };
 		DBD2244427085651004C5184 /* EasyLookViewController+setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EasyLookViewController+setup.swift"; sourceTree = "<group>"; };
 		DBD2244627085671004C5184 /* EasyLookViewController+subscribe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EasyLookViewController+subscribe.swift"; sourceTree = "<group>"; };
 		DBD2244A27085DFB004C5184 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
@@ -566,6 +568,7 @@
 				DBA0F81D2709BD41009553FC /* RecentSearchView.swift */,
 				DB37EC76270C307C00030D9A /* RecentSearchView+update.swift */,
 				DB8BF6802706D89E00FD5FDB /* ResultsWithDropBoxView.swift */,
+				DBD105502729726400632168 /* RoundCenterTextButton.swift */,
 				DB1745B62708700200EF083E /* SearchTextField.swift */,
 				DBA0F81A2709B37C009553FC /* TableVeiwCell */,
 				DB7C04FB26FB27A6009F5C0A /* TemplateImageButton.swift */,
@@ -871,6 +874,7 @@
 				DB7C04EE26FB1ACE009F5C0A /* ContentsTabView.swift in Sources */,
 				DB05B04C271F04E50067DB17 /* TextFieldWithLabelWithButtonCollectionCell.swift in Sources */,
 				DBA0F820270AF0A4009553FC /* ResultCollectionSection.swift in Sources */,
+				DBD105512729726400632168 /* RoundCenterTextButton.swift in Sources */,
 				DB05B056271FEAFA0067DB17 /* LoginViewController+subscribe.swift in Sources */,
 				DB331DAA26FDD00A00A629F5 /* ImageAssets.swift in Sources */,
 				876243E02708701B00BDA1DC /* WriteType.swift in Sources */,

--- a/ThingLog/Coordinator/RootCoordinator.swift
+++ b/ThingLog/Coordinator/RootCoordinator.swift
@@ -1,0 +1,43 @@
+//
+//  RootCoordinator.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/27.
+//
+
+import UIKit
+
+/// 가장 처음에 시작하는 Coordinator로, 로그인화면 또는 바로 홈화면을 보여주도록 하는 객체다.
+final class RootCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+    var navigationController: UINavigationController
+    weak var window: UIWindow?
+    
+    init(window: UIWindow?,
+         navigationController: UINavigationController) {
+        self.navigationController = navigationController
+        self.window = window
+        window?.rootViewController = navigationController
+        window?.makeKeyAndVisible()
+    }
+    
+    // 가장 처음에 시작하는 화면을 결정하는 메소드다.
+    func start() {
+        if UserInformationViewModel.shared.userAliasName == nil {
+            let loginViewController: LoginViewController = LoginViewController(isLogin: true)
+            loginViewController.coordinator = self
+            navigationController.pushViewController(loginViewController, animated: true)
+        } else {
+            showTabBarController()
+        }
+    }
+    
+    // 현재 화면이 LoginViewController인 경우에 홈화면으로 보여주기 위한 메소드다.
+    func showTabBarController() {
+        if let login: LoginViewController = navigationController.topViewController as? LoginViewController {
+            // RootCoordinator, LoginViewContorller 메모리 해제
+            login.coordinator = nil
+        }
+        self.window?.rootViewController = TabBarController()
+    }
+}

--- a/ThingLog/SupportingFiles/SceneDelegate.swift
+++ b/ThingLog/SupportingFiles/SceneDelegate.swift
@@ -16,8 +16,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        window?.rootViewController = TabBarController()
-        window?.makeKeyAndVisible()
+        
+        RootCoordinator(window: window,
+                        navigationController: UINavigationController()).start()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/ThingLog/SwiftGen/ColorsAsset.swift
+++ b/ThingLog/SwiftGen/ColorsAsset.swift
@@ -51,17 +51,6 @@ internal final class ColorSwiftGen {
     return color
   }()
 
-  #if os(iOS) || os(tvOS)
-  @available(iOS 11.0, tvOS 11.0, *)
-  internal func color(compatibleWith traitCollection: UITraitCollection) -> Color {
-    let bundle = BundleToken.bundle
-    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load color asset named \(name).")
-    }
-    return color
-  }
-  #endif
-
   fileprivate init(name: String) {
     self.name = name
   }

--- a/ThingLog/SwiftGen/Fonts.swift
+++ b/ThingLog/SwiftGen/Fonts.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
-#if os(macOS)
+#if os(OSX)
   import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
@@ -38,7 +38,7 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
-  #if os(macOS)
+  #if os(OSX)
   internal typealias Font = NSFont
   #elseif os(iOS) || os(tvOS) || os(watchOS)
   internal typealias Font = UIFont
@@ -69,7 +69,7 @@ internal extension FontConvertible.Font {
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
-    #elseif os(macOS)
+    #elseif os(OSX)
     if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }

--- a/ThingLog/SwiftGen/ImageAssets.swift
+++ b/ThingLog/SwiftGen/ImageAssets.swift
@@ -53,7 +53,6 @@ internal struct ImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -69,21 +68,9 @@ internal struct ImageSwiftGen {
     }
     return result
   }
-
-  #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-  #endif
 }
 
 internal extension ImageSwiftGen.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the ImageSwiftGen.image property")
   convenience init?(asset: ImageSwiftGen) {

--- a/ThingLog/View/HeaderView/LoginTopHeaderView.swift
+++ b/ThingLog/View/HeaderView/LoginTopHeaderView.swift
@@ -4,7 +4,7 @@
 //
 //  Created by hyunsu on 2021/10/19.
 //
-
+import RxSwift
 import UIKit
 
 /// 로그인 화면에 상단에 나타나는 뷰다.  왼쪽에 2열로 보여주는 Label과 우측에 버튼이 있는 Collection HeaderView다.
@@ -51,10 +51,16 @@ final class LoginTopHeaderView: UICollectionReusableView {
     }()
     
     private let paddingConstraint: CGFloat = 20.0
+    var disposeBag: DisposeBag = DisposeBag()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
     }
     
     required init?(coder: NSCoder) {

--- a/ThingLog/View/RoundCenterTextButton.swift
+++ b/ThingLog/View/RoundCenterTextButton.swift
@@ -1,0 +1,24 @@
+//
+//  RoundCenterTextButton.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/10/27.
+//
+
+import UIKit
+
+/// 가운데 흰색 텍스트를 가지면서, 검은색 배경으로, 초기화로 받는 Radius값을 통해 라운딩된 버튼이다. [이미지](https://www.notion.so/RoundCenterTextButton-63d4032c5dae4ebba2e84fc9b7923909)
+class RoundCenterTextButton: UIButton {
+    init(cornerRadius: CGFloat) {
+        super.init(frame: .zero)
+        layer.cornerRadius = cornerRadius
+        clipsToBounds = true
+        backgroundColor = SwiftGenColors.black.color
+        setTitleColor(SwiftGenColors.white.color, for: .normal)
+        titleLabel?.font = UIFont.Pretendard.title1
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/ThingLog/ViewController/LoginViewController.swift
+++ b/ThingLog/ViewController/LoginViewController.swift
@@ -39,11 +39,20 @@ final class LoginViewController: UIViewController {
         return collection
     }()
     
+    private lazy var loginButton: RoundCenterTextButton = {
+        let button: RoundCenterTextButton = RoundCenterTextButton(cornerRadius: loginButtonHeight / 2)
+        button.setTitle("로그인하기", for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
     // MARK: - Properties
     // 로그인 화면인 경우와 아닌 경우에 뷰를 다르게 보여주기 위해 필요한 프로퍼티다.
     var isLogin: Bool
     // TextFeild가 강조된 경우에만 스크롤이 더 가능하기 위해 필요한 프로퍼티다.
     var isEditMode: Bool = false
+    
+    private let loginButtonHeight: CGFloat = 56
     
     let recommendList: [String] = ["나를 찾는 여정", "미니멀리즘", "건강한 소비 습관", "취향모음", "물건의 역사", "물건을 통해 나를 본다"]
     var disposeBag: DisposeBag = DisposeBag()
@@ -64,19 +73,27 @@ final class LoginViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = SwiftGenColors.white.color
-        setupCollectionView()
+        setupView()
         setupNavigationBar()
+        
+        subscribeLoginButton()
     }
     
     // MARK: - Setup
     // TODO: ⚠️ 지원님이 글쓰기 화면에서 구현하실 하단의 검은색버튼 뷰를 재활용하여 추가할 예정이다.
-    private func setupCollectionView() {
+    private func setupView() {
         view.addSubview(collectionView)
+        view.addSubview(loginButton)
         NSLayoutConstraint.activate([
             collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            collectionView.bottomAnchor.constraint(equalTo: loginButton.topAnchor, constant: -20),
+            
+            loginButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            loginButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            loginButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
+            loginButton.heightAnchor.constraint(equalToConstant: isLogin ? loginButtonHeight : 0)
         ])
         collectionView.dataSource = self
         collectionView.delegate = self
@@ -142,6 +159,25 @@ final class LoginViewController: UIViewController {
     }
 }
 
+extension LoginViewController {
+    func subscribeLoginButton() {
+        loginButton.rx.tap.bind { [weak self] in
+            self?.enterTabBarViewController()
+        }.disposed(by: disposeBag)
+    }
+    
+    /// 탭바 화면으로 넘어가는 메소드다
+    private func enterTabBarViewController() {
+        if let rootCordinator: RootCoordinator = coordinator as? RootCoordinator {
+            rootCordinator.showTabBarController()
+            
+            // 테스트를 위해서, 설정화면에서 호출한 경우,
+        } else if let rootCordinator: SettingCoordinator = coordinator as? SettingCoordinator {
+            rootCordinator.back()
+        }
+    }
+}
+
 // MARK: - Collection DataSource
 extension LoginViewController: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
@@ -194,13 +230,7 @@ extension LoginViewController: UICollectionViewDataSource {
             }
             // 다음에 하기 버튼 클릭시 바로 탭바 화면으로 넘어간다.
             login.laterButton.rx.tap.bind { [weak self] in 
-                if let rootCordinator: RootCoordinator = self?.coordinator as? RootCoordinator {
-                    rootCordinator.showTabBarController()
-                
-                // 테스트를 위해서, 설정화면에서 호출한 경우,
-                } else if let rootCordinator: SettingCoordinator = self?.coordinator as? SettingCoordinator {
-                    rootCordinator.back()
-                }
+                self?.enterTabBarViewController()
             }.disposed(by: login.disposeBag)
             return  login
             

--- a/ThingLog/ViewController/LoginViewController.swift
+++ b/ThingLog/ViewController/LoginViewController.swift
@@ -80,7 +80,6 @@ final class LoginViewController: UIViewController {
     }
     
     // MARK: - Setup
-    // TODO: ⚠️ 지원님이 글쓰기 화면에서 구현하실 하단의 검은색버튼 뷰를 재활용하여 추가할 예정이다.
     private func setupView() {
         view.addSubview(collectionView)
         view.addSubview(loginButton)

--- a/ThingLog/ViewController/LoginViewController.swift
+++ b/ThingLog/ViewController/LoginViewController.swift
@@ -192,7 +192,18 @@ extension LoginViewController: UICollectionViewDataSource {
             guard let login = collectionView.dequeueReusableSupplementaryView(ofKind: LoginTopHeaderView.reuseIdentifier, withReuseIdentifier: LoginTopHeaderView.reuseIdentifier, for: indexPath) as? LoginTopHeaderView else {
                 return UICollectionReusableView()
             }
+            // 다음에 하기 버튼 클릭시 바로 탭바 화면으로 넘어간다.
+            login.laterButton.rx.tap.bind { [weak self] in 
+                if let rootCordinator: RootCoordinator = self?.coordinator as? RootCoordinator {
+                    rootCordinator.showTabBarController()
+                
+                // 테스트를 위해서, 설정화면에서 호출한 경우,
+                } else if let rootCordinator: SettingCoordinator = self?.coordinator as? SettingCoordinator {
+                    rootCordinator.back()
+                }
+            }.disposed(by: login.disposeBag)
             return  login
+            
         case LeftLabelRightButtonHeaderView.reuseIdentifier:
             guard let recommend = collectionView.dequeueReusableSupplementaryView(ofKind: LeftLabelRightButtonHeaderView.reuseIdentifier, withReuseIdentifier: LeftLabelRightButtonHeaderView.reuseIdentifier, for: indexPath) as? LeftLabelRightButtonHeaderView else {
                 return UICollectionReusableView()


### PR DESCRIPTION
## 개요

첫 화면 로그인화면으로 설정 및 로그인 버튼 추가 

## 시연 
![login](https://user-images.githubusercontent.com/48749182/139063429-a7d8fe16-93b9-4e71-8d4f-1cf0be096ca1.gif)

## 작업 사항

- 로그인 화면으로 첫 화면 설정하기 위해, `RootCoordinator` 객체를 생성하여 이를 통해 시작하게 했습니다. 
    - 내부적으로 우선 유저이름이 있는지를 통해 `Login`화면 또는 `TabBar`화면으로 보여지게 됩니다. 
    - 추가적으로 메모리 해제가 되는지도 테스트를 했습니다. 
- `RoundCenterTextButton` 을 구현하여, 로그인 경우에서만 버튼이 나타나도록 추가했습니다. 

## 예외사항 
- 실제로 데이터가 반영되지 않습니다. 
- 항상 첫화면은 로그인화면으로 되어있습니다 ( 실제로 데이터를 반영하지 않기 때문 ) 
    - ( 여전히 설정화며에서 다시 로그인화면으로 갈 수 있습니다 ) 


### Linked Issue

close #140 
close #139 

