### PR TITLE
[#253] 게시물: 게시물 삭제 시 휴지통으로 이동

### DIFF
--- a/ThingLog/ViewController/Post/PostViewController.swift
+++ b/ThingLog/ViewController/Post/PostViewController.swift
@@ -89,7 +89,9 @@ final class PostViewController: BaseViewController {
         }.disposed(by: disposeBag)
 
         alert.rightButton.rx.tap.bind { [weak self] in
-            self?.viewModel.repository.delete([post]) { result in
+            post.postType?.isDelete = true
+            post.deleteDate = Date()
+            self?.viewModel.repository.update(post, completion: { result in
                 switch result {
                 case .success:
                     self?.tableView.reloadData()
@@ -100,7 +102,7 @@ final class PostViewController: BaseViewController {
                 case .failure(let error):
                     fatalError("\(#function): \(error.localizedDescription)")
                 }
-            }
+            })
             alert.dismiss(animated: false, completion: nil)
         }.disposed(by: disposeBag)
 


### PR DESCRIPTION
## 개요

게시물 삭제 시 휴지통으로 이동한다. (바로 삭제가 아니고, 업데이트)

## 작업 사항

풀 리퀘스트 #236 에서 게시물 삭제 기능을 구현할 때 바로 삭제하면 안되고 휴지통으로 이동되게 했어야 했는데 그냥 삭제하는 로직으로 작성했었습니다. 그래서 해당 부분을 수정했습니다.

### Linked Issue

close #253