### PR TITLE
[#203] feat: PhotoCardCoordinatorProtocol 구현

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		DBE3E9C3272FD6B300B3EB69 /* UserInformationViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE3E9C2272FD6B300B3EB69 /* UserInformationViewModelable.swift */; };
 		DBE3E9C6272FF25A00B3EB69 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBE3E9C5272FF25A00B3EB69 /* Icons.xcassets */; };
 		DBE3E9C8272FF32D00B3EB69 /* IconsAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE3E9C7272FF32D00B3EB69 /* IconsAssets.swift */; };
+		DBFF2C602744C5F400A2CEE9 /* PhotoCardCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFF2C5F2744C5F400A2CEE9 /* PhotoCardCoordinator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -450,6 +451,7 @@
 		DBE3E9C2272FD6B300B3EB69 /* UserInformationViewModelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInformationViewModelable.swift; sourceTree = "<group>"; };
 		DBE3E9C5272FF25A00B3EB69 /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Icons.xcassets; sourceTree = "<group>"; };
 		DBE3E9C7272FF32D00B3EB69 /* IconsAssets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconsAssets.swift; sourceTree = "<group>"; };
+		DBFF2C5F2744C5F400A2CEE9 /* PhotoCardCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCardCoordinator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -736,6 +738,7 @@
 				DB6909622712DB0800BB54E4 /* SettingCoordinator.swift */,
 				DB73BB06273A61CE00719DF6 /* SplashCoordinator.swift */,
 				87BB17A827098A720088B847 /* WriteCoordinator.swift */,
+				DBFF2C5F2744C5F400A2CEE9 /* PhotoCardCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -1324,6 +1327,7 @@
 				87A86C8F27141507008FB3F0 /* RatingView.swift in Sources */,
 				DB05B04E271F09260067DB17 /* LoginTopHeaderView.swift in Sources */,
 				DB7C04F026FB1EFF009F5C0A /* HomeViewController.swift in Sources */,
+				DBFF2C602744C5F400A2CEE9 /* PhotoCardCoordinator.swift in Sources */,
 				DB148C2027043CFC00FDC48F /* DropBoxView.swift in Sources */,
 				DB331DAB26FDD00A00A629F5 /* Fonts.swift in Sources */,
 				DB6D05AD2733D47E003002A3 /* CheckView.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -734,11 +734,11 @@
 				DB7C04A726F5F2BB009F5C0A /* HomeCoordinator.swift */,
 				DBD1054C2729560600632168 /* LoginCoordinator.swift */,
 				DB7B4701274102B300426EF1 /* OnboardingCoordinator.swift */,
+				DBFF2C5F2744C5F400A2CEE9 /* PhotoCardCoordinator.swift */,
 				87EDCFD327312517002C98BE /* PostCoordinator.swift */,
 				DB6909622712DB0800BB54E4 /* SettingCoordinator.swift */,
 				DB73BB06273A61CE00719DF6 /* SplashCoordinator.swift */,
 				87BB17A827098A720088B847 /* WriteCoordinator.swift */,
-				DBFF2C5F2744C5F400A2CEE9 /* PhotoCardCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";

--- a/ThingLog/Coordinator/PhotoCardCoordinator.swift
+++ b/ThingLog/Coordinator/PhotoCardCoordinator.swift
@@ -1,0 +1,15 @@
+//
+//  PhotoCardCoordinator.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/11/17.
+//
+
+import Foundation
+import UIKit.UIImage
+
+protocol PhotoCardCoordinatorProtocol: Coordinator {
+    /// `PhotoCardViewController`를 보여준다. `PhotoCardViewController`에서 데이터를 표시하기 위해 `PostEntity`와 특정 이미지`UIImage`가 필요하다.
+    func showPhotoCardController(post: PostEntity,
+                                 image: UIImage)
+}

--- a/ThingLog/SupportingFiles/Info.plist
+++ b/ThingLog/SupportingFiles/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>18</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ThingLogTests/Info.plist
+++ b/ThingLogTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>18</string>
 </dict>
 </plist>

--- a/ThingLogUITests/Info.plist
+++ b/ThingLogUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>18</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 개요

- `PhotoCardCoordinatorProtocol` 구현
- 게시물화면에서 포토카드 버튼을 누를 경우,  `PhotoCardCoordinatorProtocol`을 채택한 `Coordinator`를 이용하여, `showPhotoCardController(post: PostEntity, image: UIImage)` 를 호출하면 됩니다.  
    - `image`는 현재 게시물화면에서 보고 있는 이미지를 전달하시면 됩니다. ( 이미지가 여러개 일 수 있으므로 )  
    - `PhotoEntity`가 필요한 이유는 포토카드에 정보가 필요하기 때문입니다 

### Linked Issue

close #203 

