### PR TITLE
[#187] 기타: 다크모드 색상 추가

### DIFF
--- a/ThingLog/Resource/Colors.xcassets/gray2.colorset/Contents.json
+++ b/ThingLog/Resource/Colors.xcassets/gray2.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.380",
-          "green" : "0.380",
-          "red" : "0.380"
+          "blue" : "0.741",
+          "green" : "0.741",
+          "red" : "0.741"
         }
       },
       "idiom" : "universal"

--- a/ThingLog/Resource/Colors.xcassets/primaryBackground.colorset/Contents.json
+++ b/ThingLog/Resource/Colors.xcassets/primaryBackground.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.929",
-          "green" : "0.968",
-          "red" : "1.000"
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"

--- a/ThingLog/Resource/Colors.xcassets/primaryBlack.colorset/Contents.json
+++ b/ThingLog/Resource/Colors.xcassets/primaryBlack.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.000",
-          "red" : "0.000"
+          "blue" : "0.929",
+          "green" : "0.969",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/ThingLog/Resource/Colors.xcassets/systemGreen.colorset/Contents.json
+++ b/ThingLog/Resource/Colors.xcassets/systemGreen.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.427",
-          "green" : "0.534",
-          "red" : "0.254"
+          "blue" : "0.314",
+          "green" : "0.400",
+          "red" : "0.192"
         }
       },
       "idiom" : "universal"

--- a/ThingLog/Resource/Colors.xcassets/systemRed.colorset/Contents.json
+++ b/ThingLog/Resource/Colors.xcassets/systemRed.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.095",
-          "green" : "0.209",
-          "red" : "0.809"
+          "blue" : "0.133",
+          "green" : "0.275",
+          "red" : "0.969"
         }
       },
       "idiom" : "universal"

--- a/ThingLog/Resource/Colors.xcassets/white.colorset/Contents.json
+++ b/ThingLog/Resource/Colors.xcassets/white.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## 개요

스타일 가이드에 추가된 다크모드 대응 색상 추가

## 작업 사항

- Primary_Background
- Gray 2
- Primary_Black
- White
- SystemRed
- SystemGreen

## 예외 사항

`Colors.xcassets` 파일에 색상 추가만 했습니다.

### Linked Issue

close #187 

