### PR TITLE
[#234] 게시물: 댓글 화면으로 이동

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		876C157B27044DFF000C1C84 /* CategoryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C157A27044DFF000C1C84 /* CategoryEntity.swift */; };
 		876C157D27047B19000C1C84 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C157C27047B19000C1C84 /* CategoryRepository.swift */; };
 		877B659D273677EF00561DDF /* CommentTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877B659C273677EF00561DDF /* CommentTableCell.swift */; };
+		87A1F947274B301D00268194 /* CommentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A1F946274B301D00268194 /* CommentCoordinator.swift */; };
 		87A86C8B2714139F008FB3F0 /* WriteTextFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8A2714139F008FB3F0 /* WriteTextFieldCell.swift */; };
 		87A86C8D271414D2008FB3F0 /* WriteRatingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */; };
 		87A86C8F27141507008FB3F0 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8E27141507008FB3F0 /* RatingView.swift */; };
@@ -311,6 +312,7 @@
 		876C157C27047B19000C1C84 /* CategoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepository.swift; sourceTree = "<group>"; };
 		877B659C273677EF00561DDF /* CommentTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTableCell.swift; sourceTree = "<group>"; };
 		8789A19D272C5DCC00CFB16C /* Notification.Name+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+.swift"; sourceTree = "<group>"; };
+		87A1F946274B301D00268194 /* CommentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCoordinator.swift; sourceTree = "<group>"; };
 		87A86C8A2714139F008FB3F0 /* WriteTextFieldCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTextFieldCell.swift; sourceTree = "<group>"; };
 		87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteRatingCell.swift; sourceTree = "<group>"; };
 		87A86C8E27141507008FB3F0 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
@@ -770,6 +772,7 @@
 		DB7C04A426F5F26B009F5C0A /* Coordinator */ = {
 			isa = PBXGroup;
 			children = (
+				87A1F946274B301D00268194 /* CommentCoordinator.swift */,
 				DB7C04A526F5F281009F5C0A /* Coordinator.swift */,
 				DB00D217272A8DB0003FC9C3 /* DrawerCoordinator.swift */,
 				DB7C04A926F5F308009F5C0A /* EasyLookCoordinator.swift */,
@@ -1425,6 +1428,7 @@
 				DB3A516927103B3E003B529D /* EmptyPostView.swift in Sources */,
 				873ED123272AA0AA00C9F7F1 /* AlbumsViewController.swift in Sources */,
 				87F2188E26FB8ACA00C3FBCA /* PostType.swift in Sources */,
+				87A1F947274B301D00268194 /* CommentCoordinator.swift in Sources */,
 				87DAEB1D270BEC170038C487 /* ThumbnailCell.swift in Sources */,
 				87EDCFDD273174E1002C98BE /* PostSlideImageViewDataSource.swift in Sources */,
 				8738E1CD271708F80069BB80 /* PaddingLabel.swift in Sources */,

--- a/ThingLog/Coordinator/CommentCoordinator.swift
+++ b/ThingLog/Coordinator/CommentCoordinator.swift
@@ -1,0 +1,14 @@
+//
+//  CommentCoordinator.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/11/22.
+//
+
+import Foundation
+
+/// 댓글 화면으로 이동하기 위한 메소드를 정의한 Coordinator 프로토콜
+protocol CommentCoordinatorProtocol {
+    /// `CommentViewController`로 이동한다. `CommentViewController`에서 데이터를 표시하기 위해 `PostEntity`가 필요하다.
+    func showCommentViewController(with entity: PostEntity)
+}

--- a/ThingLog/Coordinator/CommentCoordinator.swift
+++ b/ThingLog/Coordinator/CommentCoordinator.swift
@@ -8,7 +8,15 @@
 import Foundation
 
 /// 댓글 화면으로 이동하기 위한 메소드를 정의한 Coordinator 프로토콜
-protocol CommentCoordinatorProtocol {
+protocol CommentCoordinatorProtocol: Coordinator {
     /// `CommentViewController`로 이동한다. `CommentViewController`에서 데이터를 표시하기 위해 `PostEntity`가 필요하다.
     func showCommentViewController(with entity: PostEntity)
+}
+
+extension CommentCoordinatorProtocol {
+    func showCommentViewController(with entity: PostEntity) {
+        // TODO: CommentViewController로 대체
+        let commentViewController: TestCommentViewController = TestCommentViewController(postEntity: entity)
+        navigationController.pushViewController(commentViewController, animated: true)
+    }
 }

--- a/ThingLog/Coordinator/CommentCoordinator.swift
+++ b/ThingLog/Coordinator/CommentCoordinator.swift
@@ -17,6 +17,7 @@ extension CommentCoordinatorProtocol {
     func showCommentViewController(with entity: PostEntity) {
         // TODO: CommentViewController로 대체
         let commentViewController: TestCommentViewController = TestCommentViewController(postEntity: entity)
+        commentViewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(commentViewController, animated: true)
     }
 }

--- a/ThingLog/Coordinator/PostCoordinator.swift
+++ b/ThingLog/Coordinator/PostCoordinator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol PostCoordinatorProtocol: Coordinator {
+protocol PostCoordinatorProtocol: CommentCoordinatorProtocol {
     /// `PostViewController`를 보여준다. `PostViewController`에서 데이터를 표시하기 위해 `PostViewModel`이 필요하다.
     func showPostViewController(with viewModel: PostViewModel)
 }

--- a/ThingLog/SwiftGen/ColorsAsset.swift
+++ b/ThingLog/SwiftGen/ColorsAsset.swift
@@ -59,6 +59,17 @@ internal final class ColorSwiftGen {
     return color
   }()
 
+  #if os(iOS) || os(tvOS)
+  @available(iOS 11.0, tvOS 11.0, *)
+  internal func color(compatibleWith traitCollection: UITraitCollection) -> Color {
+    let bundle = BundleToken.bundle
+    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }

--- a/ThingLog/SwiftGen/DrawersAssets.swift
+++ b/ThingLog/SwiftGen/DrawersAssets.swift
@@ -42,6 +42,7 @@ internal struct DrawerImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -57,9 +58,21 @@ internal struct DrawerImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension DrawerImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the DrawerImageSwiftGen.image property")
   convenience init?(asset: DrawerImageSwiftGen) {

--- a/ThingLog/SwiftGen/Fonts.swift
+++ b/ThingLog/SwiftGen/Fonts.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
-#if os(OSX)
+#if os(macOS)
   import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
@@ -38,7 +38,7 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
-  #if os(OSX)
+  #if os(macOS)
   internal typealias Font = NSFont
   #elseif os(iOS) || os(tvOS) || os(watchOS)
   internal typealias Font = UIFont
@@ -69,7 +69,7 @@ internal extension FontConvertible.Font {
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
-    #elseif os(OSX)
+    #elseif os(macOS)
     if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }

--- a/ThingLog/SwiftGen/FrameAssets.swift
+++ b/ThingLog/SwiftGen/FrameAssets.swift
@@ -46,6 +46,7 @@ internal struct FrameImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -61,9 +62,21 @@ internal struct FrameImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension FrameImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the FrameImageSwiftGen.image property")
   convenience init?(asset: FrameImageSwiftGen) {

--- a/ThingLog/SwiftGen/IconsAssets.swift
+++ b/ThingLog/SwiftGen/IconsAssets.swift
@@ -76,6 +76,7 @@ internal struct IconImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -91,9 +92,21 @@ internal struct IconImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension IconImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the IconImageSwiftGen.image property")
   convenience init?(asset: IconImageSwiftGen) {

--- a/ThingLog/SwiftGen/ImageAssets.swift
+++ b/ThingLog/SwiftGen/ImageAssets.swift
@@ -56,6 +56,7 @@ internal struct ImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -71,9 +72,21 @@ internal struct ImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension ImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the ImageSwiftGen.image property")
   convenience init?(asset: ImageSwiftGen) {

--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
@@ -247,6 +247,7 @@ final class PostTableCell: UITableViewCell {
     var disposeBag: DisposeBag = DisposeBag()
     private(set) var imageCount: Int = 0
 
+    // MARK: - Init
     override func prepareForReuse() {
         super.prepareForReuse()
         disposeBag = DisposeBag()
@@ -262,6 +263,7 @@ final class PostTableCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Setup
     func setupView() {
         backgroundColor = .clear
         contentView.addSubview(stackView)
@@ -278,6 +280,7 @@ final class PostTableCell: UITableViewCell {
         setupStackView()
     }
 
+    // MARK: - Public
     func configure(with post: PostEntity) {
         guard let type: PageType = post.postType?.pageType else {
             fatalError("\(#function): Not Found PageType")

--- a/ThingLog/ViewController.swift
+++ b/ThingLog/ViewController.swift
@@ -47,3 +47,41 @@ class TestPostViewController: UIViewController {
         testLabel.text = "총 Post 개수: \(postViewModel.fetchedResultsController.fetchedObjects?.count ?? 0)개 \n 시작 위치: \(postViewModel.startIndexPath.row + 1)번째"
     }
 }
+
+/// CommentViewController 테스트 용 뷰 컨트롤러입니다. 추후에 CommentViewController로 사용할 예정입니다.
+class TestCommentViewController: UIViewController {
+    var postEntity: PostEntity
+
+    let testLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.font = UIFont.Pretendard.body1
+        label.textColor = SwiftGenColors.primaryBlack.color
+        label.numberOfLines = 2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    init(postEntity: PostEntity) {
+        self.postEntity = postEntity
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubviews(testLabel)
+        view.backgroundColor = SwiftGenColors.primaryBackground.color
+        NSLayoutConstraint.activate([
+            testLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            testLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+
+        testLabel.text = """
+        본문 : \(postEntity.contents ?? "")
+        코멘트 개수 : \(postEntity.comments?.count ?? 0)개
+        """
+    }
+}

--- a/ThingLog/ViewController/Post/PostViewController+DataSource.swift
+++ b/ThingLog/ViewController/Post/PostViewController+DataSource.swift
@@ -19,6 +19,16 @@ extension PostViewController: UITableViewDataSource {
 
         let item: PostEntity = viewModel.fetchedResultsController.object(at: indexPath)
         cell.configure(with: item)
+
+        cell.commentButton.rx.tap
+            .bind { [weak self] in
+                self?.coordinator?.showCommentViewController(with: item)
+            }.disposed(by: cell.disposeBag)
+
+        cell.commentMoreButton.rx.tap
+            .bind { [weak self] in
+                self?.coordinator?.showCommentViewController(with: item)
+            }.disposed(by: cell.disposeBag)
         
         return cell
     }

--- a/ThingLog/ViewController/Post/PostViewController.swift
+++ b/ThingLog/ViewController/Post/PostViewController.swift
@@ -20,7 +20,7 @@ final class PostViewController: BaseViewController {
     }()
 
     // MARK: - Properties
-    var coordinator: Coordinator?
+    var coordinator: PostCoordinatorProtocol?
     private(set) var viewModel: PostViewModel
 
     init(viewModel: PostViewModel) {


### PR DESCRIPTION
## 개요

https://user-images.githubusercontent.com/15073405/142792520-38cff2c2-7f37-48cd-a3f8-e696eea4977a.mp4

- 게시물 화면에서 댓글 화면으로 이동한다.

## 작업 사항

- CommentCoordinatorProtocol 구현
  - extension으로 초기 구현
- PostCoordinatorProtocol이 Coordinator에서 CommentCoordinatorProtocol을 채택하게 변경
- 임시 TestCommentViewController 구현
- 게시물 화면에서 commentButton, commentMoreButton 선택 시 댓글 화면으로 이동

## 예외 사항

- #226은 해결되지 않았습니다.

### Linked Issue

close #234

