### PR TITLE
[#204, #205]  ref: 병연님 피드백 반영 1.0.0 ( 18 ), 선택적 다크모드 구현

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		DB8BF6792705D25700FD5FDB /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6782705D25700FD5FDB /* LogoView.swift */; };
 		DB8BF6812706D89E00FD5FDB /* ResultsWithDropBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6802706D89E00FD5FDB /* ResultsWithDropBoxView.swift */; };
 		DB8BF6832706DA7900FD5FDB /* EasyLookTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8BF6822706DA7900FD5FDB /* EasyLookTopView.swift */; };
+		DB8F078027462ADF00F708E2 /* AnimationJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8F077F27462ADF00F708E2 /* AnimationJson.swift */; };
 		DB98FBC32744E596002409BF /* PhotoCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB98FBC22744E596002409BF /* PhotoCardViewController.swift */; };
 		DB98FBC62744E5BC002409BF /* LabelWithUnderLineVerticalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB98FBC52744E5BC002409BF /* LabelWithUnderLineVerticalView.swift */; };
 		DB98FBC82744E5EF002409BF /* ImageViewWithSelectViewCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB98FBC72744E5EF002409BF /* ImageViewWithSelectViewCollectionCell.swift */; };
@@ -416,6 +417,7 @@
 		DB8BF6782705D25700FD5FDB /* LogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoView.swift; sourceTree = "<group>"; };
 		DB8BF6802706D89E00FD5FDB /* ResultsWithDropBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsWithDropBoxView.swift; sourceTree = "<group>"; };
 		DB8BF6822706DA7900FD5FDB /* EasyLookTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EasyLookTopView.swift; sourceTree = "<group>"; };
+		DB8F077F27462ADF00F708E2 /* AnimationJson.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationJson.swift; sourceTree = "<group>"; };
 		DB98FBC22744E596002409BF /* PhotoCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCardViewController.swift; sourceTree = "<group>"; };
 		DB98FBC52744E5BC002409BF /* LabelWithUnderLineVerticalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelWithUnderLineVerticalView.swift; sourceTree = "<group>"; };
 		DB98FBC72744E5EF002409BF /* ImageViewWithSelectViewCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewWithSelectViewCollectionCell.swift; sourceTree = "<group>"; };
@@ -713,6 +715,7 @@
 				DB1111F127352EE800D02F99 /* onboarding2.json */,
 				DBD37BD8274255F2000FDDBC /* onboarding2Dark.json */,
 				DBD37BD5274253D1000FDDBC /* splash.json */,
+				DB8F077F27462ADF00F708E2 /* AnimationJson.swift */,
 			);
 			path = Lottie;
 			sourceTree = "<group>";
@@ -1413,6 +1416,7 @@
 				DB98FBDA2745ADA9002409BF /* PhotoCardInset.swift in Sources */,
 				DBA0F81C2709B390009553FC /* LeftLabelRightButtonTableCell.swift in Sources */,
 				DBD3A21D2743AEF50001F9BF /* HomeViewController+subscribe.swift in Sources */,
+				DB8F078027462ADF00F708E2 /* AnimationJson.swift in Sources */,
 				875A966026F0E4EB001BF0D0 /* CoreDataStack.swift in Sources */,
 				DB6909612712DA8100BB54E4 /* SettingViewController.swift in Sources */,
 				87B1B6572715E2F0001EA889 /* WriteCategoryTableCell.swift in Sources */,

--- a/ThingLog/Extension/UIViewController+.swift
+++ b/ThingLog/Extension/UIViewController+.swift
@@ -24,5 +24,24 @@ extension UIViewController {
             navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
         }
     }
+    
+    func setDarkMode() {
+        let userInformationViewModel: UserInformationViewModelable = UserInformationiCloudViewModel()
+        userInformationViewModel.fetchUserInformation { userInfor in
+            guard let userInfor = userInfor else {
+                return
+            }
+            let darkMode: Bool = userInfor.isAumatedDarkMode
+            if darkMode {
+                self.overrideUserInterfaceStyle = .dark
+                self.navigationController?.overrideUserInterfaceStyle = .dark
+                self.tabBarController?.overrideUserInterfaceStyle = .dark
+            } else {
+                self.overrideUserInterfaceStyle = .light
+                self.navigationController?.overrideUserInterfaceStyle = .light
+                self.tabBarController?.overrideUserInterfaceStyle = .light
+            }
+        }
+    }
 }
  

--- a/ThingLog/Resource/Lottie/AnimationJson.swift
+++ b/ThingLog/Resource/Lottie/AnimationJson.swift
@@ -1,0 +1,23 @@
+//
+//  AnimationName.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/11/18.
+//
+
+import Foundation
+
+/// Lottie 용 애니메이션 json 파일의 이름을 돕는 객체다.
+enum AnimationJson: String {
+    case drawerNew
+    case drawerNewDark
+    case onboarding1
+    case onboarding1Dark
+    case onboarding2
+    case onboarding2Dark
+    case splash
+    
+    var name: String {
+        self.rawValue
+    }
+}

--- a/ThingLog/View/ProfileView.swift
+++ b/ThingLog/View/ProfileView.swift
@@ -132,25 +132,12 @@ final class ProfileView: UIView {
         setupBackgroundColor()
         setupView()
         setupBadgeView()
+        setupDarkModeForAnimation()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setupView()
-    }
-    
-    // 다크모드 감지
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        
-        guard UIApplication.shared.applicationState == .inactive else {
-            return
-        }
-        newBadgeAnimationView.animation = Animation.named(self.traitCollection.userInterfaceStyle == .dark ? "drawerNewDark" : "drawerNew")
-        if newBadgeAnimationView.isHidden { return }
-        DispatchQueue.main.async {
-            self.newBadgeAnimationView.play()
-        }
     }
     
     // MARK: - SetUp
@@ -206,6 +193,27 @@ final class ProfileView: UIView {
             
             badgeView.widthAnchor.constraint(equalTo: newBadgeAnimationView.heightAnchor)
         ])
+    }
+    
+    /// 다크모드 설정 여부에 따라 애니메이션 뷰의 색을 변경해준다. AnimationView는 다른 아이콘과 다르게 다크모드 라이트모드에 대응하는 쌍이 없기 때문에, 따로 로직을 추가했다. 
+    func setupDarkModeForAnimation() {
+        let userInformationViewModel: UserInformationViewModelable = UserInformationiCloudViewModel()
+        userInformationViewModel.fetchUserInformation { userInfor in
+            if let userInfor: UserInformationable = userInfor {
+                let darkMode: Bool = userInfor.isAumatedDarkMode
+                if darkMode {
+                    self.newBadgeAnimationView.animation = Animation.named("drawerNewDark")
+                } else {
+                    self.newBadgeAnimationView.animation = Animation.named("drawerNew")
+                }
+            } else {
+                self.newBadgeAnimationView.animation = Animation.named(self.traitCollection.userInterfaceStyle == .dark ? "drawerNewDark" : "drawerNew")
+            }
+            if self.newBadgeAnimationView.isHidden { return }
+            DispatchQueue.main.async {
+                self.newBadgeAnimationView.play()
+            }
+        }
     }
 }
 

--- a/ThingLog/View/ProfileView.swift
+++ b/ThingLog/View/ProfileView.swift
@@ -55,7 +55,7 @@ final class ProfileView: UIView {
     }()
     
     lazy var newBadgeAnimationView: AnimationView = {
-        let view: AnimationView = self.traitCollection.userInterfaceStyle == .dark ? AnimationView(name: "drawerNewDark") : AnimationView(name: "drawerNew")
+        let view: AnimationView = self.traitCollection.userInterfaceStyle == .dark ? AnimationView(name: AnimationJson.drawerNewDark.name) : AnimationView(name: AnimationJson.drawerNew.name)
         view.animationSpeed = 1.0
         view.loopMode = .loop
         view.isHidden = true
@@ -202,12 +202,12 @@ final class ProfileView: UIView {
             if let userInfor: UserInformationable = userInfor {
                 let darkMode: Bool = userInfor.isAumatedDarkMode
                 if darkMode {
-                    self.newBadgeAnimationView.animation = Animation.named("drawerNewDark")
+                    self.newBadgeAnimationView.animation = Animation.named(AnimationJson.drawerNewDark.name)
                 } else {
-                    self.newBadgeAnimationView.animation = Animation.named("drawerNew")
+                    self.newBadgeAnimationView.animation = Animation.named(AnimationJson.drawerNew.name)
                 }
             } else {
-                self.newBadgeAnimationView.animation = Animation.named(self.traitCollection.userInterfaceStyle == .dark ? "drawerNewDark" : "drawerNew")
+                self.newBadgeAnimationView.animation = Animation.named(self.traitCollection.userInterfaceStyle == .dark ? AnimationJson.drawerNewDark.name : AnimationJson.drawerNew.name)
             }
             if self.newBadgeAnimationView.isHidden { return }
             DispatchQueue.main.async {

--- a/ThingLog/ViewController/AlertViewController.swift
+++ b/ThingLog/ViewController/AlertViewController.swift
@@ -203,6 +203,7 @@ final class AlertViewController: UIViewController {
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        setDarkMode()
         view.backgroundColor = .clear
         view.layoutIfNeeded()
         

--- a/ThingLog/ViewController/BaseViewController.swift
+++ b/ThingLog/ViewController/BaseViewController.swift
@@ -15,7 +15,7 @@ class BaseViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        setDarkMode()
         view.backgroundColor = SwiftGenColors.primaryBackground.color
 
         setupNavigationBar()

--- a/ThingLog/ViewController/Drawer/SelectingDrawerViewController.swift
+++ b/ThingLog/ViewController/Drawer/SelectingDrawerViewController.swift
@@ -30,7 +30,7 @@ class SelectingDrawerViewController: UIViewController {
         label.textAlignment = .center
         label.numberOfLines = 0
         label.font = UIFont.Pretendard.body2
-        label.textColor = SwiftGenColors.systemBlue.color
+        label.textColor = SwiftGenColors.systemGreen.color
         label.translatesAutoresizingMaskIntoConstraints = false
         label.setContentHuggingPriority(.init(rawValue: 50), for: .vertical)
         return label

--- a/ThingLog/ViewController/Drawer/SelectingDrawerViewController.swift
+++ b/ThingLog/ViewController/Drawer/SelectingDrawerViewController.swift
@@ -83,6 +83,7 @@ class SelectingDrawerViewController: UIViewController {
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        setDarkMode()
         addSubView()
         setupDimmedView()
         setupPopupView()

--- a/ThingLog/ViewController/Home/HomeViewController.swift
+++ b/ThingLog/ViewController/Home/HomeViewController.swift
@@ -67,6 +67,7 @@ final class HomeViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        setDarkMode()
         fetchRepresentativeDrawer()
     }
     
@@ -195,6 +196,7 @@ extension HomeViewController {
                 self.profileView.newBadgeAnimationView.isHidden = true
                 return
             }
+            self.profileView.setupDarkModeForAnimation()
             DispatchQueue.main.async {
                 self.profileView.newBadgeAnimationView.isHidden = false
                 self.profileView.newBadgeAnimationView.play()

--- a/ThingLog/ViewController/Login/LoginViewController.swift
+++ b/ThingLog/ViewController/Login/LoginViewController.swift
@@ -56,7 +56,9 @@ final class LoginViewController: UIViewController {
     let recommendList: [String] = ["나를 찾는 여정", "미니멀리즘", "건강한 소비 습관", "취향모음", "물건의 역사", "물건을 통해 나를 본다"]
     var disposeBag: DisposeBag = DisposeBag()
     
-    var userInformation: UserInformationable = UserInformation(userAliasName: "", userOneLineIntroduction: "", isAumatedDarkMode: true)
+    var userInformation: UserInformationable = UserInformation(userAliasName: "",
+                                                               userOneLineIntroduction: "",
+                                                               isAumatedDarkMode: false)
     private let userInformationViewModel: UserInformationViewModelable = UserInformationiCloudViewModel()
     
     // MARK: - Init
@@ -77,7 +79,7 @@ final class LoginViewController: UIViewController {
         setupBackgroundColor()
         setupView()
         setupNavigationBar()
-        setupUserInformation()
+        fetchUserInformation()
         
         subscribeLoginButton()
     }
@@ -156,9 +158,9 @@ final class LoginViewController: UIViewController {
         navigationItem.rightBarButtonItems = [fixedSpace, editBarButton]
     }
     
-    func setupUserInformation() {
+    func fetchUserInformation() {
         userInformationViewModel.fetchUserInformation { userInformation in
-            if let userInformation = userInformation {
+            if let userInformation: UserInformationable = userInformation {
                 self.userInformation = userInformation
                 self.collectionView.reloadData()
             }

--- a/ThingLog/ViewController/Onboarding/List/OnboardingPage1ViewController.swift
+++ b/ThingLog/ViewController/Onboarding/List/OnboardingPage1ViewController.swift
@@ -17,7 +17,7 @@ final class OnboardingPage1ViewController: UIViewController {
     }()
     
     lazy var startAnimationView: AnimationView = {
-        let view: AnimationView = self.traitCollection.userInterfaceStyle == .dark ? AnimationView(name: "onboarding1Dark") : AnimationView(name: "onboarding1")
+        let view: AnimationView = self.traitCollection.userInterfaceStyle == .dark ? AnimationView(name: AnimationJson.onboarding1Dark.name) : AnimationView(name: AnimationJson.onboarding1.name)
         view.animationSpeed = 1.0
         view.loopMode = .loop
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -84,7 +84,7 @@ final class OnboardingPage1ViewController: UIViewController {
         guard UIApplication.shared.applicationState == .inactive else {
             return
         }
-        startAnimationView.animation = Animation.named(self.traitCollection.userInterfaceStyle == .dark ? "onboarding1Dark" : "onboarding1")
+        startAnimationView.animation = Animation.named(self.traitCollection.userInterfaceStyle == .dark ? AnimationJson.onboarding1Dark.name : AnimationJson.onboarding1.name)
         DispatchQueue.main.async {
             self.startAnimationView.play()
         }

--- a/ThingLog/ViewController/Onboarding/List/OnboardingPage2ViewController.swift
+++ b/ThingLog/ViewController/Onboarding/List/OnboardingPage2ViewController.swift
@@ -17,7 +17,7 @@ final class OnboardingPage2ViewController: UIViewController {
     }()
     
     lazy var startAnimationView: AnimationView = {
-        let view: AnimationView = self.traitCollection.userInterfaceStyle == .dark ? AnimationView(name: "onboarding2Dark") : AnimationView(name: "onboarding2")
+        let view: AnimationView = self.traitCollection.userInterfaceStyle == .dark ? AnimationView(name: AnimationJson.onboarding2Dark.name) : AnimationView(name: AnimationJson.onboarding2.name)
         view.animationSpeed = 1.0
         view.loopMode = .loop
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -124,7 +124,7 @@ final class OnboardingPage2ViewController: UIViewController {
             return
         }
         
-        startAnimationView.animation = Animation.named(self.traitCollection.userInterfaceStyle == .dark ? "onboarding2Dark" : "onboarding2")
+        startAnimationView.animation = Animation.named(self.traitCollection.userInterfaceStyle == .dark ? AnimationJson.onboarding2Dark.name : AnimationJson.onboarding2.name)
         DispatchQueue.main.async {
             self.startAnimationView.play()
         }

--- a/ThingLog/ViewController/Onboarding/OnboardingStartViewController.swift
+++ b/ThingLog/ViewController/Onboarding/OnboardingStartViewController.swift
@@ -54,7 +54,6 @@ final class OnboardingStartViewController: UIViewController {
     
     // MARK: - Properties
     private let topPaddingForLogo: CGFloat = 33
-    private let logoHeight: CGFloat = 120
     private let startButtonHeight: CGFloat = 52
     private let leadingPadding: CGFloat = 20
     private let startButtonPadding: CGFloat = 20
@@ -86,8 +85,8 @@ final class OnboardingStartViewController: UIViewController {
             titleView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             
             logoView.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: topPaddingForLogo),
-            logoView.heightAnchor.constraint(equalToConstant: logoHeight),
-            logoView.widthAnchor.constraint(equalToConstant: logoHeight),
+            logoView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.26),
+            logoView.heightAnchor.constraint(equalTo: logoView.widthAnchor),
             logoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 
             startButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: startButtonPadding),

--- a/ThingLog/ViewController/Onboarding/OnboardingStartViewController.swift
+++ b/ThingLog/ViewController/Onboarding/OnboardingStartViewController.swift
@@ -62,6 +62,7 @@ final class OnboardingStartViewController: UIViewController {
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        setDarkMode()
         view.backgroundColor = SwiftGenColors.primaryBackground.color
         setupView()
         setupBaseNavigationBar()

--- a/ThingLog/ViewController/Photos/AlbumsViewController.swift
+++ b/ThingLog/ViewController/Photos/AlbumsViewController.swift
@@ -75,7 +75,7 @@ final class AlbumsViewController: BaseViewController {
 // MARK: - Private
 extension AlbumsViewController {
     private func setupCollectionView() {
-        view.backgroundColor = .white
+        view.backgroundColor = SwiftGenColors.primaryBackground.color
 
         view.addSubview(collectionView)
 

--- a/ThingLog/ViewController/SettingViewController.swift
+++ b/ThingLog/ViewController/SettingViewController.swift
@@ -97,6 +97,7 @@ final class SettingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setDarkMode()
         setupTableView()
         setupNavigationBar()
         setupBackgroundColor()
@@ -187,6 +188,7 @@ extension SettingViewController: UITableViewDataSource {
                             return
                         }
                         self?.userInformationViewModel.updateUserInformation(userInformation)
+                        self?.setDarkMode()
                     }
                     .disposed(by: cell.disposeBag)
                 

--- a/ThingLog/ViewController/SplashViewController.swift
+++ b/ThingLog/ViewController/SplashViewController.swift
@@ -30,8 +30,8 @@ class SplashViewController: UIViewController {
         NSLayoutConstraint.activate([
             starAnimationView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             starAnimationView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            starAnimationView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.65),
-            starAnimationView.heightAnchor.constraint(equalTo: starAnimationView.widthAnchor)
+            starAnimationView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.26),
+            starAnimationView.heightAnchor.constraint(equalTo: starAnimationView.widthAnchor, multiplier: 2)
         ])
         
         // 애니메이션 동작후, 뷰컨트롤러 전환.

--- a/ThingLog/ViewController/SplashViewController.swift
+++ b/ThingLog/ViewController/SplashViewController.swift
@@ -12,7 +12,7 @@ class SplashViewController: UIViewController {
     var coordinator: SplashCoordinator?
     
     let starAnimationView: AnimationView = {
-        let view: AnimationView = AnimationView(name: "splash")
+        let view: AnimationView = AnimationView(name: AnimationJson.splash.name)
         view.animationSpeed = 1.0
         view.translatesAutoresizingMaskIntoConstraints = false
         return view

--- a/ThingLog/ViewController/SplashViewController.swift
+++ b/ThingLog/ViewController/SplashViewController.swift
@@ -20,6 +20,7 @@ class SplashViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setDarkMode()
         setupView()
     }
     

--- a/ThingLog/ViewController/TabBarController.swift
+++ b/ThingLog/ViewController/TabBarController.swift
@@ -35,6 +35,7 @@ final class TabBarController: UITabBarController {
     // MARK: - Life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        setDarkMode()
         setupView()
         setupWriteView()
         setupDimmedView()


### PR DESCRIPTION
## 개요

- 병연님 피드백 반영 1.0.0 ( 18 )
- 선택적 다크모드 구현

![dark](https://user-images.githubusercontent.com/48749182/142357626-3644d9e1-dc09-4c6d-bf03-f276a5b322e9.gif)

## 작업 사항
-  진열장 대표물건 설정할 때 나오는 파란색 글씨 -> 시스템 그린 으로 변경
- 스플래시 모션 사이즈가 좀 큰거같은데 100(가로)x200 사이즈로 비율로 맞춤
- 온보딩Start화면의 로고 사이즈 100x99.62사이즈로 비율로 맞춤

- 선택적 다크모드는 `UIViewController` `extension`하여, `setDarkMode()` 메소드 구현하여, 이 메소드를 삽입함. 
- 추가적으로, 홈 - #205  - 진열장 반짝이는 애니메이션은 위와 비슷한 로직으로 따로 구현하여 호출함. 

### Linked Issue

close #204 
close #205

