### PR TITLE
[#138] ref: 글쓰기 화면 스크롤 튀는 현상 해결

### DIFF
--- a/ThingLog/View/CollectionViewCell/CameraButtonCollectionCell.swift
+++ b/ThingLog/View/CollectionViewCell/CameraButtonCollectionCell.swift
@@ -90,7 +90,6 @@ extension CameraButtonCollectionCell {
             stackView.translatesAutoresizingMaskIntoConstraints = false
             stackView.axis = .vertical
             stackView.alignment = .center
-            stackView.distribution = .equalCentering
             return stackView
         }()
 
@@ -102,13 +101,15 @@ extension CameraButtonCollectionCell {
 
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingTopTrailing),
-            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -paddingTopTrailing),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor,
+                                           constant: paddingTopTrailing),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
+                                                constant: -paddingTopTrailing),
             stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             emptyTopView.heightAnchor.constraint(equalToConstant: emptyViewHeight),
-            emptyBottomView.heightAnchor.constraint(equalToConstant: emptyViewHeight),
-            emptyTopView.widthAnchor.constraint(equalToConstant: emptyViewWidth),
-            emptyBottomView.widthAnchor.constraint(equalToConstant: emptyViewWidth),
+            emptyBottomView.heightAnchor.constraint(greaterThanOrEqualToConstant: 0),
+            emptyTopView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            emptyBottomView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
             iconImageView.heightAnchor.constraint(equalToConstant: 18)
         ])
     }

--- a/ThingLog/View/TableVeiwCell/WriteImageTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteImageTableCell.swift
@@ -66,7 +66,7 @@ extension WriteImageTableCell {
             collectionView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingTopConstaint),
             collectionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingBottomConstaint),
-            collectionView.heightAnchor.constraint(equalToConstant: thumbnailCellSize)
+            collectionView.heightAnchor.constraint(greaterThanOrEqualToConstant: collectionViewHeight)
         ])
 
         collectionView.register(CameraButtonCollectionCell.self, forCellWithReuseIdentifier: CameraButtonCollectionCell.reuseIdentifier)
@@ -84,11 +84,11 @@ extension WriteImageTableCell {
     }
 
     private func createLayout() -> UICollectionViewCompositionalLayout {
-        let itemSize: NSCollectionLayoutSize = .init(widthDimension: .absolute(thumbnailCellSize),
-                                                     heightDimension: .absolute(thumbnailCellSize))
+        let itemSize: NSCollectionLayoutSize = .init(widthDimension: .fractionalHeight(1),
+                                                     heightDimension: .fractionalHeight(1))
         let item: NSCollectionLayoutItem = .init(layoutSize: itemSize)
 
-        let groupSize: NSCollectionLayoutSize = .init(widthDimension: .estimated(1.0),
+        let groupSize: NSCollectionLayoutSize = .init(widthDimension: .estimated(80.0),
                                                       heightDimension: .fractionalHeight(1))
         let group: NSCollectionLayoutGroup = .horizontal(layoutSize: groupSize, subitems: [item])
 

--- a/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
@@ -65,7 +65,7 @@ extension WriteTextViewCell {
             textView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: paddingTopBottom),
             textView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -paddingLeadingTrailing),
             textView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -paddingTopBottom),
-            textView.heightAnchor.constraint(equalToConstant: minHeight)
+            textView.heightAnchor.constraint(greaterThanOrEqualToConstant: minHeight)
         ])
 
         textView.delegate = self

--- a/ThingLog/ViewController/Write/WriteViewController+setup.swift
+++ b/ThingLog/ViewController/Write/WriteViewController+setup.swift
@@ -111,4 +111,8 @@ extension WriteViewController {
                 self?.tableView.reloadData()
             }).disposed(by: disposeBag)
     }
+    
+    
+    
+    
 }

--- a/ThingLog/ViewController/Write/WriteViewController.swift
+++ b/ThingLog/ViewController/Write/WriteViewController.swift
@@ -156,17 +156,8 @@ extension WriteViewController {
     /// indexPath.row의 위치로 이동한다.
     /// - Parameter indexPath: 이동하려는 셀의 IndexPath
     func scrollToCurrentRow(at indexPath: IndexPath) {
-        if indexPath.section == WriteViewModel.Section.type.rawValue {
-            let rowRect: CGRect = tableView.rectForRow(at: indexPath)
-            UIView.animate(withDuration: 0.3) {
-                self.tableView.scrollRectToVisible(rowRect, animated: false)
-            }
-        } else if indexPath.section == WriteViewModel.Section.contents.rawValue {
-            let bottomOffset: CGPoint = CGPoint(x: 0,
-                                                y: tableView.contentSize.height - tableView.bounds.height + tableView.contentInset.bottom)
-            UIView.animate(withDuration: 0.3) {
-                self.tableView.setContentOffset(bottomOffset, animated: false)
-            }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.tableView.scrollToRow(at: indexPath, at: .top, animated: true)
         }
     }
 }


### PR DESCRIPTION
## 개요

 글쓰기 화면 스크롤 튀는 현상 해결

![scroll](https://user-images.githubusercontent.com/48749182/142757902-38b0547a-8a2c-4d2f-b658-0ddd96ce832a.gif)

## 작업 사항
- 크게 코드를 고치거나 변경한점은 거의 없습니다. 
- `WriteViewController`에서 발생하는 오토레이아웃 워닝 최대한 제거  
    - 상단 이미지 컬렉션뷰 셀크기가 계속 맞지 않다라고 나와서, 그 카메라 버튼 셀의 뷰들의 크기를 최대한 동적으로 결정되도록 변경 
        - 이 과정에서 카메라 버튼 내부 크기가 피그마와 정확히 안맞을 수 있는데, 이 부분은 지원님께서 변경하시면 될 것 같습니다. 
    - 하단 텍스트뷰도 텍스트뷰 크기가 맞지 않다고 해서, 380보다 크도록 constraint 변경 
    - 하단 버튼은 잘 모르겠어서 그냥 두었습니다. 


### Linked Issue

close #138 

