### PR TITLE
[#257] 글쓰기: 저장할 때 textView의 색상이 placeholder 색상이면 텍스트 저장하지 않기

### DIFF
--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
@@ -318,7 +318,7 @@ final class PostTableCell: UITableViewCell {
         configurePriceLabel(type: type, price: post.price)
 
         // 본문
-        configureContents(text: post.contents)
+        contentTextView.text = post.contents
 
         // 댓글 n개 모두 보기
         configureCommentMoreButton(with: post.comments?.allObjects.count)
@@ -391,14 +391,6 @@ extension PostTableCell {
         priceLabel.text = price == 0 ? "가격" : "\(formattedPrice) 원"
         priceLabel.font = price == 0 ? UIFont.Pretendard.body1 : UIFont.Pretendard.title1
         priceLabel.textColor = price == 0 ? SwiftGenColors.gray2.color : SwiftGenColors.black.color
-    }
-
-    /// contentTextView를 구성한다. 텍스트가 없는 경우 기본 값과 함께 색상을 변경한다.
-    private func configureContents(text: String?) {
-        let isEmpty: Bool = text?.isEmpty ?? true
-
-        contentTextView.text = isEmpty ? "물건에 대한 생각이나 감정을 자유롭게 기록해보세요." : text
-        contentTextView.textColor = isEmpty ? SwiftGenColors.gray2.color : SwiftGenColors.primaryBlack.color
     }
 
     /// CommentMoreButton을 구성한다.

--- a/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
@@ -54,9 +54,9 @@ final class WriteTextFieldCell: UITableViewCell {
     func configure(keyboardType: UIKeyboardType, placeholder: String) {
         textField.keyboardType = keyboardType
         textField.isSelection = keyboardType == .numberPad ? false : true
-        textField.attributedPlaceholder = NSAttributedString(string: placeholder ?? "",
+        textField.attributedPlaceholder = NSAttributedString(string: placeholder,
                                                              attributes: [
-                                                                NSAttributedString.Key.foregroundColor: SwiftGenColors.gray3.color,
+                                                                NSAttributedString.Key.foregroundColor: SwiftGenColors.gray2.color,
                                                                 NSAttributedString.Key.font: UIFont.Pretendard.body1
                                                              ])
     }

--- a/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextViewCell.swift
@@ -18,7 +18,7 @@ final class WriteTextViewCell: UITableViewCell {
         textView.isEditable = true
         textView.isScrollEnabled = false
         textView.font = UIFont.Pretendard.body1
-        textView.textColor = SwiftGenColors.gray4.color
+        textView.textColor = SwiftGenColors.gray2.color
         textView.text = "물건에 대한 생각이나 감정을 자유롭게 기록해보세요."
         textView.backgroundColor = .clear
         textView.sizeToFit()
@@ -95,16 +95,16 @@ extension WriteTextViewCell {
 
 extension WriteTextViewCell: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.textColor == SwiftGenColors.gray4.color {
+        if textView.textColor == SwiftGenColors.gray2.color {
             textView.text = nil
-            textView.textColor = SwiftGenColors.black.color
+            textView.textColor = SwiftGenColors.primaryBlack.color
         }
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
             textView.text = "물건에 대한 생각이나 감정을 자유롭게 기록해보세요."
-            textView.textColor = SwiftGenColors.gray4.color
+            textView.textColor = SwiftGenColors.gray2.color
         }
     }
 

--- a/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
+++ b/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
@@ -110,7 +110,11 @@ extension WriteViewController {
             }.disposed(by: cell.disposeBag)
         cell.textView.rx.text.orEmpty
             .subscribe(onNext: { [weak self] text in
-                self?.viewModel.contents = text
+                if cell.textView.textColor == SwiftGenColors.gray4.color {
+                    self?.viewModel.contents = ""
+                } else {
+                    self?.viewModel.contents = text
+                }
             }).disposed(by: cell.disposeBag)
 
         return cell

--- a/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
+++ b/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
@@ -110,7 +110,7 @@ extension WriteViewController {
             }.disposed(by: cell.disposeBag)
         cell.textView.rx.text.orEmpty
             .subscribe(onNext: { [weak self] text in
-                if cell.textView.textColor == SwiftGenColors.gray4.color {
+                if cell.textView.textColor == SwiftGenColors.gray2.color {
                     self?.viewModel.contents = ""
                 } else {
                     self?.viewModel.contents = text

--- a/ThingLog/ViewController/Write/WriteViewController.swift
+++ b/ThingLog/ViewController/Write/WriteViewController.swift
@@ -20,7 +20,7 @@ final class WriteViewController: BaseViewController {
         
         let headerLabel: UILabel = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 29.0))
         headerLabel.font = UIFont.Pretendard.body2
-        headerLabel.textColor = SwiftGenColors.gray3.color
+        headerLabel.textColor = SwiftGenColors.gray2.color
         headerLabel.text = "\(Date().toString(.year))년 \(Date().toString(.month))월 \(Date().toString(.day))일"
         headerLabel.textAlignment = .center
         


### PR DESCRIPTION
## 개요

- textView 색상이 placeholder 색상일 때 본문 저장하지 않게 수정
- 글쓰기 화면 일부 색상 변경
- 자유 글쓰기 항목이 비어있을 때 아무 글도 노출되지 않게 변경

## 작업 사항

`textView 색상이 placeholder 색상일 때 본문 저장하지 않게 수정`와 간단한 작업을 추가적으로 함께 진행했습니다.

- textView 색상이 placeholder 색상일 때 본문 저장하지 않게 수정
  - 텍스트 뷰는 placeholder를 지원하지 않아서 약간의 편법으로 placeholder를 구현했는데, 이 값이 게시물을 저장할 때 같이 저장되고 있었습니다. 그래서 사용자가 본문을 작성하지 않았음에도 `물건에 대한 생각이나 감정을 자유롭게 기록해보세요.`이 저장되고 있어서 해당 부분을 수정했습니다.
- 글쓰기 화면 일부 색상 변경
  - 화면 설계서와 달리 반영되지 않았던 색상을 반영했습니다.
- 자유 글쓰기 항목이 비어있을 때 아무 글도 노출되지 않게 변경
  - 병연님 요청 사항으로 수정했습니다.

### Linked Issue

close #257

