### PR TITLE
[#235] 댓글: 실제 데이터 바인딩

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		876C157D27047B19000C1C84 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C157C27047B19000C1C84 /* CategoryRepository.swift */; };
 		877B659D273677EF00561DDF /* CommentTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877B659C273677EF00561DDF /* CommentTableCell.swift */; };
 		87A1F947274B301D00268194 /* CommentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A1F946274B301D00268194 /* CommentCoordinator.swift */; };
-		8789A19E272C5DCC00CFB16C /* Notification.Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8789A19D272C5DCC00CFB16C /* Notification.Name+.swift */; };
 		87A863C82740DCBE0023FBE7 /* CommentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A863C72740DCBE0023FBE7 /* CommentViewController.swift */; };
 		87A863CA2740DD4B0023FBE7 /* CommentViewController+setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A863C92740DD4B0023FBE7 /* CommentViewController+setup.swift */; };
 		87A863CC2740DDAD0023FBE7 /* CommentViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A863CB2740DDAD0023FBE7 /* CommentViewController+DataSource.swift */; };
@@ -58,6 +57,7 @@
 		87A86C8D271414D2008FB3F0 /* WriteRatingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */; };
 		87A86C8F27141507008FB3F0 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C8E27141507008FB3F0 /* RatingView.swift */; };
 		87A86C9127141576008FB3F0 /* WriteTextViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A86C9027141576008FB3F0 /* WriteTextViewCell.swift */; };
+		87ABD823274BDA3600E989D9 /* CommentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABD822274BDA3600E989D9 /* CommentViewModel.swift */; };
 		87ACB0B227229A3000C78C86 /* CenterTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ACB0B127229A3000C78C86 /* CenterTextButton.swift */; };
 		87ACB0B427229E2B00C78C86 /* WriteImageTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ACB0B327229E2B00C78C86 /* WriteImageTableCell.swift */; };
 		87AD860B2740066E0056C690 /* TextViewWithSideButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AD860A2740066E0056C690 /* TextViewWithSideButtonsView.swift */; };
@@ -327,6 +327,7 @@
 		87A86C8C271414D2008FB3F0 /* WriteRatingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteRatingCell.swift; sourceTree = "<group>"; };
 		87A86C8E27141507008FB3F0 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		87A86C9027141576008FB3F0 /* WriteTextViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTextViewCell.swift; sourceTree = "<group>"; };
+		87ABD822274BDA3600E989D9 /* CommentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentViewModel.swift; sourceTree = "<group>"; };
 		87ACB0B127229A3000C78C86 /* CenterTextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterTextButton.swift; sourceTree = "<group>"; };
 		87ACB0B327229E2B00C78C86 /* WriteImageTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteImageTableCell.swift; sourceTree = "<group>"; };
 		87AD860A2740066E0056C690 /* TextViewWithSideButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewWithSideButtonsView.swift; sourceTree = "<group>"; };
@@ -673,6 +674,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		875C09A82747580800ECE706 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				875C09A92747581D00ECE706 /* TextViewCellDelegate.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		877B659E273692DC00561DDF /* Write */ = {
 			isa = PBXGroup;
 			children = (
@@ -683,24 +692,6 @@
 			path = Write;
 			sourceTree = "<group>";
 		};
-		87B9EEE6273BDE22001F3FB4 /* DropDownView */ = {
-			isa = PBXGroup;
-			children = (
-				87B9EEE7273BDE3B001F3FB4 /* DropDownView.swift */,
-				87B9EEE9273BE0D2001F3FB4 /* DropDownView+DataSource.swift */,
-				874F52C8273E868200F79921 /* DropDownView+Delegate.swift */,
-			);
-			path = DropDownView;
-			sourceTree = "<group>";
-		};
-		875C09A82747580800ECE706 /* Protocol */ = {
-			isa = PBXGroup;
-			children = (
-				875C09A92747581D00ECE706 /* TextViewCellDelegate.swift */,
-			);
-			path = Protocol;
-			sourceTree = "<group>";
-		};
 		87A863C62740DCB10023FBE7 /* Comment */ = {
 			isa = PBXGroup;
 			children = (
@@ -709,6 +700,16 @@
 				87A863C92740DD4B0023FBE7 /* CommentViewController+setup.swift */,
 			);
 			path = Comment;
+			sourceTree = "<group>";
+		};
+		87B9EEE6273BDE22001F3FB4 /* DropDownView */ = {
+			isa = PBXGroup;
+			children = (
+				87B9EEE7273BDE3B001F3FB4 /* DropDownView.swift */,
+				87B9EEE9273BE0D2001F3FB4 /* DropDownView+DataSource.swift */,
+				874F52C8273E868200F79921 /* DropDownView+Delegate.swift */,
+			);
+			path = DropDownView;
 			sourceTree = "<group>";
 		};
 		87EDCFD527316E55002C98BE /* PostTableCell */ = {
@@ -832,6 +833,7 @@
 				DB9FBDB5272E99ED005E64AF /* UserInformationViewModel */,
 				87336FDC272EE85E00E1C4CA /* UserPermissionsViewModel.swift */,
 				87BB17AA27098D760088B847 /* WriteViewModel.swift */,
+				87ABD822274BDA3600E989D9 /* CommentViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1418,6 +1420,7 @@
 				87A86C8B2714139F008FB3F0 /* WriteTextFieldCell.swift in Sources */,
 				87EDCFD027311E9F002C98BE /* PostViewModel.swift in Sources */,
 				87DAEB1B270BEAE50038C487 /* CameraButtonCollectionCell.swift in Sources */,
+				87ABD823274BDA3600E989D9 /* CommentViewModel.swift in Sources */,
 				DB73BB07273A61CE00719DF6 /* SplashCoordinator.swift in Sources */,
 				875C09AA2747581D00ECE706 /* TextViewCellDelegate.swift in Sources */,
 				DBD2244B27085DFB004C5184 /* SearchViewController.swift in Sources */,

--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		87CFA333273A5A1600D08824 /* WriteViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CFA332273A5A1600D08824 /* WriteViewController+DataSource.swift */; };
 		87DAEB1B270BEAE50038C487 /* CameraButtonCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DAEB1A270BEAE50038C487 /* CameraButtonCollectionCell.swift */; };
 		87DAEB1D270BEC170038C487 /* ThumbnailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DAEB1C270BEC170038C487 /* ThumbnailCell.swift */; };
+		87DD9E4D274F5569002CFB3A /* Int64+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DD9E4C274F5569002CFB3A /* Int64+.swift */; };
 		87E8E81927355EEB0042AA7E /* HorizontalScrollLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E8E81827355EEB0042AA7E /* HorizontalScrollLabel.swift */; };
 		87EDCFCE2731166D002C98BE /* PhotosViewController+Caching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87EDCFCD2731166D002C98BE /* PhotosViewController+Caching.swift */; };
 		87EDCFD027311E9F002C98BE /* PostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87EDCFCF27311E9F002C98BE /* PostViewModel.swift */; };
@@ -343,6 +344,7 @@
 		87CFA332273A5A1600D08824 /* WriteViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WriteViewController+DataSource.swift"; sourceTree = "<group>"; };
 		87DAEB1A270BEAE50038C487 /* CameraButtonCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraButtonCollectionCell.swift; sourceTree = "<group>"; };
 		87DAEB1C270BEC170038C487 /* ThumbnailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailCell.swift; sourceTree = "<group>"; };
+		87DD9E4C274F5569002CFB3A /* Int64+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int64+.swift"; sourceTree = "<group>"; };
 		87E8E81827355EEB0042AA7E /* HorizontalScrollLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalScrollLabel.swift; sourceTree = "<group>"; };
 		87EDCFCD2731166D002C98BE /* PhotosViewController+Caching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhotosViewController+Caching.swift"; sourceTree = "<group>"; };
 		87EDCFCF27311E9F002C98BE /* PostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewModel.swift; sourceTree = "<group>"; };
@@ -945,6 +947,7 @@
 				DB05B03F27185C500067DB17 /* UIViewController+.swift */,
 				DB7C04C926F9E69D009F5C0A /* UserDefaults+.swift */,
 				8789A19D272C5DCC00CFB16C /* Notification.Name+.swift */,
+				87DD9E4C274F5569002CFB3A /* Int64+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1476,6 +1479,7 @@
 				DB7B47002740FE7800426EF1 /* OnboardingStartViewController.swift in Sources */,
 				DB7B470927410CC800426EF1 /* OnboardingPage1ViewController.swift in Sources */,
 				876C157B27044DFF000C1C84 /* CategoryEntity.swift in Sources */,
+				87DD9E4D274F5569002CFB3A /* Int64+.swift in Sources */,
 				87F2188926FB5E9500C3FBCA /* PostRepository.swift in Sources */,
 				8736B3F626FE245A000433E1 /* PostEntity+.swift in Sources */,
 				DB1745B72708700200EF083E /* SearchTextField.swift in Sources */,

--- a/ThingLog/Coordinator/CommentCoordinator.swift
+++ b/ThingLog/Coordinator/CommentCoordinator.swift
@@ -9,14 +9,14 @@ import Foundation
 
 /// 댓글 화면으로 이동하기 위한 메소드를 정의한 Coordinator 프로토콜
 protocol CommentCoordinatorProtocol: Coordinator {
-    /// `CommentViewController`로 이동한다. `CommentViewController`에서 데이터를 표시하기 위해 `PostEntity`가 필요하다.
-    func showCommentViewController(with entity: PostEntity)
+    /// `CommentViewController`로 이동한다. `CommentViewModel`이 필요하다.
+    func showCommentViewController(with viewModel: CommentViewModel)
 }
 
 extension CommentCoordinatorProtocol {
-    func showCommentViewController(with entity: PostEntity) {
-        // TODO: CommentViewController로 대체
-        let commentViewController: TestCommentViewController = TestCommentViewController(postEntity: entity)
+    func showCommentViewController(with viewModel: CommentViewModel) {
+        let commentViewController: CommentViewController = CommentViewController(viewModel: viewModel)
+        commentViewController.coordinator = self
         commentViewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(commentViewController, animated: true)
     }

--- a/ThingLog/Coordinator/SettingCoordinator.swift
+++ b/ThingLog/Coordinator/SettingCoordinator.swift
@@ -49,11 +49,4 @@ final class SettingCoordinator: PostCoordinatorProtocol,
         card.coordinator = self
         navigationController.pushViewController(card, animated: true)
     }
-
-    func showCommentViewController() {
-        let commentViewController: CommentViewController = CommentViewController()
-        commentViewController.coordinator = self
-        commentViewController.hidesBottomBarWhenPushed = true
-        navigationController.pushViewController(commentViewController, animated: true)
-    }
 }

--- a/ThingLog/Extension/Int64+.swift
+++ b/ThingLog/Extension/Int64+.swift
@@ -1,0 +1,21 @@
+//
+//  Int64+.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/11/25.
+//
+
+import Foundation
+
+extension Int64 {
+    func toStringWithComma() -> String? {
+        let formatter: NumberFormatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+
+        let number: NSNumber = NSNumber(value: self)
+        // 3자리마다 , 삽입
+        let formattedString: String? = formatter.string(from: number)
+        return formattedString
+    }
+}

--- a/ThingLog/Model/Comment.swift
+++ b/ThingLog/Model/Comment.swift
@@ -18,6 +18,7 @@ extension Comment {
         let entity: CommentEntity = CommentEntity(context: context)
         entity.identifier = identifier
         entity.contents = contents
+        entity.createDate = Date()
         return entity
     }
 }

--- a/ThingLog/Repository/PostRepository.swift
+++ b/ThingLog/Repository/PostRepository.swift
@@ -144,7 +144,23 @@ final class PostRepository: PostRepositoryProtocol {
             }
         }
     }
-    
+
+    /// PostEntity의 속성을 변경한다.
+    /// - Parameters:
+    ///   - updatePost: PostEntity의 속성을 담은 모델 객체, identifier 속성을 통해 PostEntity를 가져오고 변경 사항을 반영한다.
+    ///   - completion: 결과를 클로저 형태로 반환한다. 성공했을 경우 무조건 true를 반환하며, 실패했을 경우 PostRepositoryError 타입을 반환한다.
+    func update(_ updateEntity: PostEntity, completion: @escaping (Result<Bool, RepositoryError>) -> Void) {
+        let context: NSManagedObjectContext = coreDataStack.mainContext
+        context.performAndWait {
+            do {
+                try context.save()
+                completion(.success(true))
+            } catch {
+                completion(.failure(.failedUpdate))
+            }
+        }
+    }
+
     /// identifier 속성을 이용해 PostEntity 객체를 한 개 가져온다.
     /// - Parameters:
     ///   - identifier: PostEntity를 찾기 위한 UUID 속성

--- a/ThingLog/SupportingFiles/ThingLog.xcdatamodeld/ThingLog.xcdatamodel/contents
+++ b/ThingLog/SupportingFiles/ThingLog.xcdatamodeld/ThingLog.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20E241" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Attachment" representedClassName="AttachmentEntity" syncable="YES" codeGenerationType="class">
         <attribute name="identifier" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="thumbnail" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
@@ -13,7 +13,7 @@
     </entity>
     <entity name="Comment" representedClassName="CommentEntity" syncable="YES" codeGenerationType="class">
         <attribute name="contents" attributeType="String"/>
-        <attribute name="createDate" attributeType="Date" defaultDateTimeInterval="654164520" usesScalarValueType="NO"/>
+        <attribute name="createDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="identifier" attributeType="UUID" usesScalarValueType="NO"/>
         <relationship name="post" maxCount="1" deletionRule="Nullify" destinationEntity="Post" inverseName="comments" inverseEntity="Post"/>
     </entity>
@@ -61,7 +61,7 @@
     <elements>
         <element name="Attachment" positionX="-7253.027587890626" positionY="-4690.344833374023" width="128" height="103"/>
         <element name="Category" positionX="-7669.173278808594" positionY="-4417.294006347656" width="128" height="74"/>
-        <element name="Comment" positionX="-6921.718536376953" positionY="-4342.518676757812" width="128" height="103"/>
+        <element name="Comment" positionX="-6921.718536376953" positionY="-4342.518676757812" width="128" height="89"/>
         <element name="Drawer" positionX="-6919.932647705078" positionY="-4487.72053527832" width="128" height="134"/>
         <element name="ImageData" positionX="-7058.579223632812" positionY="-4674.90251159668" width="128" height="73"/>
         <element name="Post" positionX="-7234.070434570312" positionY="-4447.350189208984" width="128" height="268"/>

--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell+setup.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell+setup.swift
@@ -104,6 +104,7 @@ extension PostTableCell {
     }
 
     func setupContentsContainerView() {
+        let commentMoreButtonTopSpacing: CGFloat = 7.0
         let topSpacing: CGFloat = 14.0
         let bottomSpacing: CGFloat = 16.0
         let leadingTrailingSpacing: CGFloat = 20.0
@@ -120,14 +121,20 @@ extension PostTableCell {
             lineView.topAnchor.constraint(equalTo: contentsContainerView.topAnchor, constant: topSpacing),
             lineView.leadingAnchor.constraint(equalTo: contentsContainerView.leadingAnchor),
             lineView.trailingAnchor.constraint(equalTo: contentsContainerView.trailingAnchor),
-            contentTextView.leadingAnchor.constraint(equalTo: contentsContainerView.leadingAnchor, constant: leadingTrailingSpacing),
-            contentTextView.trailingAnchor.constraint(equalTo: contentsContainerView.trailingAnchor, constant: -leadingTrailingSpacing),
+            contentTextView.leadingAnchor.constraint(equalTo: contentsContainerView.leadingAnchor,
+                                                     constant: leadingTrailingSpacing),
+            contentTextView.trailingAnchor.constraint(equalTo: contentsContainerView.trailingAnchor,
+                                                      constant: -leadingTrailingSpacing),
             contentTextView.centerXAnchor.constraint(equalTo: contentsContainerView.centerXAnchor),
             contentTextView.centerYAnchor.constraint(equalTo: contentsContainerView.centerYAnchor),
-            commentMoreButton.topAnchor.constraint(equalTo: contentTextView.bottomAnchor),
-            commentMoreButton.leadingAnchor.constraint(equalTo: contentsContainerView.leadingAnchor, constant: leadingTrailingSpacing),
-            commentMoreButton.trailingAnchor.constraint(lessThanOrEqualTo: contentsContainerView.trailingAnchor, constant: -leadingTrailingSpacing),
-            commentMoreButton.bottomAnchor.constraint(equalTo: contentsContainerView.bottomAnchor, constant: -bottomSpacing)
+            commentMoreButton.topAnchor.constraint(equalTo: contentTextView.bottomAnchor,
+                                                   constant: commentMoreButtonTopSpacing),
+            commentMoreButton.leadingAnchor.constraint(equalTo: contentsContainerView.leadingAnchor,
+                                                       constant: leadingTrailingSpacing),
+            commentMoreButton.trailingAnchor.constraint(lessThanOrEqualTo: contentsContainerView.trailingAnchor,
+                                                        constant: -leadingTrailingSpacing),
+            commentMoreButton.bottomAnchor.constraint(equalTo: contentsContainerView.bottomAnchor,
+                                                      constant: -bottomSpacing)
         ])
     }
 

--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
@@ -179,6 +179,8 @@ final class PostTableCell: UITableViewCell {
         Complaint that PorchCam can't pick up voices/speech when there's a loud fan running or other background noise (like a storm, etc.)
         Complaint that PorchCam can't pick up voices/speech when there's a loud fan running or other background noise (like a storm, etc.)Complaint that PorchCam can't pick up voices/speech when there's a loud fan running or other background noise (like a storm,
         """
+        textView.textContainer.lineFragmentPadding = .zero
+        textView.textContainerInset = .zero
         textView.sizeToFit()
         return textView
     }()
@@ -365,7 +367,12 @@ extension PostTableCell {
             return
         }
 
-        priceLabel.text = price == 0 ? "가격" : "\(price)원"
+        guard let formattedPrice: String = price.toStringWithComma() else {
+            priceLabel.text = ""
+            return
+        }
+
+        priceLabel.text = price == 0 ? "가격" : "\(formattedPrice) 원"
         priceLabel.font = price == 0 ? UIFont.Pretendard.body1 : UIFont.Pretendard.title1
         priceLabel.textColor = price == 0 ? SwiftGenColors.gray2.color : SwiftGenColors.black.color
     }

--- a/ThingLog/View/TextViewWithSideButtonsView.swift
+++ b/ThingLog/View/TextViewWithSideButtonsView.swift
@@ -31,7 +31,7 @@ final class TextViewWithSideButtonsView: UIView {
         return button
     }()
 
-    private let textView: UITextView = {
+    let textView: UITextView = {
         let textView: UITextView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.isScrollEnabled = false
@@ -45,7 +45,7 @@ final class TextViewWithSideButtonsView: UIView {
         return textView
     }()
 
-    private let rightButton: UIButton = {
+    let rightButton: UIButton = {
         let button: UIButton = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle("확인", for: .normal)

--- a/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
@@ -10,7 +10,7 @@ import UIKit
 extension CommentViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // TODO: 실제 데이터 바인딩 1 = 본문, 10 = 댓글
-        1 + 10
+        1 + viewModel.commentCount
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -26,10 +26,7 @@ extension CommentViewController {
     private func configureContentCell(with indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: UITableViewCell.reuseIdentifier, for: indexPath)
 
-        cell.textLabel?.text = """
-        Complaint that PorchCam can't pick up voices/speech when there's a loud fan running or other background noise (like a storm, etc.)
-        Complaint that PorchCam can't pick up voices/speech when there's a loud fan running or other background noise (like a storm, etc.)Complaint that PorchCam can't pick up voices/speech when there's a loud fan running or other background noise (like a storm,
-        """
+        cell.textLabel?.text = viewModel.contents
         cell.backgroundColor = .clear
         cell.textLabel?.font = UIFont.Pretendard.body1
         cell.textLabel?.numberOfLines = 0
@@ -44,7 +41,7 @@ extension CommentViewController {
         }
 
         cell.delegate = self
-        cell.textView.text = "테스트"
+        cell.textView.text = viewModel.getComment(at: indexPath.row - 1)
 
         cell.toolbarCancleCallback = { [weak self] in
             cell.isEditable = false

--- a/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
@@ -46,12 +46,17 @@ extension CommentViewController {
         cell.toolbarCancleCallback = { [weak self] in
             cell.isEditable = false
             self?.hideCommentInputView(false)
+            self?.tableView.reloadData()
         }
 
         cell.modifyButton.rx.tap
             .bind { [weak self] in
                 cell.isEditable.toggle()
-                cell.textView.isEditable ? cell.textView.becomeFirstResponder() : cell.textView.resignFirstResponder()
+                cell.isEditable ? cell.textView.becomeFirstResponder() : cell.textView.resignFirstResponder()
+                if !cell.isEditable {
+                    self?.viewModel.updateComment(at: indexPath.row - 1,
+                                                  text: cell.textView.text)
+                }
                 self?.hideCommentInputView(cell.isEditable)
             }.disposed(by: cell.disposeBag)
 
@@ -60,6 +65,7 @@ extension CommentViewController {
                 if cell.isEditable {
                     cell.isEditable.toggle()
                     cell.textView.resignFirstResponder()
+                    self?.tableView.reloadData()
                 } else {
                     self?.showRemoveCommentAlert(at: indexPath.row - 1)
                 }

--- a/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
@@ -61,7 +61,7 @@ extension CommentViewController {
                     cell.isEditable.toggle()
                     cell.textView.resignFirstResponder()
                 } else {
-                    // TODO: 삭제 기능
+                    self?.showRemoveCommentAlert(at: indexPath.row - 1)
                 }
                 self?.hideCommentInputView(cell.isEditable)
             }.disposed(by: cell.disposeBag)

--- a/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+DataSource.swift
@@ -42,6 +42,7 @@ extension CommentViewController {
 
         cell.delegate = self
         cell.textView.text = viewModel.getComment(at: indexPath.row - 1)
+        cell.dateLabel.text = viewModel.getCommentDate(at: indexPath.row - 1)
 
         cell.toolbarCancleCallback = { [weak self] in
             cell.isEditable = false

--- a/ThingLog/ViewController/Comment/CommentViewController+setup.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController+setup.swift
@@ -74,6 +74,17 @@ extension CommentViewController {
             }.disposed(by: disposeBag)
     }
 
+    /// 댓글을 입력하고 확인 버튼을 선택했을 때 댓글을 저장한다.
+    func bindCommentInputView() {
+        commentInputView.rightButton.rx.tap
+            .bind { [weak self] in
+                guard let self = self else { return }
+                self.viewModel.saveComment(self.commentInputView.textView.text) { _ in
+                    self.commentInputView.textView.text = ""
+                }
+            }.disposed(by: disposeBag)
+    }
+
     // MARK: - Support Method for setup, bind
     /// TableView 하단에 여백을 지정한다.
     /// - Parameter height: 테이블 뷰 하단에 들어갈 높이

--- a/ThingLog/ViewController/Comment/CommentViewController.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 이지원 on 2021/11/14.
 //
 
+import CoreData
 import UIKit
 
 /// 게시물 > 댓글 화면을 나타내는 뷰 컨트롤러
@@ -33,6 +34,18 @@ final class CommentViewController: BaseViewController {
     var tableViewBottomSafeAnchorConstraint: NSLayoutConstraint?
     var commentInputViewBottomConstraint: NSLayoutConstraint?
     var coordinator: Coordinator?
+    var viewModel: CommentViewModel
+    var repository: PostRepository = PostRepository(fetchedResultsControllerDelegate: nil)
+
+    // MARK: - Init
+    init(viewModel: CommentViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
 
     // MARK: - Life Cycle
     override func viewDidLoad() {

--- a/ThingLog/ViewController/Comment/CommentViewController.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController.swift
@@ -35,7 +35,6 @@ final class CommentViewController: BaseViewController {
     var commentInputViewBottomConstraint: NSLayoutConstraint?
     var coordinator: Coordinator?
     var viewModel: CommentViewModel
-    var repository: PostRepository = PostRepository(fetchedResultsControllerDelegate: nil)
 
     // MARK: - Init
     init(viewModel: CommentViewModel) {
@@ -44,12 +43,13 @@ final class CommentViewController: BaseViewController {
     }
 
     required init?(coder: NSCoder) {
-        fatalError()
+        fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        viewModel.repository.fetchedResultsController.delegate = self
     }
 
     // MARK: - Setup
@@ -82,6 +82,7 @@ final class CommentViewController: BaseViewController {
     override func setupBinding() {
         bindKeyboardWillShow()
         bindKeyboardWillHide()
+        bindCommentInputView()
     }
 
     // MARK: - Public
@@ -92,5 +93,13 @@ final class CommentViewController: BaseViewController {
             self?.tableViewBottomConstraint?.isActive = !bool
             self?.tableViewBottomSafeAnchorConstraint?.isActive = bool
         }
+    }
+}
+
+// MARK: - NSFetchedResultsControllerDelegate
+extension CommentViewController: NSFetchedResultsControllerDelegate {
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        print("⚡️ \(#function): 호출")
+        tableView.reloadData()
     }
 }

--- a/ThingLog/ViewController/Comment/CommentViewController.swift
+++ b/ThingLog/ViewController/Comment/CommentViewController.swift
@@ -94,12 +94,32 @@ final class CommentViewController: BaseViewController {
             self?.tableViewBottomSafeAnchorConstraint?.isActive = bool
         }
     }
+
+    /// 댓글을 삭제하기 전에 사용자에게 경고 알럿을 띄운다.
+    func showRemoveCommentAlert(at index: Int) {
+        let alert: AlertViewController = AlertViewController()
+        alert.hideTextField()
+        alert.hideTitleLabel()
+        alert.contentsLabel.text = "댓글을 정말 삭제하시겠어요?"
+        alert.leftButton.setTitle("아니요", for: .normal)
+        alert.rightButton.setTitle("네", for: .normal)
+        alert.modalPresentationStyle = .overFullScreen
+        alert.leftButton.rx.tap.bind {
+            alert.dismiss(animated: false, completion: nil)
+        }.disposed(by: disposeBag)
+
+        alert.rightButton.rx.tap.bind { [weak self] in
+            self?.viewModel.removeComment(at: index)
+            alert.dismiss(animated: false, completion: nil)
+        }.disposed(by: disposeBag)
+
+        present(alert, animated: false, completion: nil)
+    }
 }
 
 // MARK: - NSFetchedResultsControllerDelegate
 extension CommentViewController: NSFetchedResultsControllerDelegate {
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        print("⚡️ \(#function): 호출")
         tableView.reloadData()
     }
 }

--- a/ThingLog/ViewController/Post/PostViewController+DataSource.swift
+++ b/ThingLog/ViewController/Post/PostViewController+DataSource.swift
@@ -22,12 +22,14 @@ extension PostViewController: UITableViewDataSource {
 
         cell.commentButton.rx.tap
             .bind { [weak self] in
-                self?.coordinator?.showCommentViewController(with: item)
+                let viewModel: CommentViewModel = CommentViewModel(postEntity: item)
+                self?.coordinator?.showCommentViewController(with: viewModel)
             }.disposed(by: cell.disposeBag)
 
         cell.commentMoreButton.rx.tap
             .bind { [weak self] in
-                self?.coordinator?.showCommentViewController(with: item)
+                let viewModel: CommentViewModel = CommentViewModel(postEntity: item)
+                self?.coordinator?.showCommentViewController(with: viewModel)
             }.disposed(by: cell.disposeBag)
         
         return cell

--- a/ThingLog/ViewController/Post/PostViewController.swift
+++ b/ThingLog/ViewController/Post/PostViewController.swift
@@ -41,10 +41,12 @@ final class PostViewController: BaseViewController {
         super.viewDidAppear(animated)
         let startIndexPath: IndexPath = IndexPath(row: viewModel.startIndexPath.row, section: 0)
         tableView.scrollToRow(at: startIndexPath, at: .top, animated: false)
-        if let indexPaths: [IndexPath] = tableView.indexPathsForVisibleRows {
-            tableView.reloadRows(at: indexPaths, with: .none)
-        } else {
-            tableView.reloadData()
+        if isMovingFromParent {
+            if let indexPaths: [IndexPath] = tableView.indexPathsForVisibleRows {
+                tableView.reloadRows(at: indexPaths, with: .none)
+            } else {
+                tableView.reloadData()
+            }
         }
     }
 

--- a/ThingLog/ViewController/Post/PostViewController.swift
+++ b/ThingLog/ViewController/Post/PostViewController.swift
@@ -39,9 +39,10 @@ final class PostViewController: BaseViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        let startIndexPath: IndexPath = IndexPath(row: viewModel.startIndexPath.row, section: 0)
-        tableView.scrollToRow(at: startIndexPath, at: .top, animated: false)
-        if isMovingFromParent {
+        if isMovingToParent {
+            let startIndexPath: IndexPath = IndexPath(row: viewModel.startIndexPath.row, section: 0)
+            tableView.scrollToRow(at: startIndexPath, at: .top, animated: false)
+        } else {
             if let indexPaths: [IndexPath] = tableView.indexPathsForVisibleRows {
                 tableView.reloadRows(at: indexPaths, with: .none)
             } else {

--- a/ThingLog/ViewController/Post/PostViewController.swift
+++ b/ThingLog/ViewController/Post/PostViewController.swift
@@ -41,6 +41,11 @@ final class PostViewController: BaseViewController {
         super.viewDidAppear(animated)
         let startIndexPath: IndexPath = IndexPath(row: viewModel.startIndexPath.row, section: 0)
         tableView.scrollToRow(at: startIndexPath, at: .top, animated: false)
+        if let indexPaths: [IndexPath] = tableView.indexPathsForVisibleRows {
+            tableView.reloadRows(at: indexPaths, with: .none)
+        } else {
+            tableView.reloadData()
+        }
     }
 
     // MARK: - Setup

--- a/ThingLog/ViewController/SettingViewController.swift
+++ b/ThingLog/ViewController/SettingViewController.swift
@@ -24,7 +24,6 @@ final class SettingViewController: UIViewController {
         case dragonball
         case basket
         case rightAward
-        case comment
 
         var title: String {
             switch self {
@@ -50,8 +49,6 @@ final class SettingViewController: UIViewController {
                 return "진열장 - 장바구니 획득"
             case .rightAward:
                 return "진열장 - 인의예지상 획득"
-            case .comment:
-                return "댓글 화면"
             }
         }
     }
@@ -176,7 +173,7 @@ extension SettingViewController: UITableViewDataSource {
                         self?.setDarkMode()
                     }
                     .disposed(by: cell.disposeBag)
-            case .editCategory, .trash, .addDummyData, .deleteDummyData, .resetUserInfor, .clearDrawer, .blackCard, .basket, .rightAward, .dragonball, .comment:
+            case .editCategory, .trash, .addDummyData, .deleteDummyData, .resetUserInfor, .clearDrawer, .blackCard, .basket, .rightAward, .dragonball:
                 cell.changeViewType(labelType: .withBody1,
                                     buttonType: .withChevronRight,
                                     borderLineHeight: .with05Height,
@@ -226,8 +223,6 @@ extension SettingViewController: UITableViewDelegate {
                 drawerRepo.updateBasket()
             case .rightAward:
                 drawerRepo.updateRightAward()
-            case .comment:
-                coordinator?.showCommentViewController()
             }
         }
     }

--- a/ThingLog/ViewModel/CommentViewModel.swift
+++ b/ThingLog/ViewModel/CommentViewModel.swift
@@ -58,4 +58,14 @@ final class CommentViewModel {
             fatalError("\(#function): Failed to Remove Comment Entity")
         }
     }
+
+    /// 댓글을 수정한다.
+    func updateComment(at index: Int, text: String?) {
+        do {
+            comments[index].contents = text
+            try CoreDataStack.shared.mainContext.save()
+        } catch {
+            fatalError("\(#function): Failed to Update Comment Entity")
+        }
+    }
 }

--- a/ThingLog/ViewModel/CommentViewModel.swift
+++ b/ThingLog/ViewModel/CommentViewModel.swift
@@ -35,6 +35,15 @@ final class CommentViewModel {
         comments[index].contents
     }
 
+    /// 특정 위치의 댓글의 날짜를 반환한다.
+    func getCommentDate(at index: Int) -> String {
+        guard let date: Date = comments[index].createDate else {
+            let today: Date = Date()
+            return "\(today.toString(.year))년 \(today.toString(.month))월 \(today.toString(.day))일"
+        }
+        return "\(date.toString(.year))년 \(date.toString(.month))월 \(date.toString(.day))일"
+    }
+
     /// 댓글을 Core Data에 저장한다.
     func saveComment(_ text: String, completion: @escaping (Bool) -> Void) {
         let comment: Comment = Comment(contents: text)

--- a/ThingLog/ViewModel/CommentViewModel.swift
+++ b/ThingLog/ViewModel/CommentViewModel.swift
@@ -5,14 +5,29 @@
 //  Created by 이지원 on 2021/11/22.
 //
 
+import CoreData
 import Foundation
 
 final class CommentViewModel {
     // MARK: - Properties
-    var postEntity: PostEntity
+    private(set) var postEntity: PostEntity
+    lazy var commentCount: Int = {
+        postEntity.comments?.count ?? 0
+    }()
+    lazy var contents: String? = {
+        postEntity.contents
+    }()
 
     // MARK: - Init
     init(postEntity: PostEntity) {
         self.postEntity = postEntity
+    }
+
+    // MARK: - Public
+    func getComment(at index: Int) -> String? {
+        guard let commentEntities: [CommentEntity] = postEntity.comments?.allObjects as? [CommentEntity] else {
+            return nil
+        }
+        return commentEntities[index].contents
     }
 }

--- a/ThingLog/ViewModel/CommentViewModel.swift
+++ b/ThingLog/ViewModel/CommentViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  CommentViewModel.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2021/11/22.
+//
+
+import Foundation
+
+final class CommentViewModel {
+    // MARK: - Properties
+    var postEntity: PostEntity
+
+    // MARK: - Init
+    init(postEntity: PostEntity) {
+        self.postEntity = postEntity
+    }
+}

--- a/ThingLog/ViewModel/CommentViewModel.swift
+++ b/ThingLog/ViewModel/CommentViewModel.swift
@@ -14,6 +14,15 @@ final class CommentViewModel {
     var contents: String? { postEntity.contents }
     private(set) var postEntity: PostEntity
     private(set) var repository: PostRepository = PostRepository(fetchedResultsControllerDelegate: nil)
+    private var comments: [CommentEntity] {
+        guard let commentEntities: [CommentEntity] = postEntity.comments?.allObjects as? [CommentEntity] else {
+            return []
+        }
+        let sortedComment: [CommentEntity] = commentEntities.sorted(by: {
+            $0.createDate ?? Date() < $1.createDate ?? Date()
+        })
+        return sortedComment
+    }
 
     // MARK: - Init
     init(postEntity: PostEntity) {
@@ -23,13 +32,7 @@ final class CommentViewModel {
     // MARK: - Public
     /// 특정 위치의 댓글을 반환한다.
     func getComment(at index: Int) -> String? {
-        guard let commentEntities: [CommentEntity] = postEntity.comments?.allObjects as? [CommentEntity] else {
-            return nil
-        }
-        let sortedComment: [CommentEntity] = commentEntities.sorted(by: {
-            $0.createDate ?? Date() < $1.createDate ?? Date()
-        })
-        return sortedComment[index].contents
+        comments[index].contents
     }
 
     /// 댓글을 Core Data에 저장한다.
@@ -43,6 +46,16 @@ final class CommentViewModel {
             case .failure(let error):
                 fatalError("\(#function): \(error.localizedDescription)")
             }
+        }
+    }
+
+    /// 댓글을 Core Data에서 삭제한다.
+    func removeComment(at index: Int) {
+        do {
+            CoreDataStack.shared.mainContext.delete(comments[index])
+            try CoreDataStack.shared.mainContext.save()
+        } catch {
+            fatalError("\(#function): Failed to Remove Comment Entity")
         }
     }
 }

--- a/ThingLog/ViewModel/CommentViewModel.swift
+++ b/ThingLog/ViewModel/CommentViewModel.swift
@@ -10,13 +10,10 @@ import Foundation
 
 final class CommentViewModel {
     // MARK: - Properties
+    var commentCount: Int { postEntity.comments?.count ?? 0 }
+    var contents: String? { postEntity.contents }
     private(set) var postEntity: PostEntity
-    lazy var commentCount: Int = {
-        postEntity.comments?.count ?? 0
-    }()
-    lazy var contents: String? = {
-        postEntity.contents
-    }()
+    private(set) var repository: PostRepository = PostRepository(fetchedResultsControllerDelegate: nil)
 
     // MARK: - Init
     init(postEntity: PostEntity) {
@@ -24,10 +21,28 @@ final class CommentViewModel {
     }
 
     // MARK: - Public
+    /// 특정 위치의 댓글을 반환한다.
     func getComment(at index: Int) -> String? {
         guard let commentEntities: [CommentEntity] = postEntity.comments?.allObjects as? [CommentEntity] else {
             return nil
         }
-        return commentEntities[index].contents
+        let sortedComment: [CommentEntity] = commentEntities.sorted(by: {
+            $0.createDate ?? Date() < $1.createDate ?? Date()
+        })
+        return sortedComment[index].contents
+    }
+
+    /// 댓글을 Core Data에 저장한다.
+    func saveComment(_ text: String, completion: @escaping (Bool) -> Void) {
+        let comment: Comment = Comment(contents: text)
+        postEntity.addToComments(comment.toEntity(in: CoreDataStack.shared.mainContext))
+        repository.update(postEntity) { result in
+            switch result {
+            case .success:
+                completion(true)
+            case .failure(let error):
+                fatalError("\(#function): \(error.localizedDescription)")
+            }
+        }
     }
 }


### PR DESCRIPTION
## 개요

https://user-images.githubusercontent.com/15073405/142963584-e7d6fd8e-505f-43a0-9c92-036d27643fae.mp4




댓글 실제 데이터 바인딩

## 작업 사항

- 설정에 있던 댓글 화면 제거
- 댓글 저장 기능 구현
  - 이걸 구현하는 중간에 CommentEntity.createDate가 defaultDate로 저장되고 있는 걸 발견해서 현재 날짜로 저장하게 수정했습니다.
- 댓글 수정 기능 구현
  - 기존에 PostRepository에 있는 update 메서드는 Post 객체로 수정하기 때문에 PostEntity를 이용해 수정하는 메서드를 추가했습니다.
- 댓글 삭제 기능 구현
  - 댓글을 삭제 하기 전에 사용자에게 경고 알림을 띄웁니다.
- 실제 데이터 바인딩
- 게시물 화면으로 다시 돌아갔을 때 테이블뷰 업데이트
  - 댓글이 추가되거나, 삭제되고 나서 이전 화면으로 돌아갔을 때 `댓글 n개 모두 보기`가 갱신되어야 해서 추가했습니다.
- 기존에 댓글화면을 띄우기 위해서 PostEntity를 파라미터로 받고 있던 부분을, CommentViewModel로 받게 수정했습니다. CommentViewModel은 생성 시에 PostEntity가 필요합니다.

## 예외 사항

- 이전 화면으로 돌아갈 때 startIndexPath로 돌아가는 현상은 풀 리퀘스트 #243 에 있기 때문에 해결하지 않았습니다.

### Linked Issue

close #235
