### PR TITLE
[#249, #261] ref: 로그인 버튼 비활성화 및 병연님 피드백 반영 1.0.0 ( 22 )

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		DB3A5165270FFE0C003B529D /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A5164270FFE0C003B529D /* String+.swift */; };
 		DB3A516927103B3E003B529D /* EmptyPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A516827103B3E003B529D /* EmptyPostView.swift */; };
 		DB3A516B27103DC4003B529D /* EmptyResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A516A27103DC4003B529D /* EmptyResultsView.swift */; };
+		DB574FFF275330F50032057A /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB574FFE275330F50032057A /* UINavigationController+.swift */; };
 		DB62C4BE272BD9E9000ED955 /* DrawerHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB62C4BD272BD9E9000ED955 /* DrawerHeaderView.swift */; };
 		DB69095D2712B5EB00BB54E4 /* ThingLogPostTypeRequestTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB69095C2712B5EB00BB54E4 /* ThingLogPostTypeRequestTest.swift */; };
 		DB69095F2712C55F00BB54E4 /* SearchResultsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB69095E2712C55F00BB54E4 /* SearchResultsViewModel.swift */; };
@@ -408,6 +409,7 @@
 		DB3A5164270FFE0C003B529D /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		DB3A516827103B3E003B529D /* EmptyPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPostView.swift; sourceTree = "<group>"; };
 		DB3A516A27103DC4003B529D /* EmptyResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResultsView.swift; sourceTree = "<group>"; };
+		DB574FFE275330F50032057A /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		DB62C4BD272BD9E9000ED955 /* DrawerHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerHeaderView.swift; sourceTree = "<group>"; };
 		DB69095C2712B5EB00BB54E4 /* ThingLogPostTypeRequestTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingLogPostTypeRequestTest.swift; sourceTree = "<group>"; };
 		DB69095E2712C55F00BB54E4 /* SearchResultsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsViewModel.swift; sourceTree = "<group>"; };
@@ -946,16 +948,17 @@
 			children = (
 				875B8FFC273AAE850059DF2A /* Collection+.swift */,
 				DB148C25270469B300FDC48F /* Date+.swift */,
+				87DD9E4C274F5569002CFB3A /* Int64+.swift */,
 				873ED128272AB77000C9F7F1 /* Notification.Name+.swift */,
 				873ED126272AAFFD00C9F7F1 /* PHAsset+.swift */,
 				DB3A5164270FFE0C003B529D /* String+.swift */,
 				8736B3F326FDD55E000433E1 /* UIFont+.swift */,
 				DBAB64A626FE2AFF006D95ED /* UIImage+.swift */,
+				DB574FFE275330F50032057A /* UINavigationController+.swift */,
 				DB7C04EB26FB1A04009F5C0A /* UIView+.swift */,
 				DB05B03F27185C500067DB17 /* UIViewController+.swift */,
 				DB7C04C926F9E69D009F5C0A /* UserDefaults+.swift */,
 				8789A19D272C5DCC00CFB16C /* Notification.Name+.swift */,
-				87DD9E4C274F5569002CFB3A /* Int64+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1343,6 +1346,7 @@
 				DBD2244727085671004C5184 /* EasyLookViewController+subscribe.swift in Sources */,
 				8738E1CB271705220069BB80 /* CategoryViewController.swift in Sources */,
 				DB7C04EE26FB1ACE009F5C0A /* ContentsTabView.swift in Sources */,
+				DB574FFF275330F50032057A /* UINavigationController+.swift in Sources */,
 				DB7B4702274102B300426EF1 /* OnboardingCoordinator.swift in Sources */,
 				DB05B04C271F04E50067DB17 /* TextFieldWithLabelWithButtonCollectionCell.swift in Sources */,
 				DB32B289272C2028009074AF /* KeyStoreName.swift in Sources */,

--- a/ThingLog/Extension/UINavigationController+.swift
+++ b/ThingLog/Extension/UINavigationController+.swift
@@ -1,0 +1,18 @@
+//
+//  UINavigationController+.swift
+//  ThingLog
+//
+//  Created by hyunsu on 2021/11/28.
+//
+
+import UIKit
+
+extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        viewControllers.count > 1
+    }
+}

--- a/ThingLog/View/CollectionViewCell/ContentsDetailCollectionViewCell.swift
+++ b/ThingLog/View/CollectionViewCell/ContentsDetailCollectionViewCell.swift
@@ -128,7 +128,6 @@ final class ContentsDetailCollectionViewCell: UICollectionViewCell {
         stackView.axis = .horizontal
         stackView.spacing = 10
         stackView.translatesAutoresizingMaskIntoConstraints = false
-//        stackView.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return stackView
     }()
     
@@ -219,6 +218,11 @@ final class ContentsDetailCollectionViewCell: UICollectionViewCell {
         super.init(coder: coder)
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        contentsLabel.attributedText = nil 
+    }
+    
     // MARK: - Setup
     private func setBackgroundColor() {
         topBorderLineView.backgroundColor = SwiftGenColors.gray4.color
@@ -243,7 +247,10 @@ final class ContentsDetailCollectionViewCell: UICollectionViewCell {
             dateTopEmptyView.heightAnchor.constraint(equalToConstant: 4),
             
             categoryLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 80),
-            postTitleLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 80)
+            postTitleLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 80),
+            
+            rightStackViewTrailing.widthAnchor.constraint(equalToConstant: 10),
+            rightStackViewTrailing.heightAnchor.constraint(equalToConstant: 10)
         ])
     }
     
@@ -282,7 +289,7 @@ final class ContentsDetailCollectionViewCell: UICollectionViewCell {
         
         let attributedStr: NSMutableAttributedString = NSMutableAttributedString(string: newContents)
         attributedStr.addAttribute(NSAttributedString.Key.foregroundColor,
-                                   value: UIColor.systemRed,
+                                   value: SwiftGenColors.systemRed.color,
                                    range: (newContents as NSString).range(of: keyWord))
         contentsLabel.attributedText = attributedStr
     }

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -142,8 +142,8 @@ class ContentsCollectionViewCell: UICollectionViewCell {
             
             smallIconView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 7),
             smallIconView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -7),
-            smallIconView.widthAnchor.constraint(equalToConstant: 10),
-            smallIconView.heightAnchor.constraint(equalToConstant: 10),
+            smallIconView.widthAnchor.constraint(equalToConstant: 12),
+            smallIconView.heightAnchor.constraint(equalToConstant: 12),
             
             imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor),
             

--- a/ThingLog/ViewController/Login/LoginViewController.swift
+++ b/ThingLog/ViewController/Login/LoginViewController.swift
@@ -41,6 +41,8 @@ final class LoginViewController: UIViewController {
     private lazy var loginButton: RoundCenterTextButton = {
         let button: RoundCenterTextButton = RoundCenterTextButton(cornerRadius: loginButtonHeight / 2)
         button.setTitle("로그인하기", for: .normal)
+        button.setTitleColor(SwiftGenColors.white.color.withAlphaComponent(0.5), for: .disabled)
+        button.backgroundColor = button.backgroundColor?.withAlphaComponent(0.5)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
@@ -58,7 +60,18 @@ final class LoginViewController: UIViewController {
     
     lazy var userInformation: UserInformationable = UserInformation(userAliasName: "",
                                                                     userOneLineIntroduction: "",
-                                                                    isAumatedDarkMode: traitCollection.userInterfaceStyle == .dark)
+                                                                    isAumatedDarkMode: traitCollection.userInterfaceStyle == .dark) {
+        didSet {
+            if userInformation.userAliasName.isEmpty && userInformation.userOneLineIntroduction.isEmpty {
+                loginButton.backgroundColor = SwiftGenColors.primaryBlack.color.withAlphaComponent(0.5)
+                loginButton.isEnabled = false
+            } else {
+                loginButton.backgroundColor = SwiftGenColors.primaryBlack.color
+                loginButton.isEnabled = true
+            }
+        }
+    }
+    
     private let userInformationViewModel: UserInformationViewModelable = UserInformationiCloudViewModel()
     
     // MARK: - Init


### PR DESCRIPTION
## 개요
![log](https://user-images.githubusercontent.com/48749182/143728639-b0fb9e85-a6e1-4337-80b8-25deba580034.gif)

## 작업 사항
- 로그인 뷰에서 정보가 없는 경우에는 로그인 버튼의 투명도 50프로를 주면서 로그인이 되지 않게 구현
- 한 포스트에 이미지가 여러개인 경우에 표시하는 아이콘의 크기를 약간 키움 
- 네비게이션뷰 컨트롤러에서 push된 뷰컨트롤러가 swipe 하여 사라지도록 하기 위하여 `extension`으로 구현 
- 검색창의 DetailContentsCollectionViewCell 약간 조정 
    - #260 의 문제를 저는 아이폰 12 프로 14.5에서는 발견하지 못했는데, 그래도 혹시 몰라서 `prepareForResuse`에 `attribute`를 초기화하도록 했습니다.  
    - 추가적으로 컨텐츠 내용의 너비가 작게 나오는 경우, 크게 나오도록 변경. 

### Linked Issue
- close #249 
- close #261 


