### PR TITLE
[#152] 카테고리: 카테고리 기능 구현

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		876C157927044BA0000C1C84 /* RepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C157827044BA0000C1C84 /* RepositoryError.swift */; };
 		876C157B27044DFF000C1C84 /* CategoryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C157A27044DFF000C1C84 /* CategoryEntity.swift */; };
 		876C157D27047B19000C1C84 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C157C27047B19000C1C84 /* CategoryRepository.swift */; };
+		8789A19E272C5DCC00CFB16C /* Notification.Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8789A19D272C5DCC00CFB16C /* Notification.Name+.swift */; };
 		87A86C8B2714139F008FB3F0 /* WriteTextFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8A2714139F008FB3F0 /* WriteTextFieldCell.swift */; };
 		87A86C8D271414D2008FB3F0 /* WriteRatingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */; };
 		87A86C8F27141507008FB3F0 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8E27141507008FB3F0 /* RatingView.swift */; };
@@ -222,6 +223,7 @@
 		876C157827044BA0000C1C84 /* RepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryError.swift; sourceTree = "<group>"; };
 		876C157A27044DFF000C1C84 /* CategoryEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryEntity.swift; sourceTree = "<group>"; };
 		876C157C27047B19000C1C84 /* CategoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepository.swift; sourceTree = "<group>"; };
+		8789A19D272C5DCC00CFB16C /* Notification.Name+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+.swift"; sourceTree = "<group>"; };
 		87A86C8A2714139F008FB3F0 /* WriteTextFieldCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTextFieldCell.swift; sourceTree = "<group>"; };
 		87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteRatingCell.swift; sourceTree = "<group>"; };
 		87A86C8E27141507008FB3F0 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
@@ -626,6 +628,7 @@
 				DB7C04EB26FB1A04009F5C0A /* UIView+.swift */,
 				DB7C04C926F9E69D009F5C0A /* UserDefaults+.swift */,
 				DB05B03F27185C500067DB17 /* UIViewController+.swift */,
+				8789A19D272C5DCC00CFB16C /* Notification.Name+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -975,6 +978,7 @@
 				DB7C04F026FB1EFF009F5C0A /* HomeViewController.swift in Sources */,
 				DB148C2027043CFC00FDC48F /* DropBoxView.swift in Sources */,
 				DB331DAB26FDD00A00A629F5 /* Fonts.swift in Sources */,
+				8789A19E272C5DCC00CFB16C /* Notification.Name+.swift in Sources */,
 				8736B3E526FCBA77000433E1 /* RatingEntity+.swift in Sources */,
 				87F2188626FB5DFB00C3FBCA /* Post.swift in Sources */,
 				DBA0F822270AF656009553FC /* ContentsDetailCollectionViewCell.swift in Sources */,

--- a/ThingLog/Extension/Notification.Name+.swift
+++ b/ThingLog/Extension/Notification.Name+.swift
@@ -9,4 +9,5 @@ import Foundation
 
 extension Notification.Name {
     static let passToSelectedCategoryIndexPaths: Notification.Name = Notification.Name("passToSelectedCategoryIndexPaths")
+    static let passToSelectedCategory: Notification.Name = Notification.Name("passToSelectedCategory")
 }

--- a/ThingLog/Extension/Notification.Name+.swift
+++ b/ThingLog/Extension/Notification.Name+.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 extension Notification.Name {
+    /// 선택한 카테고리 IndexPaths를 전달할 때 사용한다.
     static let passToSelectedCategoryIndexPaths: Notification.Name = Notification.Name("passToSelectedCategoryIndexPaths")
-    static let passToSelectedCategory: Notification.Name = Notification.Name("passToSelectedCategory")
+    /// 선택한 카테고리의 IndexPaths와 Category를 전달할 때 사용한다.
+    static let passToSelectedIndexPathsWithCategory: Notification.Name = Notification.Name("passToSelectedIndexPathsWithCategory")
+    /// 삭제한 카테고리의 IndexPath를 전달할 때 사용한다.
+    static let removeSelectedCategory: Notification.Name = Notification.Name("removeSelectedCategory")
 }

--- a/ThingLog/Extension/Notification.Name+.swift
+++ b/ThingLog/Extension/Notification.Name+.swift
@@ -1,0 +1,12 @@
+//
+//  Notification.Name+.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/10/30.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let passToSelectedCategoryIndexPaths: Notification.Name = Notification.Name("passToSelectedCategoryIndexPaths")
+}

--- a/ThingLog/Extension/Notification.Name+.swift
+++ b/ThingLog/Extension/Notification.Name+.swift
@@ -8,10 +8,8 @@
 import Foundation
 
 extension Notification.Name {
-    /// 선택한 카테고리 IndexPaths를 전달할 때 사용한다.
-    static let passToSelectedCategoryIndexPaths: Notification.Name = Notification.Name("passToSelectedCategoryIndexPaths")
-    /// 선택한 카테고리의 IndexPaths와 Category를 전달할 때 사용한다.
-    static let passToSelectedIndexPathsWithCategory: Notification.Name = Notification.Name("passToSelectedIndexPathsWithCategory")
+    /// 선택한 카테고리를 전달할 때 사용한다.
+    static let passToSelectedCategories: Notification.Name = Notification.Name("passToSelectedCategories")
     /// 삭제한 카테고리의 IndexPath를 전달할 때 사용한다.
     static let removeSelectedCategory: Notification.Name = Notification.Name("removeSelectedCategory")
 }

--- a/ThingLog/Model/Category.swift
+++ b/ThingLog/Model/Category.swift
@@ -8,7 +8,7 @@
 import CoreData
 import Foundation
 
-struct Category {
+struct Category: Equatable {
     let identifier: UUID
     let title: String
 
@@ -18,6 +18,10 @@ struct Category {
     init(title: String, identifier: UUID = UUID()) {
         self.identifier = identifier
         self.title = title
+    }
+
+    static func == (lhs: Category, rhs: Category) -> Bool {
+        lhs.title == rhs.title
     }
 }
 

--- a/ThingLog/Repository/CategoryRepository.swift
+++ b/ThingLog/Repository/CategoryRepository.swift
@@ -27,7 +27,7 @@ final class CategoryRepository: CategoryRepositoryProtocol {
 
     lazy var fetchedResultsController: NSFetchedResultsController<CategoryEntity> = {
         let fetchRequest: NSFetchRequest<CategoryEntity> = CategoryEntity.fetchRequest()
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "title", ascending: false)]
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "title", ascending: true)]
 
         let controller: NSFetchedResultsController = NSFetchedResultsController(fetchRequest: fetchRequest,
                                                                                 managedObjectContext: coreDataStack.mainContext,

--- a/ThingLog/Repository/CategoryRepository.swift
+++ b/ThingLog/Repository/CategoryRepository.swift
@@ -49,7 +49,7 @@ final class CategoryRepository: CategoryRepositoryProtocol {
     ///   - completion: 결과를 클로저 형태로 반환한다. 성공했을 경우 무조건 true를 반환하며, 실패했을 경우 PostRepositoryError 타입을 반환한다.
     func create(_ newCategory: Category, completion: @escaping(Result<Bool, RepositoryError>) -> Void) {
         let context: NSManagedObjectContext = coreDataStack.mainContext
-        context.perform {
+        context.performAndWait {
             do {
                 let category: CategoryEntity = newCategory.toEntity(in: context)
                 try context.save()

--- a/ThingLog/View/TableVeiwCell/WriteCategoryTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteCategoryTableCell.swift
@@ -40,7 +40,7 @@ final class WriteCategoryTableCell: UITableViewCell {
 
     // MARK: - Properties
     var indicatorButtonDidTappedCallback: (() -> Void)?
-    var categories: [Category] = [] {
+    var categories: [(indexPath: IndexPath, category: Category)] = [] {
         didSet {
             DispatchQueue.main.async { [weak self] in
                 self?.updateViewByCategories()
@@ -106,9 +106,9 @@ final class WriteCategoryTableCell: UITableViewCell {
 
     /// 카테고리 선택 화면에서 전달 받은 데이터를 저장한다.
     private func bindCategories() {
-        NotificationCenter.default.rx.notification(.passToSelectedCategory, object: nil)
-            .map { notification -> [Category] in
-                notification.userInfo?[Notification.Name.passToSelectedCategory] as? [Category] ?? []
+        NotificationCenter.default.rx.notification(.passToSelectedIndexPathsWithCategory, object: nil)
+            .map { notification -> [(IndexPath, Category)] in
+                notification.userInfo?[Notification.Name.passToSelectedIndexPathsWithCategory] as? [(IndexPath, Category)] ?? []
             }
             .bind { [weak self] categories in
                 self?.categories = categories
@@ -160,9 +160,14 @@ extension WriteCategoryTableCell: UICollectionViewDataSource {
             return LabelWithButtonRoundCollectionCell()
         }
 
-        cell.configure(text: categories[indexPath.row].title)
-        cell.removeButtonDidTappedCallback = {
-            print("touch up \(indexPath.row)")
+        cell.configure(text: categories[indexPath.row].category.title)
+        // 선택한 카테고리를 삭제하려고 할 때 NotificationCenter를 통해 WriteViewModel에게 알린다.
+        cell.removeButtonDidTappedCallback = { [weak self] in
+            guard let self = self else { return }
+            NotificationCenter.default.post(name: .removeSelectedCategory,
+                                            object: nil,
+                                            userInfo: [Notification.Name.removeSelectedCategory: self.categories[indexPath.row].indexPath])
+            self.categories.remove(at: indexPath.row)
         }
 
         return cell

--- a/ThingLog/View/TableVeiwCell/WriteCategoryTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteCategoryTableCell.swift
@@ -40,7 +40,7 @@ final class WriteCategoryTableCell: UITableViewCell {
 
     // MARK: - Properties
     var indicatorButtonDidTappedCallback: (() -> Void)?
-    var categories: [(indexPath: IndexPath, category: Category)] = [] {
+    var categories: [Category] = [] {
         didSet {
             DispatchQueue.main.async { [weak self] in
                 self?.updateViewByCategories()
@@ -106,9 +106,9 @@ final class WriteCategoryTableCell: UITableViewCell {
 
     /// 카테고리 선택 화면에서 전달 받은 데이터를 저장한다.
     private func bindCategories() {
-        NotificationCenter.default.rx.notification(.passToSelectedIndexPathsWithCategory, object: nil)
-            .map { notification -> [(IndexPath, Category)] in
-                notification.userInfo?[Notification.Name.passToSelectedIndexPathsWithCategory] as? [(IndexPath, Category)] ?? []
+        NotificationCenter.default.rx.notification(.passToSelectedCategories, object: nil)
+            .map { notification -> [Category] in
+                notification.userInfo?[Notification.Name.passToSelectedCategories] as? [Category] ?? []
             }
             .bind { [weak self] categories in
                 self?.categories = categories
@@ -139,14 +139,9 @@ final class WriteCategoryTableCell: UITableViewCell {
     /// categories 값이 비어있는 경우 categoryLabel을 보여주고, collecionView를 숨긴다.
     /// categories 값이 있는 경우 categoryLabel을 숨기고 collectionView를 보여주고, collectionView.reloadData()를 호출한다.
     private func updateViewByCategories() {
-        if categories.isEmpty {
-            categoryLabel.isHidden = false
-            collectionView.isHidden = true
-        } else {
-            categoryLabel.isHidden = true
-            collectionView.isHidden = false
-            collectionView.reloadData()
-        }
+        categoryLabel.isHidden = !categories.isEmpty
+        collectionView.isHidden = categories.isEmpty
+        collectionView.reloadData()
     }
 }
 
@@ -160,13 +155,13 @@ extension WriteCategoryTableCell: UICollectionViewDataSource {
             return LabelWithButtonRoundCollectionCell()
         }
 
-        cell.configure(text: categories[indexPath.row].category.title)
+        cell.configure(text: categories[indexPath.row].title)
         // 선택한 카테고리를 삭제하려고 할 때 NotificationCenter를 통해 WriteViewModel에게 알린다.
         cell.removeButtonDidTappedCallback = { [weak self] in
             guard let self = self else { return }
             NotificationCenter.default.post(name: .removeSelectedCategory,
                                             object: nil,
-                                            userInfo: [Notification.Name.removeSelectedCategory: self.categories[indexPath.row].indexPath])
+                                            userInfo: [Notification.Name.removeSelectedCategory: self.categories[indexPath.row]])
             self.categories.remove(at: indexPath.row)
         }
 

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -128,6 +128,8 @@ extension CategoryViewController {
             textField.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topBottomConstant),
             textField.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -leadingTrailingConstant)
         ])
+
+        textField.delegate = self
     }
 
     private func setupBottomLineView() {
@@ -205,6 +207,28 @@ extension CategoryViewController: UITableViewDataSource {
         } else {
             cell.isSelectedCategory = false
         }
+    }
+}
+
+extension CategoryViewController: UITextFieldDelegate {
+    /// 키보드에서 완료 버튼을 누르면 텍스트 필드에 입력한 내용을 Core Data Category에 저장한다.
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard let name: String = textField.text else {
+            return false
+        }
+
+        repository.create(Category(title: name)) { result in
+            switch result {
+            case .success:
+                textField.text = ""
+                textField.sendActions(for: .valueChanged)
+                textField.resignFirstResponder()
+            case .failure(let error):
+                fatalError(error.localizedDescription)
+            }
+        }
+
+        return true
     }
 }
 

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 이지원 on 2021/10/13.
 //
 
+import CoreData
 import UIKit
 
 import RxCocoa
@@ -43,6 +44,7 @@ final class CategoryViewController: UIViewController {
 
     // MARK: - Properties
     var coordinator: Coordinator?
+    private lazy var repository: CategoryRepository = CategoryRepository(fetchedResultsControllerDelegate: self)
     private let disposeBag: DisposeBag = DisposeBag()
     private let leadingTrailingConstant: CGFloat = 18.0
     private let topBottomConstant: CGFloat = 12.0
@@ -180,7 +182,7 @@ extension CategoryViewController: UITableViewDelegate {
 // MARK: - TableView DataSource
 extension CategoryViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        50
+        repository.fetchedResultsController.fetchedObjects?.count ?? 0
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -188,14 +190,26 @@ extension CategoryViewController: UITableViewDataSource {
             return UITableViewCell()
         }
 
-        cell.configure(name: "테스트")
+        configureCell(cell, at: indexPath)
+
+        return cell
+    }
+
+    private func configureCell(_ cell: RoundLabelWithButtonTableCell, at indexPath: IndexPath) {
+        let category: CategoryEntity = repository.fetchedResultsController.object(at: indexPath)
+
+        cell.configure(name: category.title ?? "")
 
         if selectedCategories.contains(indexPath) {
             cell.isSelectedCategory = true
         } else {
             cell.isSelectedCategory = false
         }
+    }
+}
 
-        return cell
+extension CategoryViewController: NSFetchedResultsControllerDelegate {
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        tableView.reloadData()
     }
 }

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -48,7 +48,7 @@ final class CategoryViewController: UIViewController {
     private let disposeBag: DisposeBag = DisposeBag()
     private let leadingTrailingConstant: CGFloat = 18.0
     private let topBottomConstant: CGFloat = 12.0
-    private var selectedCategories: Set<IndexPath> = []
+    private var selectedCategoryIndexPaths: Set<IndexPath> = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -83,8 +83,11 @@ final class CategoryViewController: UIViewController {
     private func setupBinding() {
         successButton.rx.tap
             .bind { [weak self] in
-                // TODO: 카테고리 전달
-                self?.coordinator?.back()
+                guard let self = self else { return }
+                NotificationCenter.default.post(name: .passToSelectedCategoryIndexPaths,
+                                                object: nil,
+                                                userInfo: [Notification.Name.passToSelectedCategoryIndexPaths: self.selectedCategoryIndexPaths])
+                self.coordinator?.back()
             }.disposed(by: disposeBag)
     }
 
@@ -167,7 +170,7 @@ extension CategoryViewController: UITableViewDelegate {
             return
         }
 
-        selectedCategories.insert(indexPath)
+        selectedCategoryIndexPaths.insert(indexPath)
         cell.isSelectedCategory.toggle()
     }
 
@@ -176,7 +179,7 @@ extension CategoryViewController: UITableViewDelegate {
             return
         }
 
-        selectedCategories.remove(indexPath)
+        selectedCategoryIndexPaths.remove(indexPath)
         cell.isSelectedCategory.toggle()
     }
 }
@@ -202,7 +205,7 @@ extension CategoryViewController: UITableViewDataSource {
 
         cell.configure(name: category.title ?? "")
 
-        if selectedCategories.contains(indexPath) {
+        if selectedCategoryIndexPaths.contains(indexPath) {
             cell.isSelectedCategory = true
         } else {
             cell.isSelectedCategory = false

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -87,6 +87,9 @@ final class CategoryViewController: UIViewController {
                 NotificationCenter.default.post(name: .passToSelectedCategoryIndexPaths,
                                                 object: nil,
                                                 userInfo: [Notification.Name.passToSelectedCategoryIndexPaths: self.selectedCategoryIndexPaths])
+                NotificationCenter.default.post(name: .passToSelectedCategory,
+                                                object: nil,
+                                                userInfo: [Notification.Name.passToSelectedCategory: self.selectedCategory()])
                 self.coordinator?.back()
             }.disposed(by: disposeBag)
     }
@@ -118,6 +121,15 @@ final class CategoryViewController: UIViewController {
     @objc
     private func dismissKeyboard() {
         textField.resignFirstResponder()
+    }
+
+    private func selectedCategory() -> [Category] {
+        var categories: [Category] = []
+        selectedCategoryIndexPaths.forEach { indexPath in
+            let categoryEntity: CategoryEntity = repository.fetchedResultsController.object(at: indexPath)
+            categories.append(categoryEntity.toModel())
+        }
+        return categories
     }
 }
 

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -88,7 +88,7 @@ final class CategoryViewController: UIViewController {
                 // 선택한 카테고리를 Category 객체로 변환하여 WriteViewModel, WriteCategoryTableCell에게 전달한다.
                 NotificationCenter.default.post(name: .passToSelectedCategories,
                                                 object: nil,
-                                                userInfo: [Notification.Name.passToSelectedCategories: self.selectedCategory()])
+                                                userInfo: [Notification.Name.passToSelectedCategories: self.convertSelectedIndexPathToCategory()])
                 self.coordinator?.back()
             }.disposed(by: disposeBag)
     }
@@ -123,7 +123,7 @@ final class CategoryViewController: UIViewController {
     }
 
     /// 선택한 카테고리를 Category 객체로 변환해서 오름차순으로 정렬 후 반환한다.
-    private func selectedCategory() -> [Category] {
+    private func convertSelectedIndexPathToCategory() -> [Category] {
         var categories: [Category] = []
         selectedCategoryIndexPaths.forEach { indexPath in
             let categoryEntity: CategoryEntity = repository.fetchedResultsController.object(at: indexPath)

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -84,12 +84,14 @@ final class CategoryViewController: UIViewController {
         successButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
+                // 선택한 카테고리 IndexPath를 WriteViewModel에게 전달한다.
                 NotificationCenter.default.post(name: .passToSelectedCategoryIndexPaths,
                                                 object: nil,
                                                 userInfo: [Notification.Name.passToSelectedCategoryIndexPaths: self.selectedCategoryIndexPaths])
-                NotificationCenter.default.post(name: .passToSelectedCategory,
+                // 선택한 카테고리 IndexPath와 Category를 WriteCategoryTableCell에게 전달한다.
+                NotificationCenter.default.post(name: .passToSelectedIndexPathsWithCategory,
                                                 object: nil,
-                                                userInfo: [Notification.Name.passToSelectedCategory: self.selectedCategory()])
+                                                userInfo: [Notification.Name.passToSelectedIndexPathsWithCategory: self.selectedIndexPathWithCategory()])
                 self.coordinator?.back()
             }.disposed(by: disposeBag)
     }
@@ -123,11 +125,12 @@ final class CategoryViewController: UIViewController {
         textField.resignFirstResponder()
     }
 
-    private func selectedCategory() -> [Category] {
-        var categories: [Category] = []
+    /// 선택한 카테고리를 IndexPath와 함께 Category 객체로 변환해서 반환한다.
+    private func selectedIndexPathWithCategory() -> [(IndexPath, Category)] {
+        var categories: [(IndexPath, Category)] = []
         selectedCategoryIndexPaths.forEach { indexPath in
             let categoryEntity: CategoryEntity = repository.fetchedResultsController.object(at: indexPath)
-            categories.append(categoryEntity.toModel())
+            categories.append((indexPath, categoryEntity.toModel()))
         }
         return categories
     }

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -34,7 +34,7 @@ final class WriteViewModel {
     }
     // Section 마다 표시할 항목의 개수
     lazy var itemCount: [Int] = [1, 1, typeInfo.count, 1, 1]
-    private var selectedCategoryIndexPaths: Set<IndexPath> = []
+    private var selectedCategories: [Category] = []
     private let disposeBag: DisposeBag = DisposeBag()
 
     init(writeType: WriteType) {
@@ -44,32 +44,33 @@ final class WriteViewModel {
     }
 
     private func setupBinding() {
-        bindPassToSelectedCategoryIndexPaths()
-        bindRemoveSelectedCategory()
+        bindNotificationPassToSelectedCategories()
+        bindNotificationRemoveSelectedCategory()
     }
 }
 
 extension WriteViewModel {
     /// `CategoryViewController`에서 전달받은 데이터를 `selectedCategoryIndexPaths`에 저장한다.
-    private func bindPassToSelectedCategoryIndexPaths() {
-        NotificationCenter.default.rx.notification(.passToSelectedCategoryIndexPaths, object: nil)
-            .map { notification -> Set<IndexPath> in
-                notification.userInfo?[Notification.Name.passToSelectedCategoryIndexPaths] as? Set<IndexPath> ?? []
+    private func bindNotificationPassToSelectedCategories() {
+        NotificationCenter.default.rx.notification(.passToSelectedCategories, object: nil)
+            .map { notification -> [Category] in
+                notification.userInfo?[Notification.Name.passToSelectedCategories] as? [Category] ?? []
             }
-            .bind { [weak self] indexPaths in
-                self?.selectedCategoryIndexPaths = indexPaths
+            .bind { [weak self] categories in
+                self?.selectedCategories = categories
             }.disposed(by: disposeBag)
     }
 
     /// `WriteCategoryTableCell` 에서 삭제한 카테고리를 `selectedCategoryIndexPaths`에서도 삭제한다.
-    private func bindRemoveSelectedCategory() {
+    private func bindNotificationRemoveSelectedCategory() {
         NotificationCenter.default.rx.notification(.removeSelectedCategory, object: nil)
-            .map { notification -> IndexPath in
-                notification.userInfo?[Notification.Name.removeSelectedCategory] as? IndexPath ?? IndexPath()
+            .map { notification -> Category? in
+                notification.userInfo?[Notification.Name.removeSelectedCategory] as? Category
             }
-            .bind { [weak self] indexPath in
-                if let firstIndex: Set<IndexPath>.Index = self?.selectedCategoryIndexPaths.firstIndex(of: indexPath) {
-                    self?.selectedCategoryIndexPaths.remove(at: firstIndex)
+            .bind { [weak self] category in
+                if let category: Category = category,
+                   let firstIndex: Int = self?.selectedCategories.firstIndex(of: category) {
+                    self?.selectedCategories.remove(at: firstIndex)
                 }
             }.disposed(by: disposeBag)
     }

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -40,9 +40,17 @@ final class WriteViewModel {
     init(writeType: WriteType) {
         self.writeType = writeType
 
-        bindPassToSelectedCategoryIndexPaths()
+        setupBinding()
     }
 
+    private func setupBinding() {
+        bindPassToSelectedCategoryIndexPaths()
+        bindRemoveSelectedCategory()
+    }
+}
+
+extension WriteViewModel {
+    /// `CategoryViewController`에서 전달받은 데이터를 `selectedCategoryIndexPaths`에 저장한다.
     private func bindPassToSelectedCategoryIndexPaths() {
         NotificationCenter.default.rx.notification(.passToSelectedCategoryIndexPaths, object: nil)
             .map { notification -> Set<IndexPath> in
@@ -50,6 +58,19 @@ final class WriteViewModel {
             }
             .bind { [weak self] indexPaths in
                 self?.selectedCategoryIndexPaths = indexPaths
+            }.disposed(by: disposeBag)
+    }
+
+    /// `WriteCategoryTableCell` 에서 삭제한 카테고리를 `selectedCategoryIndexPaths`에서도 삭제한다.
+    private func bindRemoveSelectedCategory() {
+        NotificationCenter.default.rx.notification(.removeSelectedCategory, object: nil)
+            .map { notification -> IndexPath in
+                notification.userInfo?[Notification.Name.removeSelectedCategory] as? IndexPath ?? IndexPath()
+            }
+            .bind { [weak self] indexPath in
+                if let firstIndex: Set<IndexPath>.Index = self?.selectedCategoryIndexPaths.firstIndex(of: indexPath) {
+                    self?.selectedCategoryIndexPaths.remove(at: firstIndex)
+                }
             }.disposed(by: disposeBag)
     }
 }

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -34,7 +34,7 @@ final class WriteViewModel {
     }
     // Section 마다 표시할 항목의 개수
     lazy var itemCount: [Int] = [1, 1, typeInfo.count, 1, 1]
-    private var passToSelectedCategoryIndexPaths: Set<IndexPath> = []
+    private var selectedCategoryIndexPaths: Set<IndexPath> = []
     private let disposeBag: DisposeBag = DisposeBag()
 
     init(writeType: WriteType) {
@@ -49,7 +49,7 @@ final class WriteViewModel {
                 notification.userInfo?[Notification.Name.passToSelectedCategoryIndexPaths] as? Set<IndexPath> ?? []
             }
             .bind { [weak self] indexPaths in
-                self?.passToSelectedCategoryIndexPaths = indexPaths
+                self?.selectedCategoryIndexPaths = indexPaths
             }.disposed(by: disposeBag)
     }
 }

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RxSwift
+
 final class WriteViewModel {
     enum Section: Int, CaseIterable {
         case image
@@ -32,8 +34,22 @@ final class WriteViewModel {
     }
     // Section 마다 표시할 항목의 개수
     lazy var itemCount: [Int] = [1, 1, typeInfo.count, 1, 1]
+    private var passToSelectedCategoryIndexPaths: Set<IndexPath> = []
+    private let disposeBag: DisposeBag = DisposeBag()
 
     init(writeType: WriteType) {
         self.writeType = writeType
+
+        bindPassToSelectedCategoryIndexPaths()
+    }
+
+    private func bindPassToSelectedCategoryIndexPaths() {
+        NotificationCenter.default.rx.notification(.passToSelectedCategoryIndexPaths, object: nil)
+            .map { notification -> Set<IndexPath> in
+                notification.userInfo?[Notification.Name.passToSelectedCategoryIndexPaths] as? Set<IndexPath> ?? []
+            }
+            .bind { [weak self] indexPaths in
+                self?.passToSelectedCategoryIndexPaths = indexPaths
+            }.disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## 개요

- 카테고리와 관련된 기능 구현

## 동작 화면

<img src="https://user-images.githubusercontent.com/15073405/139523878-a126113a-6a2e-42d7-ba35-4846e731405c.gif" width="50%" />

## 작업 사항

- 카테고리 화면에서 텍스트필드에 입력한 내용을 Core Data에 저장한다.
  - `CategoryRepository`를 이용해 데이터를 저장했습니다.
  - `UITextFieldDelegate.textFieldShouldReturn(_:)`를 이용해 키보드 완료 버튼을 탭했을 때, 데이터를 저장합니다.
    - 데이터가 성공적으로 저장되었다면, `textField`를 초기화하고 키보드를 내립니다. (협의된 부분)
- 카테고리 화면에서 네비게이션 우측 상단 확인 버튼을 눌렀을 때 선택한 카테고리 목록을 `WriteViewModel`과 `WriteCategoryTableCell`에 전달한다.
  - 다른 화면으로 데이터를 전달하기 좋은 다른 방법이 생각나지 않아서 `NotificationCenter`를 사용해 데이터를 전달했습니다.
  - `[IndexPath]` → `WriteViewModel`
    - 현재 `WriteViewModel`에서 `[IndexPath]`를 갖고 있어도 사용하는 곳이 없지만, 이후에 글을 저장할 때 사용할 계획입니다.
  - `[(IndexPath, Category)]` → `WriteCategoryTableCell`
    - `IndexPath`를 같이 전달하는 이유는 글쓰기 화면에서 선택된 카테고리를 삭제할 때 사용하기 위함입니다.
- Core Data에 저장된 카테고리 데이터를 표시한다.
  - `CategoryViewController`에서 전달받은 `[(IndexPath, Category)]`가 있다면 `categoryLabel`을 숨기고 `collectionView`를 표시합니다. 
  - 데이터가 없다면 `categoryLabel`을 표시하고 `collectionView`를 숨깁니다.
- 글쓰기 화면에서 선택된 카테고리를 삭제할 수 있다.
  - `CategoryViewController`에서 `IndexPath`를 같이 전달 받은 이유인데, 카테고리 우측 버튼을 탭하면 `NotificationCenter`를 이용해 해당 `IndexPath`를 전달합니다. `WriteViewModel`에서는 이를 감지해 해당 `IndexPath`를 찾고, 삭제합니다.

### Linked Issue

close #152 
