### PR TITLE
[#177] ref: 새로운 Style Guide 휴지통화면에 적용 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		DB69095F2712C55F00BB54E4 /* SearchResultsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB69095E2712C55F00BB54E4 /* SearchResultsViewModel.swift */; };
 		DB6909612712DA8100BB54E4 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6909602712DA8100BB54E4 /* SettingViewController.swift */; };
 		DB6909632712DB0800BB54E4 /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6909622712DB0800BB54E4 /* SettingCoordinator.swift */; };
+		DB6D05AD2733D47E003002A3 /* CheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6D05AC2733D47E003002A3 /* CheckView.swift */; };
 		DB7C04AA26F5F308009F5C0A /* EasyLookCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04A926F5F308009F5C0A /* EasyLookCoordinator.swift */; };
 		DB7C04B226F87548009F5C0A /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04B126F87548009F5C0A /* TabBarController.swift */; };
 		DB7C04B626F8782B009F5C0A /* EasyLookViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7C04B526F8782B009F5C0A /* EasyLookViewController.swift */; };
@@ -126,10 +127,10 @@
 		DB8BF6792705D25700FD5FDB /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6782705D25700FD5FDB /* LogoView.swift */; };
 		DB8BF6812706D89E00FD5FDB /* ResultsWithDropBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6802706D89E00FD5FDB /* ResultsWithDropBoxView.swift */; };
 		DB8BF6832706DA7900FD5FDB /* EasyLookTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6822706DA7900FD5FDB /* EasyLookTopView.swift */; };
-		DB9FBDBB272EAB62005E64AF /* TrashCoreDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9FBDBA272EAB62005E64AF /* TrashCoreDataTests.swift */; };
 		DB9FBDB2272E8144005E64AF /* UserInformationiCloudTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9FBDB1272E8144005E64AF /* UserInformationiCloudTests.swift */; };
 		DB9FBDB7272E9A11005E64AF /* UserInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9FBDB6272E9A11005E64AF /* UserInformation.swift */; };
 		DB9FBDB9272E9A33005E64AF /* UserInformationiCloudViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9FBDB8272E9A33005E64AF /* UserInformationiCloudViewModel.swift */; };
+		DB9FBDBB272EAB62005E64AF /* TrashCoreDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9FBDBA272EAB62005E64AF /* TrashCoreDataTests.swift */; };
 		DBA0F8192709A79A009553FC /* ThingLogRecentSearchDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA0F8182709A79A009553FC /* ThingLogRecentSearchDataTests.swift */; };
 		DBA0F81C2709B390009553FC /* LeftLabelRightButtonTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA0F81B2709B390009553FC /* LeftLabelRightButtonTableCell.swift */; };
 		DBA0F81E2709BD41009553FC /* RecentSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA0F81D2709BD41009553FC /* RecentSearchView.swift */; };
@@ -306,6 +307,7 @@
 		DB69095E2712C55F00BB54E4 /* SearchResultsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsViewModel.swift; sourceTree = "<group>"; };
 		DB6909602712DA8100BB54E4 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		DB6909622712DB0800BB54E4 /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
+		DB6D05AC2733D47E003002A3 /* CheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckView.swift; sourceTree = "<group>"; };
 		DB7C04A526F5F281009F5C0A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		DB7C04A726F5F2BB009F5C0A /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		DB7C04A926F5F308009F5C0A /* EasyLookCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EasyLookCoordinator.swift; sourceTree = "<group>"; };
@@ -326,10 +328,10 @@
 		DB8BF6782705D25700FD5FDB /* LogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoView.swift; sourceTree = "<group>"; };
 		DB8BF6802706D89E00FD5FDB /* ResultsWithDropBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsWithDropBoxView.swift; sourceTree = "<group>"; };
 		DB8BF6822706DA7900FD5FDB /* EasyLookTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EasyLookTopView.swift; sourceTree = "<group>"; };
-		DB9FBDBA272EAB62005E64AF /* TrashCoreDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashCoreDataTests.swift; sourceTree = "<group>"; };
 		DB9FBDB1272E8144005E64AF /* UserInformationiCloudTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInformationiCloudTests.swift; sourceTree = "<group>"; };
 		DB9FBDB6272E9A11005E64AF /* UserInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInformation.swift; sourceTree = "<group>"; };
 		DB9FBDB8272E9A33005E64AF /* UserInformationiCloudViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInformationiCloudViewModel.swift; sourceTree = "<group>"; };
+		DB9FBDBA272EAB62005E64AF /* TrashCoreDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashCoreDataTests.swift; sourceTree = "<group>"; };
 		DBA0F8182709A79A009553FC /* ThingLogRecentSearchDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogRecentSearchDataTests.swift; sourceTree = "<group>"; };
 		DBA0F81B2709B390009553FC /* LeftLabelRightButtonTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftLabelRightButtonTableCell.swift; sourceTree = "<group>"; };
 		DBA0F81D2709BD41009553FC /* RecentSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchView.swift; sourceTree = "<group>"; };
@@ -612,6 +614,7 @@
 			isa = PBXGroup;
 			children = (
 				87ACB0B127229A3000C78C86 /* CenterTextButton.swift */,
+				DB6D05AC2733D47E003002A3 /* CheckView.swift */,
 				DB7C04B826F87BE9009F5C0A /* ChoiceWritingView.swift */,
 				DB7C04E726FB199A009F5C0A /* CollectionViewCell */,
 				DB7C04ED26FB1ACE009F5C0A /* ContentsTabView.swift */,
@@ -674,14 +677,6 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
-		DB9FBDBC272ECCC7005E64AF /* Trash */ = {
-			isa = PBXGroup;
-			children = (
-				DB9FBDBA272EAB62005E64AF /* TrashCoreDataTests.swift */,
-			);
-			path = Trash;
-            sourceTree = "<group>";
-        };
 		DB9FBDAE272E8120005E64AF /* UserInformationTest */ = {
 			isa = PBXGroup;
 			children = (
@@ -708,6 +703,14 @@
 				DBE3E9C2272FD6B300B3EB69 /* UserInformationViewModelable.swift */,
 			);
 			path = UserInformationViewModel;
+			sourceTree = "<group>";
+		};
+		DB9FBDBC272ECCC7005E64AF /* Trash */ = {
+			isa = PBXGroup;
+			children = (
+				DB9FBDBA272EAB62005E64AF /* TrashCoreDataTests.swift */,
+			);
+			path = Trash;
 			sourceTree = "<group>";
 		};
 		DBA0F81A2709B37C009553FC /* TableVeiwCell */ = {
@@ -777,6 +780,15 @@
 			path = Font;
 			sourceTree = "<group>";
 		};
+		DBE3E9BF272FB9AB00B3EB69 /* Trash */ = {
+			isa = PBXGroup;
+			children = (
+				DB05B03D27185B780067DB17 /* TrashViewController.swift */,
+				DBE3E9C0272FB9BB00B3EB69 /* TrashViewController+Collection.swift */,
+			);
+			path = Trash;
+			sourceTree = "<group>";
+		};
 		DBE3E9C92730137200B3EB69 /* EasyLook */ = {
 			isa = PBXGroup;
 			children = (
@@ -794,15 +806,6 @@
 				DBD2244A27085DFB004C5184 /* SearchViewController.swift */,
 			);
 			path = Search;
-            sourceTree = "<group>";
-        };
-		DBE3E9BF272FB9AB00B3EB69 /* Trash */ = {
-			isa = PBXGroup;
-			children = (
-				DB05B03D27185B780067DB17 /* TrashViewController.swift */,
-				DBE3E9C0272FB9BB00B3EB69 /* TrashViewController+Collection.swift */,
-			);
-			path = Trash;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1109,6 +1112,7 @@
 				DB148C2027043CFC00FDC48F /* DropBoxView.swift in Sources */,
 				DB331DAB26FDD00A00A629F5 /* Fonts.swift in Sources */,
 				8789A19E272C5DCC00CFB16C /* Notification.Name+.swift in Sources */,
+				DB6D05AD2733D47E003002A3 /* CheckView.swift in Sources */,
 				8736B3E526FCBA77000433E1 /* RatingEntity+.swift in Sources */,
 				87F2188626FB5DFB00C3FBCA /* Post.swift in Sources */,
 				DBA0F822270AF656009553FC /* ContentsDetailCollectionViewCell.swift in Sources */,

--- a/ThingLog/View/CheckView.swift
+++ b/ThingLog/View/CheckView.swift
@@ -1,0 +1,36 @@
+//
+//  CheckView.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/11/04.
+//
+
+import UIKit
+/// 내부에 `ImageView`의 `checkmark.circle`을 가지는 액션이 가능한 뷰다. [이미지](https://www.notion.so/CheckView-f3a180f503b64187998ef72a77367f97)
+final class CheckView: UIControl {
+    let imageView: UIImageView = {
+        let imageView: UIImageView = UIImageView()
+        imageView.image = UIImage(systemName: "checkmark.circle")
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.isHidden = true
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    func setupView() {
+        addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: -2),
+            imageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 2),
+            imageView.topAnchor.constraint(equalTo: topAnchor, constant: -2),
+            imageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 2)
+        ])
+    }
+}

--- a/ThingLog/View/CollectionViewCell/ContentsDetailCollectionViewCell.swift
+++ b/ThingLog/View/CollectionViewCell/ContentsDetailCollectionViewCell.swift
@@ -222,6 +222,9 @@ final class ContentsDetailCollectionViewCell: UICollectionViewCell {
     private func setupView() {
         contentView.addSubview(stackView)
         NSLayoutConstraint.activate([
+            topBorderLineView.heightAnchor.constraint(equalToConstant: 0.3),
+            bottomBorderLineView.heightAnchor.constraint(equalToConstant: 0.5),
+            
             stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
@@ -229,10 +232,7 @@ final class ContentsDetailCollectionViewCell: UICollectionViewCell {
             
             imageView.heightAnchor.constraint(equalTo: imageWithRightStackView.heightAnchor),
             imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor),
-            
-            bottomBorderLineView.heightAnchor.constraint(equalToConstant: 0.5),
-            topBorderLineView.heightAnchor.constraint(equalToConstant: 0.5),
-            
+                        
             dateTopEmptyView.heightAnchor.constraint(equalToConstant: 4)
         ])
     }

--- a/ThingLog/View/HeaderView/TwoLabelVerticalHeaderView.swift
+++ b/ThingLog/View/HeaderView/TwoLabelVerticalHeaderView.swift
@@ -15,7 +15,7 @@ class TwoLabelVerticalHeaderView: UICollectionReusableView {
     private let titleLabel: UILabel = {
         let label: UILabel = UILabel()
         label.font = UIFont.Pretendard.title2
-        label.textColor = SwiftGenColors.black.color
+        label.textColor = SwiftGenColors.primaryBlack.color
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         label.setContentHuggingPriority(.required, for: .vertical)
@@ -26,12 +26,12 @@ class TwoLabelVerticalHeaderView: UICollectionReusableView {
     private let subTitleLabel: UILabel = {
         let label: UILabel = UILabel()
         label.font = UIFont.Pretendard.body3
-        label.textColor = SwiftGenColors.black.color
+        label.textColor = SwiftGenColors.primaryBlack.color
         label.setContentHuggingPriority(.required, for: .vertical)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.text = "게시물이 삭제되기까지 남은 날짜를 보여줍니다. 해당 기간이 지나면 항목이 영구적으로 삭제됩니다. 최대 30일이 소요될 수 있습니다"
+        label.text = "게시물이 삭제되기까지 남은 날짜를 보여줍니다. 해당 기간이 지나면 항목이 영구적으로 삭제됩니다. 최대 30일이 소요될 수 있습니다."
         return label
     }()
     

--- a/ThingLog/View/LeftRightButtonView.swift
+++ b/ThingLog/View/LeftRightButtonView.swift
@@ -12,7 +12,7 @@ class LeftRightButtonView: UIView {
     let leftButton: UIButton = {
         let button: UIButton = UIButton()
         button.setTitle("모두 삭제", for: .normal)
-        button.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        button.setTitleColor(SwiftGenColors.systemRed.color, for: .normal)
         button.titleLabel?.font = UIFont.Pretendard.title1
         return button
     }()
@@ -20,14 +20,14 @@ class LeftRightButtonView: UIView {
     let rightButton: UIButton = {
         let button: UIButton = UIButton()
         button.setTitle("모두 복구", for: .normal)
-        button.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        button.setTitleColor(SwiftGenColors.primaryBlack.color, for: .normal)
         button.titleLabel?.font = UIFont.Pretendard.body1
         return button
     }()
     
     private let borderLine: UIView = {
         let view: UIView = UIView()
-        view.backgroundColor = SwiftGenColors.gray4.color
+        view.backgroundColor = SwiftGenColors.gray2.color
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -43,7 +43,7 @@ class LeftRightButtonView: UIView {
     
     private let topLineView: UIView = {
         let view: UIView = UIView()
-        view.backgroundColor = SwiftGenColors.gray4.color
+        view.backgroundColor = SwiftGenColors.gray2.color
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/ThingLog/ViewController/AlertViewController.swift
+++ b/ThingLog/ViewController/AlertViewController.swift
@@ -226,6 +226,7 @@ final class AlertViewController: UIViewController {
             UIView.animate(withDuration: 0.15) {
                 self.setBackgroundColorTint()
                 self.alertView.transform = .identity
+                UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
             }
         }
     }

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -71,12 +71,12 @@ class ContentsCollectionViewCell: UICollectionViewCell {
     }()
     
     /// 우측 상단에 체크하기 위한 버튼이다. ( 주로 휴지통 화면에서 삭제 또는 복구하기 위해 사용되는 버튼이다. )
-    let checkButton: UIButton = {
-        let button: UIButton = UIButton()
+    let checkButton: CheckView = {
+        let button: CheckView = CheckView()
         button.layer.borderWidth = 1
+        button.imageView.tintColor = SwiftGenColors.white.color
         button.layer.borderColor = SwiftGenColors.white.color.cgColor
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.titleLabel?.font = UIFont.Pretendard.overline
         button.isHidden = true
         button.isUserInteractionEnabled = false
         return button
@@ -167,7 +167,7 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         super.layoutSubviews()
         bottomGradientView.frame = contentView.bounds
         bottomGradientView.frame.size.height = contentView.bounds.height / 4
-        bottomGradientView.setGradient(startColor: SwiftGenColors.black.color,
+        bottomGradientView.setGradient(startColor: SwiftGenColors.primaryBlack.color,
                                        endColor: .clear,
                                        startPoint: CGPoint(x: 0.0, y: 1.0),
                                        endPoint: CGPoint(x: 0.0, y: 0.0))
@@ -182,10 +182,10 @@ extension ContentsCollectionViewCell {
         bottomLabel.isHidden = false
     }
     
-    // TODO: - ⚠️버튼 색이나 디자인 변경예정
     /// 체크버튼을 강조하거나 강조하지 않도록 변경하는 메서드다
     func changeCheckButton(isSelected: Bool) {
-        checkButton.layer.borderColor = isSelected ? SwiftGenColors.black.color.cgColor : SwiftGenColors.white.color.cgColor
-        checkButton.backgroundColor = isSelected ? SwiftGenColors.black.color : .clear
+        checkButton.imageView.isHidden = !isSelected
+        checkButton.backgroundColor = isSelected ? SwiftGenColors.systemGreen.color : .clear
+        checkButton.layer.borderColor = isSelected ? UIColor.clear.cgColor : SwiftGenColors.white.color.cgColor
     }
 }

--- a/ThingLog/ViewController/ContentsCollection/PostContentsCollectionViewController.swift
+++ b/ThingLog/ViewController/ContentsCollection/PostContentsCollectionViewController.swift
@@ -31,11 +31,10 @@ class PostContentsCollectionViewController: BaseContentsCollectionViewController
         let collectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewCompositionalLayout(section: section))
         collectionView.register(ContentsDetailCollectionViewCell.self, forCellWithReuseIdentifier: ContentsDetailCollectionViewCell.reuseIdentifier)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.backgroundColor = .white
         self.collectionView = collectionView
         
         view.addSubview(collectionView)
-        collectionView.backgroundColor = SwiftGenColors.white.color
+        collectionView.backgroundColor = SwiftGenColors.primaryBackground.color
         collectionView.dataSource = self
         collectionView.delegate = self
         NSLayoutConstraint.activate([

--- a/ThingLog/ViewController/Drawer/SelectingDrawerViewController.swift
+++ b/ThingLog/ViewController/Drawer/SelectingDrawerViewController.swift
@@ -87,6 +87,7 @@ class SelectingDrawerViewController: UIViewController {
         UIView.animate(withDuration: 0.35, delay: 0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0, options: .curveEaseInOut) {
             self.dimmedView.backgroundColor = .black.withAlphaComponent(0.6)
             self.popupViewBottomAnchor?.constant = 0
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
             self.view.layoutIfNeeded()
         }
     }

--- a/ThingLog/ViewController/TabBarController.swift
+++ b/ThingLog/ViewController/TabBarController.swift
@@ -152,6 +152,7 @@ extension TabBarController {
                 self.choiceView.hide(false)
                 self.dimmedView.backgroundColor = .black.withAlphaComponent(0.6)
                 self.rotatePlusButton(isRecovery: false)
+                UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
                 self.view.layoutIfNeeded()
             }
         }

--- a/ThingLog/ViewController/Trash/TrashViewController.swift
+++ b/ThingLog/ViewController/Trash/TrashViewController.swift
@@ -15,6 +15,12 @@ final class TrashViewController: UIViewController {
     /// 네비게이션바 우측에 있는 선택or취소 버튼이다
     let editButton: UIButton = UIButton()
     
+    let topBorderLineView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     let collectionView: UICollectionView = {
         let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumInteritemSpacing = 1
@@ -34,7 +40,6 @@ final class TrashViewController: UIViewController {
     private let deleteButtonView: LeftRightButtonView = {
         let deleteView: LeftRightButtonView = LeftRightButtonView()
         deleteView.clipsToBounds = true
-        deleteView.backgroundColor = SwiftGenColors.white.color
         deleteView.translatesAutoresizingMaskIntoConstraints = false
         return deleteView
     }()
@@ -53,7 +58,6 @@ final class TrashViewController: UIViewController {
         let view: EmptyResultsView = EmptyResultsView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isHidden = true
-        view.backgroundColor = SwiftGenColors.white.color
         view.label.text = "휴지통이 비었습니다"
         return view
     }()
@@ -98,6 +102,7 @@ final class TrashViewController: UIViewController {
         setupEmptyView()
         setupNavigationBar()
         setupRightNavigationBarItem()
+        setupBackgroundColor()
         
         subscribeEditButton()
         subscribeDeleteButton()
@@ -107,20 +112,33 @@ final class TrashViewController: UIViewController {
     }
     
     // MARK: - Setup
+    private func setupBackgroundColor() {
+        collectionView.backgroundColor = SwiftGenColors.primaryBackground.color
+        emptyView.backgroundColor = SwiftGenColors.primaryBackground.color
+        deleteButtonView.backgroundColor = SwiftGenColors.primaryBackground.color
+        topBorderLineView.backgroundColor = SwiftGenColors.gray4.color
+    }
+    
     private func setupStackView() {
         view.addSubview(stackView)
+        view.addSubview(topBorderLineView)
+        
         deleteButtonHeightConstraint = deleteButtonView.heightAnchor.constraint(equalToConstant: 0)
         deleteButtonHeightConstraint?.isActive = true
         NSLayoutConstraint.activate([
+            topBorderLineView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            topBorderLineView.heightAnchor.constraint(equalToConstant: 0.5),
+            topBorderLineView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topBorderLineView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stackView.topAnchor.constraint(equalTo: topBorderLineView.bottomAnchor),
             stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
     
     private func setupBaseCollectionView() {
-        collectionView.backgroundColor = SwiftGenColors.white.color
         collectionView.dataSource = self
         collectionView.delegate = self
     }
@@ -142,8 +160,8 @@ final class TrashViewController: UIViewController {
         navigationItem.titleView = logoView
         
         let backButton: UIButton = UIButton()
-        backButton.setImage(SwiftGenAssets.paddingBack.image, for: .normal)
-        backButton.tintColor = SwiftGenColors.black.color
+        backButton.setImage(SwiftGenIcons.longArrowR.image, for: .normal)
+        backButton.tintColor = SwiftGenColors.primaryBlack.color
         backButton.rx.tap
             .bind { [weak self] in
                 self?.coordinator?.back()
@@ -156,7 +174,7 @@ final class TrashViewController: UIViewController {
     private func setupRightNavigationBarItem() {
         editButton.setTitle("선택", for: .normal)
         editButton.titleLabel?.font = UIFont.Pretendard.body1
-        editButton.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        editButton.setTitleColor(SwiftGenColors.primaryBlack.color, for: .normal)
         let editBarButton: UIBarButtonItem = UIBarButtonItem(customView: editButton)
         let fixedSpace: UIBarButtonItem = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
         fixedSpace.width = 17


### PR DESCRIPTION
## 개요

새로운 Style Guide 휴지통화면에 적용 

![trash](https://user-images.githubusercontent.com/48749182/140294209-1e284c29-9e6f-4449-ab01-a19ef8abdbba.gif)


## 작업 사항
- ⚠️`CheckView`를 구현하는 것, TextField우측 x버튼 구현하는 것 외에는 크게 코드를 작성한 점은 없습니다. 이외는 대부분 색 및 아이콘 변경하는 코드가 대다수 입니다. 

## 작업 세부 사항 
- 휴지통화면 색 및 아이콘 변경 
- 휴지통화면 삭제하기 위해 체크하는 버튼 뷰 생성 
    - `CheckView` 구현. 
    - `systemImage`를 이용하여 체크버튼 구현. 
- 진동모션 코드 한줄 추가 
- 검색화면의 textField 우측에 X버튼 뜨도록 구현 ( 지원님 코드 참고 )
- 검색결과화면 색 변경. 

### Linked Issue

close #177 
close #172 
close #176 

