### PR TITLE
[#221, #220] feat:  카테고리 수정 기능 구현 및 다크모드 대응 ,  모아보기 다크모드 버그 수정 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		DBC45A9C270F24B800AB9499 /* DummyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9B270F24B800AB9499 /* DummyProtocol.swift */; };
 		DBC45A9E270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9D270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift */; };
 		DBC45AA0270F266800AB9499 /* ThingLogPostSearchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC45A9F270F266800AB9499 /* ThingLogPostSearchRequestTests.swift */; };
+		DBC4C6642748B85B00F50D7B /* ModifyCategoryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC4C6632748B85B00F50D7B /* ModifyCategoryCoordinator.swift */; };
 		DBD1054D2729560600632168 /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD1054C2729560600632168 /* LoginCoordinator.swift */; };
 		DBD105512729726400632168 /* RoundCenterTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD105502729726400632168 /* RoundCenterTextButton.swift */; };
 		DBD2244527085651004C5184 /* EasyLookViewController+setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2244427085651004C5184 /* EasyLookViewController+setup.swift */; };
@@ -461,6 +462,7 @@
 		DBC45A9B270F24B800AB9499 /* DummyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyProtocol.swift; sourceTree = "<group>"; };
 		DBC45A9D270F25E400AB9499 /* ThingLogPostCategoryRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostCategoryRequestTests.swift; sourceTree = "<group>"; };
 		DBC45A9F270F266800AB9499 /* ThingLogPostSearchRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostSearchRequestTests.swift; sourceTree = "<group>"; };
+		DBC4C6632748B85B00F50D7B /* ModifyCategoryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyCategoryCoordinator.swift; sourceTree = "<group>"; };
 		DBD1054C2729560600632168 /* LoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinator.swift; sourceTree = "<group>"; };
 		DBD105502729726400632168 /* RoundCenterTextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundCenterTextButton.swift; sourceTree = "<group>"; };
 		DBD2244427085651004C5184 /* EasyLookViewController+setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EasyLookViewController+setup.swift"; sourceTree = "<group>"; };
@@ -773,6 +775,7 @@
 				DB7C04A926F5F308009F5C0A /* EasyLookCoordinator.swift */,
 				DB7C04A726F5F2BB009F5C0A /* HomeCoordinator.swift */,
 				DBD1054C2729560600632168 /* LoginCoordinator.swift */,
+				DBC4C6632748B85B00F50D7B /* ModifyCategoryCoordinator.swift */,
 				DB7B4701274102B300426EF1 /* OnboardingCoordinator.swift */,
 				DBFF2C5F2744C5F400A2CEE9 /* PhotoCardCoordinator.swift */,
 				87EDCFD327312517002C98BE /* PostCoordinator.swift */,
@@ -1347,6 +1350,7 @@
 				DB00D218272A8DB0003FC9C3 /* DrawerCoordinator.swift in Sources */,
 				DB7C04BE26F9BE72009F5C0A /* ProfileView.swift in Sources */,
 				DB1745B927098E8A00EF083E /* RecentSearchDataViewModel.swift in Sources */,
+				DBC4C6642748B85B00F50D7B /* ModifyCategoryCoordinator.swift in Sources */,
 				DB7C04B626F8782B009F5C0A /* EasyLookViewController.swift in Sources */,
 				873ED12D272AC96000C9F7F1 /* BaseViewController.swift in Sources */,
 				8715B3B1273AC00B007A3A88 /* PostViewController+DataSource.swift in Sources */,

--- a/ThingLog/Coordinator/ModifyCategoryCoordinator.swift
+++ b/ThingLog/Coordinator/ModifyCategoryCoordinator.swift
@@ -1,0 +1,21 @@
+//
+//  ModifyCategoryCoordinator.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/11/20.
+//
+
+import Foundation
+
+protocol ModifyCategoryCoordinator: Coordinator {
+    func showCategoryViewController()
+}
+
+extension ModifyCategoryCoordinator {
+    /// CategoryViewController로 이동한다.
+    func showCategoryViewController() {
+        let categoryViewController: CategoryViewController = CategoryViewController(categoryViewType: .modify)
+        categoryViewController.coordinator = self
+        navigationController.pushViewController(categoryViewController, animated: true)
+    }
+}

--- a/ThingLog/Coordinator/SettingCoordinator.swift
+++ b/ThingLog/Coordinator/SettingCoordinator.swift
@@ -8,7 +8,9 @@
 import UIKit
 
 /// 설정화면에서 뷰전환을 돕는 Coordinator이다.
-final class SettingCoordinator: PostCoordinatorProtocol, PhotoCardCoordinatorProtocol {
+final class SettingCoordinator: PostCoordinatorProtocol,
+                                PhotoCardCoordinatorProtocol,
+                                ModifyCategoryCoordinator {
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
     

--- a/ThingLog/Coordinator/WriteCoordinator.swift
+++ b/ThingLog/Coordinator/WriteCoordinator.swift
@@ -35,7 +35,7 @@ final class WriteCoordinator: SystemSettingCoordinatorProtocol {
 
     /// CategoryViewController로 이동한다.
     func showCategoryViewController() {
-        let categoryViewController: CategoryViewController = CategoryViewController()
+        let categoryViewController: CategoryViewController = CategoryViewController(categoryViewType: .select)
         categoryViewController.coordinator = self
         navigationController.pushViewController(categoryViewController, animated: true)
     }

--- a/ThingLog/Repository/CategoryRepository.swift
+++ b/ThingLog/Repository/CategoryRepository.swift
@@ -128,4 +128,16 @@ final class CategoryRepository: CategoryRepositoryProtocol {
             }
         }
     }
+    
+    /// CategoryEntity의 변경사항을 업데이트 한다.
+    func update() {
+        let context: NSManagedObjectContext = coreDataStack.mainContext
+        context.performAndWait {
+            do {
+                try context.save()
+            } catch {
+               fatalError()
+            }
+        }
+    }
 }

--- a/ThingLog/SwiftGen/ColorsAsset.swift
+++ b/ThingLog/SwiftGen/ColorsAsset.swift
@@ -59,17 +59,6 @@ internal final class ColorSwiftGen {
     return color
   }()
 
-  #if os(iOS) || os(tvOS)
-  @available(iOS 11.0, tvOS 11.0, *)
-  internal func color(compatibleWith traitCollection: UITraitCollection) -> Color {
-    let bundle = BundleToken.bundle
-    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load color asset named \(name).")
-    }
-    return color
-  }
-  #endif
-
   fileprivate init(name: String) {
     self.name = name
   }

--- a/ThingLog/SwiftGen/DrawersAssets.swift
+++ b/ThingLog/SwiftGen/DrawersAssets.swift
@@ -42,7 +42,6 @@ internal struct DrawerImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -58,21 +57,9 @@ internal struct DrawerImageSwiftGen {
     }
     return result
   }
-
-  #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-  #endif
 }
 
 internal extension DrawerImageSwiftGen.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the DrawerImageSwiftGen.image property")
   convenience init?(asset: DrawerImageSwiftGen) {

--- a/ThingLog/SwiftGen/Fonts.swift
+++ b/ThingLog/SwiftGen/Fonts.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
-#if os(macOS)
+#if os(OSX)
   import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
@@ -38,7 +38,7 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
-  #if os(macOS)
+  #if os(OSX)
   internal typealias Font = NSFont
   #elseif os(iOS) || os(tvOS) || os(watchOS)
   internal typealias Font = UIFont
@@ -69,7 +69,7 @@ internal extension FontConvertible.Font {
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
-    #elseif os(macOS)
+    #elseif os(OSX)
     if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }

--- a/ThingLog/SwiftGen/FrameAssets.swift
+++ b/ThingLog/SwiftGen/FrameAssets.swift
@@ -46,7 +46,6 @@ internal struct FrameImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -62,21 +61,9 @@ internal struct FrameImageSwiftGen {
     }
     return result
   }
-
-  #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-  #endif
 }
 
 internal extension FrameImageSwiftGen.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the FrameImageSwiftGen.image property")
   convenience init?(asset: FrameImageSwiftGen) {

--- a/ThingLog/SwiftGen/IconsAssets.swift
+++ b/ThingLog/SwiftGen/IconsAssets.swift
@@ -76,7 +76,6 @@ internal struct IconImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -92,21 +91,9 @@ internal struct IconImageSwiftGen {
     }
     return result
   }
-
-  #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-  #endif
 }
 
 internal extension IconImageSwiftGen.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the IconImageSwiftGen.image property")
   convenience init?(asset: IconImageSwiftGen) {

--- a/ThingLog/SwiftGen/ImageAssets.swift
+++ b/ThingLog/SwiftGen/ImageAssets.swift
@@ -56,7 +56,6 @@ internal struct ImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -72,21 +71,9 @@ internal struct ImageSwiftGen {
     }
     return result
   }
-
-  #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-  #endif
 }
 
 internal extension ImageSwiftGen.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the ImageSwiftGen.image property")
   convenience init?(asset: ImageSwiftGen) {

--- a/ThingLog/View/CollectionViewCell/ButtonRoundCollectionCell.swift
+++ b/ThingLog/View/CollectionViewCell/ButtonRoundCollectionCell.swift
@@ -64,7 +64,9 @@ extension ButtonRoundCollectionCell {
     }
     
     /// 버튼의 layer, background, text 컬러를 변경한다.
-    func changeColor(borderColor: UIColor, backgroundColor: UIColor, textColor: UIColor) {
+    func changeColor(borderColor: UIColor,
+                     backgroundColor: UIColor,
+                     textColor: UIColor) {
         button.backgroundColor = backgroundColor
         button.layer.borderColor = borderColor.cgColor
         button.setTitleColor(textColor, for: .normal)

--- a/ThingLog/View/HorizontalCollectionView.swift
+++ b/ThingLog/View/HorizontalCollectionView.swift
@@ -32,7 +32,7 @@ final class HorizontalCollectionView: UIView {
     var completionBlock: ((Int) -> Void)?
     
     // 이전의 선택한 셀을 찾기 위한 프로퍼티입니다.
-    private var selectedIndexCell: (indexPath: IndexPath, cell: ButtonRoundCollectionCell) = (IndexPath(row: 0, section: 0), ButtonRoundCollectionCell())
+    private var selectedIndexPath: IndexPath = IndexPath(row: 0, section: 0)
     private let buttonHeight: CGFloat = 26
     
     // 특정 Category를 선택할 때 마다 전달하기 위한 subject입니다.
@@ -101,7 +101,7 @@ extension HorizontalCollectionView: UICollectionViewDataSource {
             return cell
         }
         
-        if selectedIndexCell.indexPath == indexPath {
+        if selectedIndexPath == indexPath {
             changeButtonColor(isSelected: true, cell: cell)
             categoryTitleSubject.onNext(item[indexPath.row].title ?? "")
         } else {
@@ -123,20 +123,9 @@ extension HorizontalCollectionView: UICollectionViewDataSource {
 
 extension HorizontalCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let cell = collectionView.cellForItem(at: indexPath) as? ButtonRoundCollectionCell else {
-            return
-        }
-        changeButtonColor(isSelected: true, cell: cell)
+        collectionView.reloadData()
         
-        // 이전의 선택한 셀이 안보이는 경우에는 cellForItem(at) 으로 찾을 수 없기 때문에, 이전의 저장한 셀에서 색을 변경한다.
-        if selectedIndexCell.indexPath != indexPath {
-            changeButtonColor(isSelected: false, cell: selectedIndexCell.cell)
-            if let cell: ButtonRoundCollectionCell = collectionView.cellForItem(at: selectedIndexCell.indexPath) as? ButtonRoundCollectionCell {
-                changeButtonColor(isSelected: false, cell: cell)
-            }
-        }
-        
-        selectedIndexCell = (indexPath, cell)
+        selectedIndexPath = indexPath
         
         guard let item = fetchResultController?.fetchedObjects else {
             return
@@ -148,6 +137,7 @@ extension HorizontalCollectionView: UICollectionViewDelegate {
 
 extension HorizontalCollectionView: NSFetchedResultsControllerDelegate {
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        selectedIndexPath.item = 0 
         collectionView.reloadData()
         completionBlock?(controller.fetchedObjects?.count ?? 0)
     }

--- a/ThingLog/View/TableVeiwCell/RoundLabelWithButtonTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/RoundLabelWithButtonTableCell.swift
@@ -4,7 +4,7 @@
 //
 //  Created by 이지원 on 2021/10/13.
 //
-
+import RxSwift
 import UIKit
 
 /// 카테고리 화면에서 카테고리를 선택할 때 사용하는 셀
@@ -12,16 +12,28 @@ import UIKit
 /// [이미지](https://www.notion.so/RoundLabelWithButtonTableCell-6f22273ede304c1caf3e6170dbcd3a50)
 final class RoundLabelWithButtonTableCell: UITableViewCell {
     // MARK: - View Properties
-    private let nameLabel: PaddingLabel = {
-        let label: PaddingLabel = PaddingLabel(padding: .init(top: 1, left: 8, bottom: 1, right: 8))
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.Pretendard.body1
-        label.textColor = SwiftGenColors.black.color
-        label.text = "사무용품"
-        label.clipsToBounds = true
-        label.layer.cornerRadius = 10
-        label.backgroundColor = SwiftGenColors.gray6.color
-        return label
+    // 기존에는 PaddingLabel이였지만 수정기능을 위해 textField로 변경
+    var nameLabel: UITextField = {
+        let textField: UITextField = UITextField()
+        textField.font = UIFont.Pretendard.body1
+        textField.textColor = SwiftGenColors.primaryBlack.color
+        textField.backgroundColor = SwiftGenColors.primaryBackground.color
+        textField.layer.cornerRadius = 12
+        textField.layer.borderWidth = 0.5
+        textField.layer.borderColor = SwiftGenColors.primaryBlack.color.cgColor
+        
+        let paddingLeadignView: UIView = UIView(frame: CGRect(x: 0, y: 0, width: 8, height: 10))
+            textField.leftView = paddingLeadignView
+        textField.leftViewMode = .always
+        let paddingTrailingView: UIView = UIView(frame: CGRect(x: 0, y: 0, width: 8, height: 10))
+        textField.rightView = paddingTrailingView
+        textField.rightViewMode = .always
+        
+        textField.returnKeyType = .done
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textField.isUserInteractionEnabled = false
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        return textField
     }()
 
     private let emptyView: UIView = {
@@ -36,30 +48,72 @@ final class RoundLabelWithButtonTableCell: UITableViewCell {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.clipsToBounds = true
         button.layer.borderWidth = 1
-        button.layer.borderColor = SwiftGenColors.black.color.cgColor
+        button.layer.borderColor = SwiftGenColors.primaryBlack.color.cgColor
+        button.backgroundColor = SwiftGenColors.primaryBackground.color
         button.titleLabel?.font = UIFont.Pretendard.body3
         button.setTitleColor(SwiftGenColors.white.color, for: .normal)
         button.isUserInteractionEnabled = false
         return button
     }()
+    
+    // MARK: - 수정, 삭제 뷰
+    let modifyButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.titleLabel?.font = UIFont.Pretendard.body2
+        button.setTitle("수정", for: .normal)
+        button.setTitleColor(SwiftGenColors.primaryBlack.color, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    let deleteButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.setTitle("삭제", for: .normal)
+        button.titleLabel?.font = UIFont.Pretendard.body2
+        button.setTitleColor(SwiftGenColors.systemRed.color, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private lazy var modifyStackView: UIStackView = {
+        let stackView: UIStackView = UIStackView(arrangedSubviews: [modifyButton, deleteButton])
+        stackView.spacing = 16
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.isHidden = true
+        return stackView
+    }()
 
     // MARK: - Properties
+    /// 카테고리 수정 및 삭제 기능뷰에서 텍스트필드 툴바의 취소버튼을 누를 때 발생하는 이벤트를 담는 클로저다.
+    var textFieldCancleToolbarCompletion: (() -> Void)?
     var isSelectedCategory: Bool = false {
         didSet {
-            selectedButton.backgroundColor = isSelectedCategory ? SwiftGenColors.black.color : SwiftGenColors.white.color
+            selectedButton.backgroundColor = isSelectedCategory ? SwiftGenColors.primaryBlack.color : SwiftGenColors.primaryBackground.color
         }
     }
+    var textFieldMaxLength: Int = 0 
     private let buttonSize: CGFloat = 24.0
     private let paddingLeadingTrailing: CGFloat = 18.0
     private let paddingTopBottom: CGFloat = 12.0
-
+    
+    var disposeBag: DisposeBag = DisposeBag()
+    
+    //MARK: - Init
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupView()
+        setupToolbar()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        nameLabel.isUserInteractionEnabled = false
+        disposeBag = DisposeBag()
     }
 
     func configure(name: String) {
@@ -68,6 +122,11 @@ final class RoundLabelWithButtonTableCell: UITableViewCell {
 
     func configure(selectedOrder: Int) {
         selectedButton.setTitle("\(selectedOrder)", for: .normal)
+    }
+    /// type에 따라, 선택 기능뷰 인지, 수정 삭제 기능 뷰인지 뷰를 세팅한다.
+    func configure(type: CategoryViewController.CategoryViewType) {
+        modifyStackView.isHidden = type == .select ? true : false
+        selectedButton.isHidden = type == .select ? false : true
     }
 }
 
@@ -78,7 +137,10 @@ extension RoundLabelWithButtonTableCell {
         selectedButton.layer.cornerRadius = buttonSize / 2
 
         let stackView: UIStackView = {
-            let stackView: UIStackView = UIStackView(arrangedSubviews: [nameLabel, emptyView, selectedButton])
+            let stackView: UIStackView = UIStackView(arrangedSubviews: [nameLabel,
+                                                                        emptyView,
+                                                                        selectedButton,
+                                                                        modifyStackView])
             stackView.translatesAutoresizingMaskIntoConstraints = false
             stackView.axis = .horizontal
             return stackView
@@ -92,7 +154,56 @@ extension RoundLabelWithButtonTableCell {
             stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -paddingLeadingTrailing),
             stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingTopBottom),
             selectedButton.widthAnchor.constraint(equalToConstant: buttonSize),
-            selectedButton.heightAnchor.constraint(equalTo: selectedButton.widthAnchor)
+            selectedButton.heightAnchor.constraint(equalTo: selectedButton.widthAnchor),
+            
+            emptyView.widthAnchor.constraint(greaterThanOrEqualToConstant: 10)
         ])
+    }
+    
+    private func setupToolbar() {
+        let keyboardToolBar: UIToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
+        keyboardToolBar.barStyle = .default
+        let cancleButton: UIButton = {
+            let button: UIButton = UIButton()
+            button.titleLabel?.font = UIFont.Pretendard.title2
+            button.setTitle("취소", for: .normal)
+            button.setTitleColor(SwiftGenColors.systemBlue.color, for: .normal)
+            button.addTarget(self, action: #selector(dismissKeyboard), for: .touchUpInside)
+            return button
+        }()
+        let cancleBarButton: UIBarButtonItem = UIBarButtonItem(customView: cancleButton)
+        cancleBarButton.tintColor = SwiftGenColors.black.color
+        keyboardToolBar.barTintColor = SwiftGenColors.gray6.color
+        keyboardToolBar.items = [cancleBarButton, UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)]
+        keyboardToolBar.sizeToFit()
+        nameLabel.inputAccessoryView = keyboardToolBar
+        nameLabel.delegate = self
+    }
+    
+    @objc
+    private func dismissKeyboard() {
+        textFieldCancleToolbarCompletion?()
+    }
+}
+
+extension RoundLabelWithButtonTableCell: UITextFieldDelegate {
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        // 공백만 이루어진건 아닌지 판별하여 저장한다.
+        var text: String = ""
+        if let textFieldText: String = textField.text {
+            if textFieldText.filter({ $0 == " " }).count == textFieldText.count {
+                textField.text = ""
+            } else {
+                text = textFieldText
+            }
+        }
+        
+        // 최대 글자개수를 넘지않도록 저장한다.
+        let counting: Int = text.count
+        if counting > textFieldMaxLength {
+            textField.text = Array((textField.text ?? "").map { String($0) }[0..<textFieldMaxLength]).joined()
+        } else {
+            textField.text = text
+        }
     }
 }

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -13,76 +13,105 @@ import RxSwift
 
 /// 글쓰기 화면에서 카테고리 추가, 선택할 때 사용된다.
 final class CategoryViewController: UIViewController {
+    /// 카테고리 뷰의 타입에 따라, 선택기능 관련 뷰를 보여줄지, 수정 삭제 기능 관련 뷰를 보여줄지 정하는 타입이다.
+    enum CategoryViewType {
+        case select
+        case modify
+    }
+    
     // MARK: - View Properties
+    private let topBorderLineView: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = SwiftGenColors.gray4.color
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    /// 카테고리 선택하는 뷰에서는 필요한 네비게이션 우측 버튼이고, 카테고리 수정하는 뷰에서는 필요하지 않다.
     private let successButton: UIButton = {
         let button: UIButton = UIButton()
         button.setTitle("확인", for: .normal)
-        button.setTitleColor(SwiftGenColors.black.color, for: .normal)
+        button.setTitleColor(SwiftGenColors.primaryBlack.color, for: .normal)
         button.titleLabel?.font = UIFont.Pretendard.body1
         return button
     }()
     private let textField: UITextField = {
         let textField: UITextField = UITextField()
+        textField.font = UIFont.Pretendard.body1
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.placeholder = "카테고리를 만들어보세요! (최대 20자)"
         textField.returnKeyType = .done
+        textField.attributedPlaceholder = NSAttributedString(string: "카테고리를 만들어보세요! (최대 20자)", attributes: [NSAttributedString.Key.foregroundColor: SwiftGenColors.gray2.color])
         return textField
     }()
     private let bottomLineView: UIView = {
         let view: UIView = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = SwiftGenColors.gray5.color
+        view.backgroundColor = SwiftGenColors.gray4.color
         return view
     }()
     private let tableView: UITableView = {
         let tableView: UITableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorStyle = .none
+        tableView.backgroundColor = SwiftGenColors.primaryBackground.color
         tableView.allowsMultipleSelection = true
         return tableView
     }()
-
+    
     // MARK: - Properties
     var coordinator: Coordinator?
+    var categoryViewType: CategoryViewType
     private lazy var repository: CategoryRepository = CategoryRepository(fetchedResultsControllerDelegate: self)
     private let disposeBag: DisposeBag = DisposeBag()
     private let leadingTrailingConstant: CGFloat = 18.0
     private let topBottomConstant: CGFloat = 12.0
     private var selectedCategory: [CategoryEntity] = []
     private let textFieldMaxLength: Int = 21
-
+    
+    // MARK: - Init
+    init(categoryViewType: CategoryViewType) {
+        self.categoryViewType = categoryViewType
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        view.backgroundColor = SwiftGenColors.white.color
+        
+        view.backgroundColor = SwiftGenColors.primaryBackground.color
         setupNavigationBar()
         setupView()
         setupBinding()
         setupToolbar()
     }
-
+    
     // MARK: - setup
     private func setupNavigationBar() {
         setupBaseNavigationBar()
-
+        
         let logoView: LogoView = LogoView("카테고리")
         navigationItem.titleView = logoView
-
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: SwiftGenAssets.back.image.withRenderingMode(.alwaysOriginal),
+        
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: SwiftGenAssets.back.image.withRenderingMode(.alwaysTemplate),
                                                            style: .plain,
                                                            target: self,
                                                            action: #selector(didTapBackButton))
-
+        navigationItem.leftBarButtonItem?.tintColor = SwiftGenColors.primaryBlack.color
+        
+        if categoryViewType == .modify { return }
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: successButton)
     }
-
+    
     private func setupView() {
         setupTextField()
         setupBottomLineView()
         setupTableView()
     }
-
+    
     private func setupBinding() {
         successButton.rx.tap
             .bind { [weak self] in
@@ -95,7 +124,7 @@ final class CategoryViewController: UIViewController {
                 self.coordinator?.back()
             }.disposed(by: disposeBag)
     }
-
+    
     private func setupToolbar() {
         let keyboardToolBar: UIToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
         keyboardToolBar.barStyle = .default
@@ -114,17 +143,17 @@ final class CategoryViewController: UIViewController {
         keyboardToolBar.sizeToFit()
         textField.inputAccessoryView = keyboardToolBar
     }
-
+    
     @objc
     private func didTapBackButton() {
         coordinator?.back()
     }
-
+    
     @objc
     private func dismissKeyboard() {
         textField.resignFirstResponder()
     }
-
+    
     /// 선택한 카테고리를 Category 객체로 변환해서 오름차순으로 정렬 후 반환한다.
     private func convertSelectedIndexPathToCategory() -> [Category] {
         var categories: [Category] = []
@@ -138,20 +167,26 @@ final class CategoryViewController: UIViewController {
 // MARK: - Setup
 extension CategoryViewController {
     private func setupTextField() {
+        view.addSubview(topBorderLineView)
         view.addSubview(textField)
-
+        
         NSLayoutConstraint.activate([
+            topBorderLineView.heightAnchor.constraint(equalToConstant: 0.3),
+            topBorderLineView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            topBorderLineView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topBorderLineView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            
             textField.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: leadingTrailingConstant),
-            textField.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topBottomConstant),
+            textField.topAnchor.constraint(equalTo: topBorderLineView.bottomAnchor, constant: topBottomConstant),
             textField.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -leadingTrailingConstant)
         ])
-
+        
         textField.delegate = self
     }
-
+    
     private func setupBottomLineView() {
         view.addSubview(bottomLineView)
-
+        
         NSLayoutConstraint.activate([
             bottomLineView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             bottomLineView.topAnchor.constraint(equalTo: textField.bottomAnchor, constant: topBottomConstant),
@@ -159,17 +194,17 @@ extension CategoryViewController {
             bottomLineView.heightAnchor.constraint(equalToConstant: 0.5)
         ])
     }
-
+    
     private func setupTableView() {
         view.addSubview(tableView)
-
+        
         NSLayoutConstraint.activate([
             tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             tableView.topAnchor.constraint(equalTo: bottomLineView.bottomAnchor, constant: topBottomConstant),
             tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
-
+        
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(RoundLabelWithButtonTableCell.self, forCellReuseIdentifier: RoundLabelWithButtonTableCell.reuseIdentifier)
@@ -177,9 +212,34 @@ extension CategoryViewController {
     }
 }
 
+extension CategoryViewController {
+    /// 카테고리 수정 및 삭제 기능뷰에서 삭제누를 때 나타나느 뷰,
+    func showAlertViewController(indexPath: IndexPath) {
+        let alert: AlertViewController = AlertViewController()
+        alert.hideTitleLabel()
+        alert.hideTextField()
+        alert.contentsLabel.text = "정말 삭제하시겠어요?\n이 동작은 취소할 수 없습니다."
+        alert.leftButton.setTitle("취소", for: .normal)
+        alert.rightButton.setTitle("삭제", for: .normal)
+        alert.modalPresentationStyle = .overFullScreen
+        alert.leftButton.rx.tap.bind {
+            alert.dismiss(animated: false, completion: nil)
+        }.disposed(by: disposeBag)
+        
+        alert.rightButton.rx.tap.bind { [weak self] in
+            self?.repository.delete(at: indexPath)
+            alert.dismiss(animated: false, completion: nil)
+            self?.tableView.contentInset.bottom = 0
+        }.disposed(by: disposeBag)
+        
+        present(alert, animated: false, completion: nil)
+    }
+}
+
 // MARK: - TableView Delegate
 extension CategoryViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if categoryViewType == .modify { return } // 터치 발생안하도록 한다.
         let category: CategoryEntity = repository.fetchedResultsController.object(at: indexPath)
         if let index: Int = selectedCategory.firstIndex(of: category) {
             selectedCategory.remove(at: index)
@@ -195,26 +255,55 @@ extension CategoryViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         repository.fetchedResultsController.fetchedObjects?.count ?? 0
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell: RoundLabelWithButtonTableCell = tableView.dequeueReusableCell(withIdentifier: RoundLabelWithButtonTableCell.reuseIdentifier, for: indexPath) as? RoundLabelWithButtonTableCell else {
             return UITableViewCell()
         }
-
         configureCell(cell, at: indexPath)
-
+        
         return cell
     }
-
+    
     private func configureCell(_ cell: RoundLabelWithButtonTableCell, at indexPath: IndexPath) {
         let category: CategoryEntity = repository.fetchedResultsController.object(at: indexPath)
-
+        cell.backgroundColor = SwiftGenColors.primaryBackground.color
+        cell.textFieldMaxLength = textFieldMaxLength
         cell.configure(name: category.title ?? "")
-
-        if selectedCategory.contains(category) {
-            cell.isSelectedCategory = true
-        } else {
-            cell.isSelectedCategory = false
+        cell.configure(type: categoryViewType)
+        cell.isSelectedCategory = selectedCategory.contains(category)
+        
+        if categoryViewType == .modify {
+            cell.textFieldCancleToolbarCompletion = { [weak self] in
+                cell.configure(name: category.title ?? "")
+                cell.nameLabel.isUserInteractionEnabled = false
+                cell.nameLabel.resignFirstResponder()
+                self?.tableView.contentInset.bottom = 0
+            }
+            
+            cell.modifyButton.rx.tap.bind { [weak self] in
+                cell.nameLabel.isUserInteractionEnabled = true
+                cell.nameLabel.becomeFirstResponder()
+                if self?.tableView.contentInset.bottom == 0 {
+                    self?.tableView.contentInset.bottom += 500
+                }
+                self?.tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+            }.disposed(by: cell.disposeBag)
+                
+            cell.deleteButton.rx.tap.bind { [weak self] in
+                self?.showAlertViewController(indexPath: indexPath)
+            }.disposed(by: cell.disposeBag)
+            
+            cell.nameLabel.rx.controlEvent(.editingDidEndOnExit).bind { [weak self] in
+                cell.nameLabel.isUserInteractionEnabled = false
+                self?.tableView.contentInset.bottom = 0
+                if let text: String = cell.nameLabel.text, text.isEmpty {
+                    cell.configure(name: category.title ?? "")
+                    return
+                }
+                category.title = cell.nameLabel.text
+                self?.repository.update()
+            }.disposed(by: cell.disposeBag)
         }
     }
 }
@@ -225,17 +314,17 @@ extension CategoryViewController: UITextFieldDelegate {
         let newLength: Int = text.count + string.count - range.length
         return newLength <= textFieldMaxLength
     }
-
+    
     /// 키보드에서 완료 버튼을 누르면 텍스트 필드에 입력한 내용을 Core Data Category에 저장한다.
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         guard let name: String = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines) else {
             return false
         }
-
+        
         guard !name.isEmpty else {
             return false
         }
-
+        
         repository.create(Category(title: name)) { result in
             switch result {
             case .success:
@@ -246,7 +335,7 @@ extension CategoryViewController: UITextFieldDelegate {
                 fatalError(error.localizedDescription)
             }
         }
-
+        
         return true
     }
 }

--- a/ThingLog/ViewController/EasyLook/EasyLookViewController.swift
+++ b/ThingLog/ViewController/EasyLook/EasyLookViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class EasyLookViewController: UIViewController {
     var coordinator: EasyLookCoordinator?
     
+    // MARK: - View
     lazy var easyLookTopView: EasyLookTopView = {
         let easyLookTopView: EasyLookTopView = EasyLookTopView(superView: view)
         easyLookTopView.translatesAutoresizingMaskIntoConstraints = false
@@ -38,6 +39,7 @@ final class EasyLookViewController: UIViewController {
     
     let contentsViewController: BaseContentsCollectionViewController = BaseContentsCollectionViewController(willHideFilterView: true)
     
+    // MARK: - Properties
     var viewModel: EasyLookViewModel = EasyLookViewModel()
     let categoryRepo: CategoryRepository = CategoryRepository(fetchedResultsControllerDelegate: nil)
     
@@ -66,6 +68,11 @@ final class EasyLookViewController: UIViewController {
         
         setupHorizontalColletionCompletion()
         setupContentsViewControllerCompletion()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        easyLookTopView.horizontalCollectionView.reloadData()
     }
 }
 

--- a/ThingLog/ViewController/SettingViewController.swift
+++ b/ThingLog/ViewController/SettingViewController.swift
@@ -207,7 +207,7 @@ extension SettingViewController: UITableViewDelegate {
             case .darkMode:
                 return
             case .editCategory:
-                return
+                coordinator?.showCategoryViewController()
             case .trash:
                 coordinator?.showTrashViewController()
             case .login:

--- a/ThingLog/ViewController/SettingViewController.swift
+++ b/ThingLog/ViewController/SettingViewController.swift
@@ -16,12 +16,8 @@ final class SettingViewController: UIViewController {
         case darkMode
         case editCategory
         case trash
-        case login
         case addDummyData
         case deleteDummyData
-        case alert1
-        case alert2
-        case alert3
         case resetUserInfor
         case clearDrawer
         case blackCard
@@ -37,18 +33,10 @@ final class SettingViewController: UIViewController {
                 return "카테고리 수정"
             case .trash:
                 return "휴지통"
-            case .login:
-                return "로그인 화면 ( 테스트 )"
             case .addDummyData:
                 return "랜덤 데이터 400개 추가"
             case .deleteDummyData:
                 return "랜덤 데이터 모두 삭제"
-            case .alert1:
-                return "기본 Alert"
-            case .alert2:
-                return "내용과 버튼 하나만 있는 Alert"
-            case .alert3:
-                return "제목과 텍스트필드, 두개의 버튼 있는 Alert"
             case .resetUserInfor:
                 return "유저정보 초기화 ( 앱 종료됩니다 )"
             case .clearDrawer:
@@ -186,7 +174,7 @@ extension SettingViewController: UITableViewDataSource {
                     }
                     .disposed(by: cell.disposeBag)
                 
-            case .editCategory, .trash, .login, .addDummyData, .deleteDummyData, .alert1, .alert2, .alert3, .resetUserInfor, .clearDrawer, .blackCard, .basket, .rightAward, .dragonball:
+            case .editCategory, .trash, .addDummyData, .deleteDummyData, .resetUserInfor, .clearDrawer, .blackCard, .basket, .rightAward, .dragonball:
                 cell.changeViewType(labelType: .withBody1,
                                     buttonType: .withChevronRight,
                                     borderLineHeight: .with05Height,
@@ -210,18 +198,10 @@ extension SettingViewController: UITableViewDelegate {
                 coordinator?.showCategoryViewController()
             case .trash:
                 coordinator?.showTrashViewController()
-            case .login:
-                coordinator?.showLoginViewController()
             case .addDummyData:
                 makeDummy()
             case .deleteDummyData:
                 deleteAllEntity()
-            case .alert1:
-                showAlert1()
-            case .alert2:
-                showAlert2()
-            case .alert3:
-                showAlert3()
             case .resetUserInfor:
                 UserInformationiCloudViewModel().resetUserInformation()
                 exit(1)
@@ -246,41 +226,6 @@ extension SettingViewController: UITableViewDelegate {
                 drawerRepo.updateRightAward()
             }
         }
-    }
-    func showAlert1() {
-        let alert = AlertViewController()
-        alert.modalPresentationStyle = .overFullScreen
-        alert.leftButton.rx.tap.bind {
-            alert.dismiss(animated: false, completion: nil)
-        }
-        present(alert, animated: false, completion: nil)
-    }
-    
-    func showAlert2() {
-        let alert = AlertViewController()
-        alert.modalPresentationStyle = .overFullScreen
-        alert.hideTitleLabel()
-        alert.hideRightButton()
-        alert.hideTextField()
-        alert.changeContentsText("이미지는 최대 10개까지 첨부할 수 있어요")
-        alert.leftButton.setTitle("확인", for: .normal)
-        alert.leftButton.rx.tap.bind {
-            alert.dismiss(animated: false, completion: nil)
-        }
-        present(alert, animated: false, completion: nil)
-    }
-    
-    func showAlert3() {
-        let alert = AlertViewController()
-        alert.hideContentsLabel()
-        alert.titleLabel.text = "카테고리 수정"
-        alert.leftButton.setTitle("취소", for: .normal)
-        alert.rightButton.setTitle("확인", for: .normal)
-        alert.modalPresentationStyle = .overFullScreen
-        alert.leftButton.rx.tap.bind {
-            alert.dismiss(animated: false, completion: nil)
-        }
-        present(alert, animated: false, completion: nil)
     }
 }
 


### PR DESCRIPTION
## 개요
- 카테고리 수정 기능 구현 및 다크모드 대응 
-  모아보기 다크모드 버그 수정 
![categorymodify](https://user-images.githubusercontent.com/48749182/142718243-08199b2e-61a5-4d28-baf8-cf631c3842af.gif)


## 작업 사항
- 이 기능을 구현하기 위해 기존에 지원님이 구현하신 로직은 거의 건드리지 않고 작업했습니다. 
- 카테고리 수정 기능을 위한 뷰를 위해, 기존의 지원님이 구현하신 `RoundLabelWithButtonTableCell`를 리팩토링했습니다.
    - 예외적으로 기존 `nameLabel`을 `UILabel`에서 UITextFeild로 변경했습니다. ( 부득이하게 수정 기능을 위하여 ) 
    - 수정 / 삭제 버튼 뷰를 추가했습니다. 
    - `CategoryViewController.CategoryViewType` `enum`타입을 새로 추가하여, 이를 통해 `CategoryViewController` 초기화의 인자로 주입받고, `Cell`에도 이 타입을 주입하여 뷰를 수정 또는 선택에 따라 다르게 보이도록 구현했습니다. 
- `CategoryViewController`에서 수정 삭제 버튼의 액션 로직들을 RxSwift를 이용하여 바인딩 했습니다. 
-  `ModifyCategoryCoordinator` Protocol을 선언하여, 미리 `showCategoryViewController()` 를 구현하여, `SettingCoordinator`가 이를 채택하고 있습니다.
    - `WriteCoordinator`는 modify가 아니므로, 이니셜라이저만 리팩토링했습니다. 
- `CategoryViewController` 에 있는 뷰들을 모두 다크모드에 대응했습니다. 
- 수정기능을 위하여 `CategoryRepository` 객체에 `update` 메소드를 추가했습니다. 
- 모아보기의 카테고리 탭의 다크모드 버그를 수정하기 위하여 그에 필요한 뷰들을 리팩토링 진행했습니다. 
### Linked Issue

close #221 
close #220

