### PR TITLE
[#190] 댓글: 댓글 화면 및 입력 구현 

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -48,6 +48,10 @@
 		876C157B27044DFF000C1C84 /* CategoryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C157A27044DFF000C1C84 /* CategoryEntity.swift */; };
 		876C157D27047B19000C1C84 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C157C27047B19000C1C84 /* CategoryRepository.swift */; };
 		877B659D273677EF00561DDF /* CommentTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877B659C273677EF00561DDF /* CommentTableCell.swift */; };
+		8789A19E272C5DCC00CFB16C /* Notification.Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8789A19D272C5DCC00CFB16C /* Notification.Name+.swift */; };
+		87A863C82740DCBE0023FBE7 /* CommentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A863C72740DCBE0023FBE7 /* CommentViewController.swift */; };
+		87A863CA2740DD4B0023FBE7 /* CommentViewController+setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A863C92740DD4B0023FBE7 /* CommentViewController+setup.swift */; };
+		87A863CC2740DDAD0023FBE7 /* CommentViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A863CB2740DDAD0023FBE7 /* CommentViewController+DataSource.swift */; };
 		87A86C8B2714139F008FB3F0 /* WriteTextFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8A2714139F008FB3F0 /* WriteTextFieldCell.swift */; };
 		87A86C8D271414D2008FB3F0 /* WriteRatingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */; };
 		87A86C8F27141507008FB3F0 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8E27141507008FB3F0 /* RatingView.swift */; };
@@ -311,6 +315,9 @@
 		876C157C27047B19000C1C84 /* CategoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepository.swift; sourceTree = "<group>"; };
 		877B659C273677EF00561DDF /* CommentTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTableCell.swift; sourceTree = "<group>"; };
 		8789A19D272C5DCC00CFB16C /* Notification.Name+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+.swift"; sourceTree = "<group>"; };
+		87A863C72740DCBE0023FBE7 /* CommentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentViewController.swift; sourceTree = "<group>"; };
+		87A863C92740DD4B0023FBE7 /* CommentViewController+setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentViewController+setup.swift"; sourceTree = "<group>"; };
+		87A863CB2740DDAD0023FBE7 /* CommentViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentViewController+DataSource.swift"; sourceTree = "<group>"; };
 		87A86C8A2714139F008FB3F0 /* WriteTextFieldCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTextFieldCell.swift; sourceTree = "<group>"; };
 		87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteRatingCell.swift; sourceTree = "<group>"; };
 		87A86C8E27141507008FB3F0 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
@@ -679,6 +686,16 @@
 			path = DropDownView;
 			sourceTree = "<group>";
 		};
+		87A863C62740DCB10023FBE7 /* Comment */ = {
+			isa = PBXGroup;
+			children = (
+				87A863C72740DCBE0023FBE7 /* CommentViewController.swift */,
+				87A863C92740DD4B0023FBE7 /* CommentViewController+setup.swift */,
+				87A863CB2740DDAD0023FBE7 /* CommentViewController+DataSource.swift */,
+			);
+			path = Comment;
+			sourceTree = "<group>";
+		};
 		87EDCFD527316E55002C98BE /* PostTableCell */ = {
 			isa = PBXGroup;
 			children = (
@@ -808,6 +825,7 @@
 				DB2B8AFC272151A800A02090 /* AlertViewController.swift */,
 				873ED12C272AC96000C9F7F1 /* BaseViewController.swift */,
 				8738E1CA271705220069BB80 /* CategoryViewController.swift */,
+				87A863C62740DCB10023FBE7 /* Comment */,
 				DB7C04E026FB1900009F5C0A /* ContentsCollection */,
 				DB00D214272A8D1E003FC9C3 /* Drawer */,
 				DBE3E9C92730137200B3EB69 /* EasyLook */,
@@ -871,8 +889,8 @@
 				DB1745B62708700200EF083E /* SearchTextField.swift */,
 				DBA0F81A2709B37C009553FC /* TableVeiwCell */,
 				DB7C04FB26FB27A6009F5C0A /* TemplateImageButton.swift */,
-				876243E12708704800BDA1DC /* WriteTypeButton.swift */,
 				87AD860A2740066E0056C690 /* TextViewWithSideButtonsView.swift */,
+				876243E12708704800BDA1DC /* WriteTypeButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1281,6 +1299,7 @@
 				DBAB64A526FCC2F8006D95ED /* HomeCoordinator.swift in Sources */,
 				DBD545522703409300063C98 /* HorizontalCollectionView.swift in Sources */,
 				DBAB64A426FCC2C5006D95ED /* Coordinator.swift in Sources */,
+				87A863CA2740DD4B0023FBE7 /* CommentViewController+setup.swift in Sources */,
 				DBA0F81E2709BD41009553FC /* RecentSearchView.swift in Sources */,
 				DBD2244727085671004C5184 /* EasyLookViewController+subscribe.swift in Sources */,
 				8738E1CB271705220069BB80 /* CategoryViewController.swift in Sources */,
@@ -1295,6 +1314,7 @@
 				87B9EEE8273BDE3B001F3FB4 /* DropDownView.swift in Sources */,
 				DBD5454727032B1C00063C98 /* FilterType.swift in Sources */,
 				DB1111EE27352D2D00D02F99 /* SplashViewController.swift in Sources */,
+				87A863CC2740DDAD0023FBE7 /* CommentViewController+DataSource.swift in Sources */,
 				DBAB64A726FE2AFF006D95ED /* UIImage+.swift in Sources */,
 				DB3A516B27103DC4003B529D /* EmptyResultsView.swift in Sources */,
 				DB148C26270469B300FDC48F /* Date+.swift in Sources */,
@@ -1413,6 +1433,7 @@
 				87EDCFDB273171BC002C98BE /* PostCategoryViewDataSouce.swift in Sources */,
 				874D92F9271AD672005FF8F3 /* DummyData.swift in Sources */,
 				8715B3AF273ABFB3007A3A88 /* PostViewController+setup.swift in Sources */,
+				87A863C82740DCBE0023FBE7 /* CommentViewController.swift in Sources */,
 				8736B3EF26FDC1AD000433E1 /* Comment.swift in Sources */,
 				8736B3E326FCB9F3000433E1 /* Rating.swift in Sources */,
 				DB00D211272A8A79003FC9C3 /* SelectingDrawerViewController.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		874F52C9273E868200F79921 /* DropDownView+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874F52C8273E868200F79921 /* DropDownView+Delegate.swift */; };
 		875A966026F0E4EB001BF0D0 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875A965F26F0E4EB001BF0D0 /* CoreDataStack.swift */; };
 		875B8FFD273AAE850059DF2A /* Collection+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875B8FFC273AAE850059DF2A /* Collection+.swift */; };
+		875C09AA2747581D00ECE706 /* TextViewCellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875C09A92747581D00ECE706 /* TextViewCellDelegate.swift */; };
 		8761A88427296C0800EA8683 /* PhotosViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8761A88327296C0700EA8683 /* PhotosViewController.swift */; };
 		876243E22708704800BDA1DC /* WriteTypeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876243E12708704800BDA1DC /* WriteTypeButton.swift */; };
 		876C157927044BA0000C1C84 /* RepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C157827044BA0000C1C84 /* RepositoryError.swift */; };
@@ -308,6 +309,7 @@
 		874F52C8273E868200F79921 /* DropDownView+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DropDownView+Delegate.swift"; sourceTree = "<group>"; };
 		875A965F26F0E4EB001BF0D0 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
 		875B8FFC273AAE850059DF2A /* Collection+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+.swift"; sourceTree = "<group>"; };
+		875C09A92747581D00ECE706 /* TextViewCellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewCellDelegate.swift; sourceTree = "<group>"; };
 		8761A88327296C0700EA8683 /* PhotosViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosViewController.swift; sourceTree = "<group>"; };
 		876243E12708704800BDA1DC /* WriteTypeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTypeButton.swift; sourceTree = "<group>"; };
 		876C157827044BA0000C1C84 /* RepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryError.swift; sourceTree = "<group>"; };
@@ -572,15 +574,16 @@
 		873EC00726D39055003C3525 /* ThingLog */ = {
 			isa = PBXGroup;
 			children = (
-				DBB862BA272BFE9200B72730 /* ThingLog.entitlements */,
-				DBAE8E9226FDB39C00F536AD /* Resource */,
-				DBAE8E9126FDAE7500F536AD /* SwiftGen */,
-				87F2188A26FB78B700C3FBCA /* Entity */,
-				87F2188726FB5E6000C3FBCA /* Repository */,
 				DB7C04A426F5F26B009F5C0A /* Coordinator */,
+				87F2188A26FB78B700C3FBCA /* Entity */,
 				DB7C04EA26FB19FE009F5C0A /* Extension */,
 				875A965E26F0E4DC001BF0D0 /* Model */,
+				875C09A82747580800ECE706 /* Protocol */,
+				87F2188726FB5E6000C3FBCA /* Repository */,
+				DBAE8E9226FDB39C00F536AD /* Resource */,
 				873EC05026D50825003C3525 /* SupportingFiles */,
+				DBAE8E9126FDAE7500F536AD /* SwiftGen */,
+				DBB862BA272BFE9200B72730 /* ThingLog.entitlements */,
 				DB7C04E626FB1990009F5C0A /* View */,
 				DB7C04DF26FB18F4009F5C0A /* ViewController */,
 				873EC00C26D39055003C3525 /* ViewController.swift */,
@@ -684,6 +687,14 @@
 				874F52C8273E868200F79921 /* DropDownView+Delegate.swift */,
 			);
 			path = DropDownView;
+			sourceTree = "<group>";
+		};
+		875C09A82747580800ECE706 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				875C09A92747581D00ECE706 /* TextViewCellDelegate.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		87A863C62740DCB10023FBE7 /* Comment */ = {
@@ -1401,6 +1412,7 @@
 				87EDCFD027311E9F002C98BE /* PostViewModel.swift in Sources */,
 				87DAEB1B270BEAE50038C487 /* CameraButtonCollectionCell.swift in Sources */,
 				DB73BB07273A61CE00719DF6 /* SplashCoordinator.swift in Sources */,
+				875C09AA2747581D00ECE706 /* TextViewCellDelegate.swift in Sources */,
 				DBD2244B27085DFB004C5184 /* SearchViewController.swift in Sources */,
 				873ED12B272AC8CB00C9F7F1 /* PhotosViewController+Albums.swift in Sources */,
 				DB7C04C726F9E693009F5C0A /* UserInformationUserDefaultsViewModel.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -690,8 +690,8 @@
 			isa = PBXGroup;
 			children = (
 				87A863C72740DCBE0023FBE7 /* CommentViewController.swift */,
-				87A863C92740DD4B0023FBE7 /* CommentViewController+setup.swift */,
 				87A863CB2740DDAD0023FBE7 /* CommentViewController+DataSource.swift */,
+				87A863C92740DD4B0023FBE7 /* CommentViewController+setup.swift */,
 			);
 			path = Comment;
 			sourceTree = "<group>";

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		87A86C9127141576008FB3F0 /* WriteTextViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C9027141576008FB3F0 /* WriteTextViewCell.swift */; };
 		87ACB0B227229A3000C78C86 /* CenterTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ACB0B127229A3000C78C86 /* CenterTextButton.swift */; };
 		87ACB0B427229E2B00C78C86 /* WriteImageTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ACB0B327229E2B00C78C86 /* WriteImageTableCell.swift */; };
+		87AD860B2740066E0056C690 /* TextViewWithSideButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AD860A2740066E0056C690 /* TextViewWithSideButtonsView.swift */; };
 		87B1B6552715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B1B6542715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift */; };
 		87B1B6572715E2F0001EA889 /* WriteCategoryTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B1B6562715E2F0001EA889 /* WriteCategoryTableCell.swift */; };
 		87B9EEE8273BDE3B001F3FB4 /* DropDownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B9EEE7273BDE3B001F3FB4 /* DropDownView.swift */; };
@@ -316,6 +317,7 @@
 		87A86C9027141576008FB3F0 /* WriteTextViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTextViewCell.swift; sourceTree = "<group>"; };
 		87ACB0B127229A3000C78C86 /* CenterTextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterTextButton.swift; sourceTree = "<group>"; };
 		87ACB0B327229E2B00C78C86 /* WriteImageTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteImageTableCell.swift; sourceTree = "<group>"; };
+		87AD860A2740066E0056C690 /* TextViewWithSideButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewWithSideButtonsView.swift; sourceTree = "<group>"; };
 		87B1B6542715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelWithButtonRoundCollectionCell.swift; sourceTree = "<group>"; };
 		87B1B6562715E2F0001EA889 /* WriteCategoryTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteCategoryTableCell.swift; sourceTree = "<group>"; };
 		87B9EEE7273BDE3B001F3FB4 /* DropDownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropDownView.swift; sourceTree = "<group>"; };
@@ -870,6 +872,7 @@
 				DBA0F81A2709B37C009553FC /* TableVeiwCell */,
 				DB7C04FB26FB27A6009F5C0A /* TemplateImageButton.swift */,
 				876243E12708704800BDA1DC /* WriteTypeButton.swift */,
+				87AD860A2740066E0056C690 /* TextViewWithSideButtonsView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1369,6 +1372,7 @@
 				DB8BF6792705D25700FD5FDB /* LogoView.swift in Sources */,
 				DBA0F829270B26A0009553FC /* SearchResultsViewController.swift in Sources */,
 				87078B5B26EA44B5007AE242 /* ThingLog.xcdatamodeld in Sources */,
+				87AD860B2740066E0056C690 /* TextViewWithSideButtonsView.swift in Sources */,
 				87EDCFCE2731166D002C98BE /* PhotosViewController+Caching.swift in Sources */,
 				877B659D273677EF00561DDF /* CommentTableCell.swift in Sources */,
 				DBD1054D2729560600632168 /* LoginCoordinator.swift in Sources */,

--- a/ThingLog/Coordinator/SettingCoordinator.swift
+++ b/ThingLog/Coordinator/SettingCoordinator.swift
@@ -47,4 +47,11 @@ final class SettingCoordinator: PostCoordinatorProtocol, PhotoCardCoordinatorPro
         card.coordinator = self
         navigationController.pushViewController(card, animated: true)
     }
+
+    func showCommentViewController() {
+        let commentViewController: CommentViewController = CommentViewController()
+        commentViewController.coordinator = self
+        commentViewController.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(commentViewController, animated: true)
+    }
 }

--- a/ThingLog/Protocol/TextViewCellDelegate.swift
+++ b/ThingLog/Protocol/TextViewCellDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  TextViewCellDelegate.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/11/19.
+//
+
+import Foundation
+
+/// 텍스트뷰를 포함한 셀의 높이를 동적으로 변경하기 위한 프로토콜
+protocol TextViewCellDelegate: AnyObject {
+    func updateTextViewHeight()
+}

--- a/ThingLog/View/TableVeiwCell/CommentTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/CommentTableCell.swift
@@ -80,6 +80,7 @@ final class CommentTableCell: UITableViewCell {
     }()
 
     // MARK: - Properties
+    var toolbarCancleCallback: (() -> Void)?
     weak var delegate: TextViewCellDelegate?
     var isEditable: Bool = false {
         didSet { setEditMode() }
@@ -164,20 +165,23 @@ final class CommentTableCell: UITableViewCell {
     @objc
     private func dismissKeyboard() {
         textView.resignFirstResponder()
+        toolbarCancleCallback?()
     }
 
     private func setEditMode() {
         textView.isEditable = isEditable
         textView.isUserInteractionEnabled = isEditable
-        isEditable ? modifyButton.setTitle("편집 완료", for: .normal) : modifyButton.setTitle("수정", for: .normal)
-        isEditable ? modifyButton.setTitleColor(SwiftGenColors.systemGreen.color, for: .normal) : modifyButton.setTitleColor(SwiftGenColors.primaryBlack.color, for: .normal)
-        isEditable ? deleteButton.setTitle("취소", for: .normal) : deleteButton.setTitle("삭제", for: .normal)
+        modifyButton.setTitle(isEditable ? "편집 완료" : "수정", for: .normal)
+        modifyButton.setTitleColor(isEditable ? SwiftGenColors.systemGreen.color : SwiftGenColors.primaryBlack.color, for: .normal)
+        deleteButton.setTitle(isEditable ? "취소" : "삭제", for: .normal)
+        layoutIfNeeded()
     }
 
     private func setupBinding() {
         textView.rx.didEndEditing
             .bind { [weak self] in
-                self?.isEditable = false
+                guard let self = self else { return }
+                self.isEditable = false
             }.disposed(by: disposeBag)
     }
 }

--- a/ThingLog/View/TableVeiwCell/CommentTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/CommentTableCell.swift
@@ -91,6 +91,7 @@ final class CommentTableCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         disposeBag = DisposeBag()
+        setupBinding()
     }
 
     // MARK: - Init
@@ -98,12 +99,14 @@ final class CommentTableCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupView()
         setupKeyboardToolbar()
+        setupBinding()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setupView()
         setupKeyboardToolbar()
+        setupBinding()
     }
 
     // MARK: - Setup
@@ -169,6 +172,13 @@ final class CommentTableCell: UITableViewCell {
         isEditable ? modifyButton.setTitle("편집 완료", for: .normal) : modifyButton.setTitle("수정", for: .normal)
         isEditable ? modifyButton.setTitleColor(SwiftGenColors.systemGreen.color, for: .normal) : modifyButton.setTitleColor(SwiftGenColors.primaryBlack.color, for: .normal)
         isEditable ? deleteButton.setTitle("취소", for: .normal) : deleteButton.setTitle("삭제", for: .normal)
+    }
+
+    private func setupBinding() {
+        textView.rx.didEndEditing
+            .bind { [weak self] in
+                self?.isEditable = false
+            }.disposed(by: disposeBag)
     }
 }
 

--- a/ThingLog/View/TableVeiwCell/CommentTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/CommentTableCell.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
+
 /// 댓글 화면에서 댓글을 표시할 때 사용하는 컬렉션뷰 셀
 /// [이미지](https://www.notion.so/CommentTableCell-79a4165aa5804c5e86875368b8d53705)
 final class CommentTableCell: UITableViewCell {
@@ -76,15 +79,31 @@ final class CommentTableCell: UITableViewCell {
         return textView
     }()
 
+    // MARK: - Properties
+    weak var delegate: TextViewCellDelegate?
+    var isEditable: Bool = false {
+        didSet { setEditMode() }
+    }
+
+    // MARK: - Rx
+    var disposeBag: DisposeBag = DisposeBag()
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+    }
+
     // MARK: - Init
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupView()
+        setupKeyboardToolbar()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setupView()
+        setupKeyboardToolbar()
     }
 
     // MARK: - Setup
@@ -116,5 +135,48 @@ final class CommentTableCell: UITableViewCell {
             textView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -leadingTrailingSpacing),
             textView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -topBottomSpacing)
         ])
+
+        textView.delegate = self
+    }
+
+    private func setupKeyboardToolbar() {
+        let keyboardToolBar: UIToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
+        keyboardToolBar.barStyle = .default
+        let cancleButton: UIButton = {
+            let button: UIButton = UIButton()
+            button.titleLabel?.font = UIFont.Pretendard.title2
+            button.setTitle("취소", for: .normal)
+            button.setTitleColor(SwiftGenColors.systemBlue.color, for: .normal)
+            button.addTarget(self, action: #selector(dismissKeyboard), for: .touchUpInside)
+            return button
+        }()
+        let cancleBarButton: UIBarButtonItem = UIBarButtonItem(customView: cancleButton)
+        cancleBarButton.tintColor = SwiftGenColors.black.color
+        keyboardToolBar.barTintColor = SwiftGenColors.gray6.color
+        keyboardToolBar.items = [cancleBarButton, UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)]
+        keyboardToolBar.sizeToFit()
+        textView.inputAccessoryView = keyboardToolBar
+    }
+
+    @objc
+    private func dismissKeyboard() {
+        textView.resignFirstResponder()
+    }
+
+    private func setEditMode() {
+        textView.isEditable = isEditable
+        textView.isUserInteractionEnabled = isEditable
+        isEditable ? modifyButton.setTitle("편집 완료", for: .normal) : modifyButton.setTitle("수정", for: .normal)
+        isEditable ? modifyButton.setTitleColor(SwiftGenColors.systemGreen.color, for: .normal) : modifyButton.setTitleColor(SwiftGenColors.primaryBlack.color, for: .normal)
+        isEditable ? deleteButton.setTitle("취소", for: .normal) : deleteButton.setTitle("삭제", for: .normal)
+    }
+}
+
+// MARK: - Delegate
+extension CommentTableCell: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        if let delegate: TextViewCellDelegate = delegate {
+            delegate.updateTextViewHeight()
+        }
     }
 }

--- a/ThingLog/View/TableVeiwCell/CommentTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/CommentTableCell.swift
@@ -71,6 +71,7 @@ final class CommentTableCell: UITableViewCell {
         """
         textView.textContainer.lineFragmentPadding = .zero
         textView.textContainerInset = .zero
+        textView.backgroundColor = .clear
         textView.sizeToFit()
         return textView
     }()
@@ -88,6 +89,7 @@ final class CommentTableCell: UITableViewCell {
 
     // MARK: - Setup
     private func setupView() {
+        backgroundColor = .clear
         let leadingTrailingSpacing: CGFloat = 20.0
         let topBottomSpacing: CGFloat = 14.0
 
@@ -97,9 +99,7 @@ final class CommentTableCell: UITableViewCell {
             return stackView
         }()
 
-        contentView.addSubview(topLineView)
-        contentView.addSubview(headerStackView)
-        contentView.addSubview(textView)
+        contentView.addSubviews(topLineView, headerStackView, textView)
 
         NSLayoutConstraint.activate([
             topLineView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),

--- a/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
@@ -10,11 +10,6 @@ import UIKit
 import RxCocoa
 import RxSwift
 
-/// 글쓰기 화면에서 WriteTextViewCell의 높이를 동적으로 변경하기 위한 프로토콜
-protocol WriteTextViewCellDelegate: AnyObject {
-    func updateTextViewHeight()
-}
-
 /// 글쓰기 화면에서 자유 글쓰기를 입력할 때 사용하는 셀
 final class WriteTextViewCell: UITableViewCell {
     let textView: UITextView = {
@@ -30,7 +25,7 @@ final class WriteTextViewCell: UITableViewCell {
     }()
 
     var isEditingSubject: PublishSubject<Bool> = PublishSubject<Bool>()
-    weak var delegate: WriteTextViewCellDelegate?
+    weak var delegate: TextViewCellDelegate?
     private(set) var disposeBag: DisposeBag = DisposeBag()
     private let paddingLeadingTrailing: CGFloat = 23.0
     private let paddingTopBottom: CGFloat = 24.0
@@ -112,7 +107,7 @@ extension WriteTextViewCell: UITextViewDelegate {
     }
 
     func textViewDidChange(_ textView: UITextView) {
-        if let delegate: WriteTextViewCellDelegate = delegate {
+        if let delegate: TextViewCellDelegate = delegate {
             delegate.updateTextViewHeight()
         }
     }

--- a/ThingLog/View/TextViewWithSideButtonsView.swift
+++ b/ThingLog/View/TextViewWithSideButtonsView.swift
@@ -113,7 +113,7 @@ final class TextViewWithSideButtonsView: UIView {
     private func bindLeftButton() {
         leftButton.rx.tap
             .bind { [weak self] in
-                self?.textView.text = nil
+                self?.setupPlaceholder()
                 self?.textView.resignFirstResponder()
             }.disposed(by: disposeBag)
     }
@@ -126,6 +126,12 @@ final class TextViewWithSideButtonsView: UIView {
                 guard let self = self else { return }
                 self.rightButton.isEnabled = isPlaceholder && !self.textView.text.isEmpty
             }.disposed(by: disposeBag)
+    }
+
+    /// 텍스트 뷰의 placholder를 세팅한다.
+    private func setupPlaceholder() {
+        textView.text = placeholder
+        textView.textColor = SwiftGenColors.gray2.color
     }
 }
 
@@ -141,8 +147,7 @@ extension TextViewWithSideButtonsView: UITextViewDelegate {
 
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
-            textView.text = placeholder
-            textView.textColor = SwiftGenColors.gray2.color
+            setupPlaceholder()
         }
     }
 }

--- a/ThingLog/View/TextViewWithSideButtonsView.swift
+++ b/ThingLog/View/TextViewWithSideButtonsView.swift
@@ -59,9 +59,11 @@ final class TextViewWithSideButtonsView: UIView {
 
     // MARK: - Properties
     private let placeholder: String = "댓글로 경험을 추가하세요!"
+    private let textViewMaximumNumberOfLines: Int = 3
     private let leadingTrailingSpacing: CGFloat = 20.0
     private let topBottomSpacing: CGFloat = 12.0
     private let disposeBag: DisposeBag = DisposeBag()
+    private var textViewHeightConstraint: NSLayoutConstraint?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -89,6 +91,9 @@ final class TextViewWithSideButtonsView: UIView {
 
         addSubviews(topLineView, stackView)
 
+        textViewHeightConstraint = textView.heightAnchor.constraint(equalToConstant: UIFont.Pretendard.body1.lineHeight)
+        textViewHeightConstraint?.isActive = true
+
         NSLayoutConstraint.activate([
             topLineView.leadingAnchor.constraint(equalTo: leadingAnchor),
             topLineView.topAnchor.constraint(equalTo: topAnchor),
@@ -113,6 +118,7 @@ final class TextViewWithSideButtonsView: UIView {
     private func bindLeftButton() {
         leftButton.rx.tap
             .bind { [weak self] in
+                self?.textViewHeightConstraint?.constant = UIFont.Pretendard.body1.lineHeight
                 self?.setupPlaceholder()
                 self?.textView.resignFirstResponder()
             }.disposed(by: disposeBag)
@@ -149,5 +155,20 @@ extension TextViewWithSideButtonsView: UITextViewDelegate {
         if textView.text.isEmpty {
             setupPlaceholder()
         }
+    }
+
+    func textViewDidChange(_ textView: UITextView) {
+        let lineHeight: CGFloat = textView.font?.lineHeight ?? 1
+        let linesCount: Int = Int(textView.contentSize.height / lineHeight)
+        let size: CGSize = CGSize(width: textView.frame.size.width, height: .infinity)
+        let estimatedSize: CGSize = textView.sizeThatFits(size)
+
+        guard linesCount < textViewMaximumNumberOfLines else {
+            textView.isScrollEnabled = true
+            return
+        }
+
+        textView.isScrollEnabled = false
+        textViewHeightConstraint?.constant = estimatedSize.height
     }
 }

--- a/ThingLog/View/TextViewWithSideButtonsView.swift
+++ b/ThingLog/View/TextViewWithSideButtonsView.swift
@@ -147,7 +147,7 @@ extension TextViewWithSideButtonsView: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.textColor == SwiftGenColors.gray2.color {
             textView.text = nil
-            textView.textColor = SwiftGenColors.black.color
+            textView.textColor = SwiftGenColors.primaryBlack.color
         }
     }
 

--- a/ThingLog/View/TextViewWithSideButtonsView.swift
+++ b/ThingLog/View/TextViewWithSideButtonsView.swift
@@ -85,7 +85,7 @@ final class TextViewWithSideButtonsView: UIView {
             let stackView: UIStackView = UIStackView(arrangedSubviews: [leftButton, textView, rightButton])
             stackView.translatesAutoresizingMaskIntoConstraints = false
             stackView.spacing = 12.0
-            stackView.alignment = .lastBaseline
+            stackView.alignment = .center
             return stackView
         }()
 

--- a/ThingLog/View/TextViewWithSideButtonsView.swift
+++ b/ThingLog/View/TextViewWithSideButtonsView.swift
@@ -1,0 +1,131 @@
+//
+//  TextViewWithSideButtonsView.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/11/13.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+/// [버튼, 텍스트 뷰, 버튼] 형태의 뷰
+/// [이미지](https://www.notion.so/TextFieldWithSideButtonsView-b49640be11914396970a35f1f3561d68)
+final class TextViewWithSideButtonsView: UIView {
+    // MARK: View Properties
+    private let leftButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("취소", for: .normal)
+        button.titleLabel?.font = UIFont.Pretendard.body2
+        button.setTitleColor(SwiftGenColors.primaryBlack.color, for: .normal)
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        return button
+    }()
+
+    private let textView: UITextView = {
+        let textView: UITextView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.isScrollEnabled = false
+        textView.font = UIFont.Pretendard.body1
+        textView.textColor = SwiftGenColors.gray2.color
+        textView.text = "댓글로 경험을 추가하세요!"
+        textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return textView
+    }()
+
+    private let rightButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("확인", for: .normal)
+        button.titleLabel?.font = UIFont.Pretendard.body2
+        button.setTitleColor(SwiftGenColors.gray2.color, for: .disabled)
+        button.setTitleColor(SwiftGenColors.systemBlue.color, for: .normal)
+        button.isEnabled = false
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        return button
+    }()
+
+    // MARK: - Properties
+    private let placeholder: String = "댓글로 경험을 추가하세요!"
+    private let disposeBag: DisposeBag = DisposeBag()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupView()
+        setupBinding()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+
+        setupView()
+        setupBinding()
+    }
+
+    private func setupView() {
+        let stackView: UIStackView = {
+            let stackView: UIStackView = UIStackView(arrangedSubviews: [leftButton, textView, rightButton])
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+            stackView.spacing = 12.0
+            stackView.alignment = .lastBaseline
+            return stackView
+        }()
+
+        addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        textView.delegate = self
+    }
+
+    private func setupBinding() {
+        bindLeftButton()
+        bindRightButton()
+    }
+
+    /// leftButton을 탭하면 텍스트 뷰의 모든 텍스트를 지우고, 키보드를 내린다.
+    private func bindLeftButton() {
+        leftButton.rx.tap
+            .bind { [weak self] in
+                self?.textView.text = nil
+                self?.textView.resignFirstResponder()
+            }.disposed(by: disposeBag)
+    }
+
+    /// 텍스트 뷰가 placeholder를 표시하고 있지 않고 && 텍스트 뷰가 비어있지 않는 경우에 `rightButton`을 활성화 시킨다.
+    private func bindRightButton() {
+        textView.rx.text.orEmpty
+            .map { $0 != self.placeholder }
+            .bind { [weak self] isPlaceholder in
+                guard let self = self else { return }
+                self.rightButton.isEnabled = isPlaceholder && !self.textView.text.isEmpty
+            }.disposed(by: disposeBag)
+    }
+}
+
+// MARK: - UITextView Delegate
+/// TextView Placeholder 구현
+extension TextViewWithSideButtonsView: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == SwiftGenColors.gray2.color {
+            textView.text = nil
+            textView.textColor = SwiftGenColors.black.color
+        }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = placeholder
+            textView.textColor = SwiftGenColors.gray2.color
+        }
+    }
+}

--- a/ThingLog/View/TextViewWithSideButtonsView.swift
+++ b/ThingLog/View/TextViewWithSideButtonsView.swift
@@ -14,6 +14,13 @@ import RxSwift
 /// [이미지](https://www.notion.so/TextFieldWithSideButtonsView-b49640be11914396970a35f1f3561d68)
 final class TextViewWithSideButtonsView: UIView {
     // MARK: View Properties
+    private let topLineView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = SwiftGenColors.gray4.color
+        return view
+    }()
+
     private let leftButton: UIButton = {
         let button: UIButton = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -31,6 +38,8 @@ final class TextViewWithSideButtonsView: UIView {
         textView.font = UIFont.Pretendard.body1
         textView.textColor = SwiftGenColors.gray2.color
         textView.text = "댓글로 경험을 추가하세요!"
+        textView.textContainer.lineFragmentPadding = .zero
+        textView.textContainerInset = .zero
         textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
         textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return textView
@@ -50,6 +59,8 @@ final class TextViewWithSideButtonsView: UIView {
 
     // MARK: - Properties
     private let placeholder: String = "댓글로 경험을 추가하세요!"
+    private let leadingTrailingSpacing: CGFloat = 20.0
+    private let topBottomSpacing: CGFloat = 12.0
     private let disposeBag: DisposeBag = DisposeBag()
 
     override init(frame: CGRect) {
@@ -67,6 +78,7 @@ final class TextViewWithSideButtonsView: UIView {
     }
 
     private func setupView() {
+        backgroundColor = SwiftGenColors.white.color
         let stackView: UIStackView = {
             let stackView: UIStackView = UIStackView(arrangedSubviews: [leftButton, textView, rightButton])
             stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -75,13 +87,18 @@ final class TextViewWithSideButtonsView: UIView {
             return stackView
         }()
 
-        addSubview(stackView)
+        addSubviews(topLineView, stackView)
 
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            topLineView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            topLineView.topAnchor.constraint(equalTo: topAnchor),
+            topLineView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topLineView.heightAnchor.constraint(equalToConstant: 0.5),
+
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: leadingTrailingSpacing),
+            stackView.topAnchor.constraint(equalTo: topLineView.bottomAnchor, constant: topBottomSpacing),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -leadingTrailingSpacing),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -topBottomSpacing)
         ])
 
         textView.delegate = self

--- a/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
@@ -43,8 +43,36 @@ extension CommentViewController {
             return CommentTableCell()
         }
 
+        cell.delegate = self
         cell.textView.text = "테스트"
+        cell.modifyButton.rx.tap
+            .bind { [weak self] in
+                cell.isEditable.toggle()
+                cell.textView.isEditable ? cell.textView.becomeFirstResponder() : cell.textView.resignFirstResponder()
+                self?.hideCommentInputView(cell.isEditable)
+            }.disposed(by: cell.disposeBag)
+
+        cell.deleteButton.rx.tap
+            .bind { [weak self] in
+                if cell.isEditable {
+                    cell.isEditable.toggle()
+                    cell.textView.resignFirstResponder()
+                } else {
+                    // TODO: 삭제 기능
+                }
+                self?.hideCommentInputView(cell.isEditable)
+            }.disposed(by: cell.disposeBag)
 
         return cell
+    }
+}
+
+extension CommentViewController: TextViewCellDelegate {
+    func updateTextViewHeight() {
+        DispatchQueue.main.async { [weak tableView] in
+            tableView?.beginUpdates()
+            tableView?.endUpdates()
+            tableView?.layoutIfNeeded()
+        }
     }
 }

--- a/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
@@ -45,6 +45,12 @@ extension CommentViewController {
 
         cell.delegate = self
         cell.textView.text = "테스트"
+
+        cell.toolbarCancleCallback = { [weak self] in
+            cell.isEditable = false
+            self?.hideCommentInputView(false)
+        }
+
         cell.modifyButton.rx.tap
             .bind { [weak self] in
                 cell.isEditable.toggle()

--- a/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
@@ -1,0 +1,50 @@
+//
+//  CommentViewController+DataSource.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/11/13.
+//
+
+import UIKit
+
+extension CommentViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // TODO: 실제 데이터 바인딩 1 = 본문, 10 = 댓글
+        1 + 10
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.row == 0 {
+            return configureContentCell(with: indexPath)
+        } else {
+            return configureCommentCell(with: indexPath)
+        }
+    }
+}
+
+extension CommentViewController {
+    private func configureContentCell(with indexPath: IndexPath) -> UITableViewCell {
+        let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: UITableViewCell.reuseIdentifier, for: indexPath)
+
+        cell.textLabel?.text = """
+        Complaint that PorchCam can't pick up voices/speech when there's a loud fan running or other background noise (like a storm, etc.)
+        Complaint that PorchCam can't pick up voices/speech when there's a loud fan running or other background noise (like a storm, etc.)Complaint that PorchCam can't pick up voices/speech when there's a loud fan running or other background noise (like a storm,
+        """
+        cell.backgroundColor = .clear
+        cell.textLabel?.font = UIFont.Pretendard.body1
+        cell.textLabel?.numberOfLines = 0
+        cell.textLabel?.textColor = SwiftGenColors.primaryBlack.color
+
+        return cell
+    }
+
+    private func configureCommentCell(with indexPath: IndexPath) -> CommentTableCell {
+        guard let cell: CommentTableCell = tableView.dequeueReusableCell(withIdentifier: CommentTableCell.reuseIdentifier, for: indexPath) as? CommentTableCell else {
+            return CommentTableCell()
+        }
+
+        cell.textView.text = "테스트"
+
+        return cell
+    }
+}

--- a/ThingLog/ViewController/Comment/CommentViewController+setup.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+setup.swift
@@ -40,21 +40,7 @@ extension CommentViewController {
         ])
     }
 
-    /// TableView 하단에 여백을 지정한다.
-    /// - Parameter height: 테이블 뷰 하단에 들어갈 높이
-    private func setupTableViewBottomInset(height: CGFloat, duration: TimeInterval) {
-        var inset: UIEdgeInsets = self.tableView.contentInset
-        inset.bottom = height
-        UIView.animate(withDuration: duration) {
-            self.tableView.contentInset = inset
-        }
-        inset = tableView.verticalScrollIndicatorInsets
-        inset.bottom = height
-        UIView.animate(withDuration: duration) {
-            self.tableView.scrollIndicatorInsets = inset
-        }
-    }
-
+    // MARK: - Bind
     /// 키보드가 올라왔을 때 commentInputView 위치 변경
     func bindKeyboardWillShow() {
         NotificationCenter.default.rx
@@ -86,6 +72,22 @@ extension CommentViewController {
                     self.setupTableViewBottomInset(height: 0, duration: duration)
                 }
             }.disposed(by: disposeBag)
+    }
+
+    // MARK: - Support Method for setup, bind
+    /// TableView 하단에 여백을 지정한다.
+    /// - Parameter height: 테이블 뷰 하단에 들어갈 높이
+    private func setupTableViewBottomInset(height: CGFloat, duration: TimeInterval) {
+        var inset: UIEdgeInsets = self.tableView.contentInset
+        inset.bottom = height
+        UIView.animate(withDuration: duration) {
+            self.tableView.contentInset = inset
+        }
+        inset = tableView.verticalScrollIndicatorInsets
+        inset.bottom = height
+        UIView.animate(withDuration: duration) {
+            self.tableView.scrollIndicatorInsets = inset
+        }
     }
 
     /// CommentInputView의 하단 constant를 설정한다.

--- a/ThingLog/ViewController/Comment/CommentViewController+setup.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+setup.swift
@@ -1,0 +1,78 @@
+//
+//  CommentViewController+setup.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/11/14.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+extension CommentViewController {
+    func setupTableView() {
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: commentInputView.topAnchor)
+        ])
+
+        tableView.estimatedRowHeight = 44
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.reuseIdentifier)
+        tableView.register(CommentTableCell.self, forCellReuseIdentifier: CommentTableCell.reuseIdentifier)
+    }
+
+    func setupCommentInputView() {
+        commentInputViewBottomConstraint = commentInputView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        commentInputViewBottomConstraint?.constant = 0
+        commentInputViewBottomConstraint?.isActive = true
+
+        NSLayoutConstraint.activate([
+            commentInputView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            commentInputView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+    }
+
+    /// 키보드가 올라왔을 때 commentInputView 위치 변경
+    func bindKeyboardWillShow() {
+        NotificationCenter.default.rx
+            .notification(UIResponder.keyboardWillShowNotification)
+            .map { notification -> (CGFloat, TimeInterval) in
+                ((notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.height ?? 0,
+                 notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval ?? 0)
+            }
+            .bind { [weak self] height, duration in
+                guard let self = self else { return }
+                DispatchQueue.main.async {
+                    self.setupCommentInputViewBottomConstraint(height: height, duration: duration)
+                }
+            }.disposed(by: disposeBag)
+    }
+
+    /// 키보드가 내려갔을 때 commentInputView 위치 변경
+    func bindKeyboardWillHide() {
+        NotificationCenter.default.rx
+            .notification(UIResponder.keyboardWillHideNotification)
+            .map { notification -> TimeInterval in
+                notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval ?? 0
+            }
+            .bind { [weak self] duration in
+                guard let self = self else { return }
+                DispatchQueue.main.async {
+                    self.setupCommentInputViewBottomConstraint(height: 0, duration: duration)
+                }
+            }.disposed(by: disposeBag)
+    }
+
+    func setupCommentInputViewBottomConstraint(height: CGFloat, duration: TimeInterval) {
+        commentInputViewBottomConstraint?.constant = -height
+
+        UIView.animate(withDuration: duration) {
+            self.view.layoutIfNeeded()
+        }
+    }
+}

--- a/ThingLog/ViewController/Comment/CommentViewController+setup.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+setup.swift
@@ -12,11 +12,15 @@ import RxSwift
 
 extension CommentViewController {
     func setupTableView() {
+        tableViewBottomSafeAnchorConstraint = tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        tableViewBottomSafeAnchorConstraint?.isActive = false
+        tableViewBottomConstraint = tableView.bottomAnchor.constraint(equalTo: commentInputView.topAnchor)
+        tableViewBottomConstraint?.isActive = true
+
         NSLayoutConstraint.activate([
             tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: commentInputView.topAnchor)
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
 
         tableView.estimatedRowHeight = 44
@@ -28,13 +32,27 @@ extension CommentViewController {
 
     func setupCommentInputView() {
         commentInputViewBottomConstraint = commentInputView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
-        commentInputViewBottomConstraint?.constant = 0
         commentInputViewBottomConstraint?.isActive = true
 
         NSLayoutConstraint.activate([
             commentInputView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             commentInputView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
+    }
+
+    /// TableView 하단에 여백을 지정한다.
+    /// - Parameter height: 테이블 뷰 하단에 들어갈 높이
+    private func setupTableViewBottomInset(height: CGFloat, duration: TimeInterval) {
+        var inset: UIEdgeInsets = self.tableView.contentInset
+        inset.bottom = height
+        UIView.animate(withDuration: duration) {
+            self.tableView.contentInset = inset
+        }
+        inset = tableView.verticalScrollIndicatorInsets
+        inset.bottom = height
+        UIView.animate(withDuration: duration) {
+            self.tableView.scrollIndicatorInsets = inset
+        }
     }
 
     /// 키보드가 올라왔을 때 commentInputView 위치 변경
@@ -49,6 +67,7 @@ extension CommentViewController {
                 guard let self = self else { return }
                 DispatchQueue.main.async {
                     self.setupCommentInputViewBottomConstraint(height: height, duration: duration)
+                    self.setupTableViewBottomInset(height: height, duration: duration)
                 }
             }.disposed(by: disposeBag)
     }
@@ -64,12 +83,19 @@ extension CommentViewController {
                 guard let self = self else { return }
                 DispatchQueue.main.async {
                     self.setupCommentInputViewBottomConstraint(height: 0, duration: duration)
+                    self.setupTableViewBottomInset(height: 0, duration: duration)
                 }
             }.disposed(by: disposeBag)
     }
 
+    /// CommentInputView의 하단 constant를 설정한다.
     func setupCommentInputViewBottomConstraint(height: CGFloat, duration: TimeInterval) {
-        commentInputViewBottomConstraint?.constant = -height
+        let bottomInset: CGFloat = view.safeAreaInsets.bottom
+        if height == 0 && bottomInset != 0 {
+            commentInputViewBottomConstraint?.constant = -height
+        } else {
+            commentInputViewBottomConstraint?.constant = -height + bottomInset
+        }
 
         UIView.animate(withDuration: duration) {
             self.view.layoutIfNeeded()

--- a/ThingLog/ViewController/Comment/CommentViewController.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController.swift
@@ -29,6 +29,8 @@ final class CommentViewController: BaseViewController {
     }()
 
     // MARK: - Properties
+    var tableViewBottomConstraint: NSLayoutConstraint?
+    var tableViewBottomSafeAnchorConstraint: NSLayoutConstraint?
     var commentInputViewBottomConstraint: NSLayoutConstraint?
     var coordinator: Coordinator?
 
@@ -43,7 +45,7 @@ final class CommentViewController: BaseViewController {
         navigationItem.titleView = logoView
 
         let backButton: UIButton = UIButton()
-        backButton.setImage(SwiftGenIcons.longArrowR.image, for: .normal)
+        backButton.setImage(SwiftGenIcons.longArrowR.image.withRenderingMode(.alwaysTemplate), for: .normal)
         backButton.tintColor = SwiftGenColors.primaryBlack.color
         backButton.rx.tap
             .bind { [weak self] in
@@ -55,6 +57,7 @@ final class CommentViewController: BaseViewController {
     }
 
     override func setupView() {
+        view.backgroundColor = SwiftGenColors.white.color
         view.addSubviews(tableView, commentInputView)
 
         setupTableView()
@@ -64,5 +67,14 @@ final class CommentViewController: BaseViewController {
     override func setupBinding() {
         bindKeyboardWillShow()
         bindKeyboardWillHide()
+    }
+
+    /// 댓글 편집 모드 여부에 따라 CommentInputView를 숨김/표시한다.
+    func hideCommentInputView(_ bool: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            self?.commentInputView.isHidden = bool
+            self?.tableViewBottomConstraint?.isActive = !bool
+            self?.tableViewBottomSafeAnchorConstraint?.isActive = bool
+        }
     }
 }

--- a/ThingLog/ViewController/Comment/CommentViewController.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController.swift
@@ -30,9 +30,28 @@ final class CommentViewController: BaseViewController {
 
     // MARK: - Properties
     var commentInputViewBottomConstraint: NSLayoutConstraint?
+    var coordinator: Coordinator?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+
+        let logoView: LogoView = LogoView("게시물", font: UIFont.Pretendard.headline4)
+        navigationItem.titleView = logoView
+
+        let backButton: UIButton = UIButton()
+        backButton.setImage(SwiftGenIcons.longArrowR.image, for: .normal)
+        backButton.tintColor = SwiftGenColors.primaryBlack.color
+        backButton.rx.tap
+            .bind { [weak self] in
+                self?.coordinator?.back()
+            }
+            .disposed(by: disposeBag)
+        let backBarButton: UIBarButtonItem = UIBarButtonItem(customView: backButton)
+        navigationItem.leftBarButtonItem = backBarButton
     }
 
     override func setupView() {

--- a/ThingLog/ViewController/Comment/CommentViewController.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController.swift
@@ -1,0 +1,49 @@
+//
+//  CommentViewController.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/11/14.
+//
+
+import UIKit
+
+/// 게시물 > 댓글 화면을 나타내는 뷰 컨트롤러
+final class CommentViewController: BaseViewController {
+    // MARK: - View Properties
+    /// 게시물 본문, 댓글 목록을 표시하는 테이블 뷰
+    let tableView: UITableView = {
+        let tableView: UITableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.backgroundColor = SwiftGenColors.primaryBackground.color
+        tableView.allowsSelection = false
+        tableView.separatorStyle = .none
+        return tableView
+    }()
+
+    /// 댓글 입력하는 뷰
+    let commentInputView: TextViewWithSideButtonsView = {
+        let view: TextViewWithSideButtonsView = TextViewWithSideButtonsView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = SwiftGenColors.white.color
+        return view
+    }()
+
+    // MARK: - Properties
+    var commentInputViewBottomConstraint: NSLayoutConstraint?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override func setupView() {
+        view.addSubviews(tableView, commentInputView)
+
+        setupTableView()
+        setupCommentInputView()
+    }
+
+    override func setupBinding() {
+        bindKeyboardWillShow()
+        bindKeyboardWillHide()
+    }
+}

--- a/ThingLog/ViewController/Comment/CommentViewController.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController.swift
@@ -34,10 +34,12 @@ final class CommentViewController: BaseViewController {
     var commentInputViewBottomConstraint: NSLayoutConstraint?
     var coordinator: Coordinator?
 
+    // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
     }
 
+    // MARK: - Setup
     override func setupNavigationBar() {
         super.setupNavigationBar()
 
@@ -69,6 +71,7 @@ final class CommentViewController: BaseViewController {
         bindKeyboardWillHide()
     }
 
+    // MARK: - Public
     /// 댓글 편집 모드 여부에 따라 CommentInputView를 숨김/표시한다.
     func hideCommentInputView(_ bool: Bool) {
         DispatchQueue.main.async { [weak self] in

--- a/ThingLog/ViewController/SettingViewController.swift
+++ b/ThingLog/ViewController/SettingViewController.swift
@@ -28,7 +28,8 @@ final class SettingViewController: UIViewController {
         case dragonball
         case basket
         case rightAward
-        
+        case comment
+
         var title: String {
             switch self {
             case .darkMode:
@@ -61,6 +62,8 @@ final class SettingViewController: UIViewController {
                 return "진열장 - 장바구니 획득"
             case .rightAward:
                 return "진열장 - 인의예지상 획득"
+            case .comment:
+                return "댓글 화면"
             }
         }
     }
@@ -185,8 +188,8 @@ extension SettingViewController: UITableViewDataSource {
                         self?.setDarkMode()
                     }
                     .disposed(by: cell.disposeBag)
-                
-            case .editCategory, .trash, .login, .addDummyData, .deleteDummyData, .alert1, .alert2, .alert3, .resetUserInfor, .clearDrawer, .blackCard, .basket, .rightAward, .dragonball:
+
+            case .editCategory, .trash, .login, .addDummyData, .deleteDummyData, .alert1, .alert2, .alert3, .resetUserInfor, .clearDrawer, .blackCard, .basket, .rightAward, .dragonball, .comment:
                 cell.changeViewType(labelType: .withBody1,
                                     buttonType: .withChevronRight,
                                     borderLineHeight: .with05Height,
@@ -244,6 +247,8 @@ extension SettingViewController: UITableViewDelegate {
                 drawerRepo.updateBasket()
             case .rightAward:
                 drawerRepo.updateRightAward()
+            case .comment:
+                coordinator?.showCommentViewController()
             }
         }
     }

--- a/ThingLog/ViewController/Write/WriteViewController.swift
+++ b/ThingLog/ViewController/Write/WriteViewController.swift
@@ -181,7 +181,7 @@ extension WriteViewController: UITableViewDelegate {
 }
 
 // MARK: - Delegate
-extension WriteViewController: WriteTextViewCellDelegate {
+extension WriteViewController: TextViewCellDelegate {
     func updateTextViewHeight() {
         DispatchQueue.main.async { [weak tableView] in
             tableView?.beginUpdates()


### PR DESCRIPTION
## 개요

<img src="https://user-images.githubusercontent.com/15073405/142733531-af03bc63-2132-464f-861c-095e2cfd3375.gif" width="50%" />

댓글 화면 구현

## 작업 사항

- TextViewWithSideButtonsView 구현
  - `글쓰기 > 댓글` 화면 하단에 들어가는 댓글 입력 뷰
- 댓글 화면 구현
  - 테이블 뷰와 TextviewWithSideButtonsView를 이용해 구현했습니다.

## 예외 사항

- 실제 데이터 바인딩
  - 댓글 수정, 삭제, 저장 기능 X
- iOS 13, 14에서 댓글 수정 모드로 진입할 때 [수정/편집 완료] 텍스트가 변경되면서 Label이 늘어났다가 줄어드는 형태로 표시됩니다. 이 문제는 텍스트뷰에 키보드 포커싱이 있을 때 생기는 거 같은데, 해결 방안을 찾지 못했습니다. ㅠㅠ

## 테스트

설정 화면에서 확인할 수 있습니다.

### Linked Issue

close #190

