### PR TITLE
[#245] 글쓰기: 수정 기능 구현

### DIFF
--- a/ThingLog/SwiftGen/ColorsAsset.swift
+++ b/ThingLog/SwiftGen/ColorsAsset.swift
@@ -59,6 +59,17 @@ internal final class ColorSwiftGen {
     return color
   }()
 
+  #if os(iOS) || os(tvOS)
+  @available(iOS 11.0, tvOS 11.0, *)
+  internal func color(compatibleWith traitCollection: UITraitCollection) -> Color {
+    let bundle = BundleToken.bundle
+    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }

--- a/ThingLog/SwiftGen/DrawersAssets.swift
+++ b/ThingLog/SwiftGen/DrawersAssets.swift
@@ -42,6 +42,7 @@ internal struct DrawerImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -57,9 +58,21 @@ internal struct DrawerImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension DrawerImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the DrawerImageSwiftGen.image property")
   convenience init?(asset: DrawerImageSwiftGen) {

--- a/ThingLog/SwiftGen/Fonts.swift
+++ b/ThingLog/SwiftGen/Fonts.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
-#if os(OSX)
+#if os(macOS)
   import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
@@ -38,7 +38,7 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
-  #if os(OSX)
+  #if os(macOS)
   internal typealias Font = NSFont
   #elseif os(iOS) || os(tvOS) || os(watchOS)
   internal typealias Font = UIFont
@@ -69,7 +69,7 @@ internal extension FontConvertible.Font {
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
-    #elseif os(OSX)
+    #elseif os(macOS)
     if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }

--- a/ThingLog/SwiftGen/FrameAssets.swift
+++ b/ThingLog/SwiftGen/FrameAssets.swift
@@ -46,6 +46,7 @@ internal struct FrameImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -61,9 +62,21 @@ internal struct FrameImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension FrameImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the FrameImageSwiftGen.image property")
   convenience init?(asset: FrameImageSwiftGen) {

--- a/ThingLog/SwiftGen/IconsAssets.swift
+++ b/ThingLog/SwiftGen/IconsAssets.swift
@@ -77,6 +77,7 @@ internal struct IconImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -92,9 +93,21 @@ internal struct IconImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension IconImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the IconImageSwiftGen.image property")
   convenience init?(asset: IconImageSwiftGen) {

--- a/ThingLog/SwiftGen/ImageAssets.swift
+++ b/ThingLog/SwiftGen/ImageAssets.swift
@@ -56,6 +56,7 @@ internal struct ImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -71,9 +72,21 @@ internal struct ImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension ImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the ImageSwiftGen.image property")
   convenience init?(asset: ImageSwiftGen) {

--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
@@ -349,6 +349,7 @@ extension PostTableCell {
         if let categories: [CategoryEntity] = categories?.allObjects as? [CategoryEntity] {
             categoryViewDataSource.items = categories.isEmpty ? ["카테고리"] : categories.compactMap { $0.title }
             categoryViewDataSource.isEmpty = categories.isEmpty
+            categoryCollectionView.reloadData()
         }
     }
 

--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
@@ -386,7 +386,7 @@ extension PostTableCell {
 
         priceLabel.text = price == 0 ? "가격" : "\(formattedPrice) 원"
         priceLabel.font = price == 0 ? UIFont.Pretendard.body1 : UIFont.Pretendard.title1
-        priceLabel.textColor = price == 0 ? SwiftGenColors.gray2.color : SwiftGenColors.black.color
+        priceLabel.textColor = price == 0 ? SwiftGenColors.gray2.color : SwiftGenColors.primaryBlack.color
     }
 
     /// CommentMoreButton을 구성한다.

--- a/ThingLog/View/TableVeiwCell/WriteRatingCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteRatingCell.swift
@@ -51,6 +51,10 @@ final class WriteRatingCell: UITableViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    func setCurrentRating(_ rating: Int) {
+        ratingView.currentRating = rating
+    }
 }
 
 extension WriteRatingCell {

--- a/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
+++ b/ThingLog/View/TableVeiwCell/WriteTextFieldCell.swift
@@ -51,7 +51,7 @@ final class WriteTextFieldCell: UITableViewCell {
     }
 
     /// 텍스트 필드의 키보드 타입과 플레이스 홀더를 구성한다.
-    func configure(keyboardType: UIKeyboardType, placeholder: String) {
+    func configure(keyboardType: UIKeyboardType, placeholder: String, text: String?) {
         textField.keyboardType = keyboardType
         textField.isSelection = keyboardType == .numberPad ? false : true
         textField.attributedPlaceholder = NSAttributedString(string: placeholder,
@@ -59,6 +59,12 @@ final class WriteTextFieldCell: UITableViewCell {
                                                                 NSAttributedString.Key.foregroundColor: SwiftGenColors.gray2.color,
                                                                 NSAttributedString.Key.font: UIFont.Pretendard.body1
                                                              ])
+        if keyboardType == .numberPad,
+           let priceText: String = Int64(text ?? "")?.toStringWithComma() {
+            textField.text = "\(priceText) 원"
+        } else {
+            textField.text = text
+        }
     }
 }
 

--- a/ThingLog/ViewController/Photos/PhotosViewController+CollectionView.swift
+++ b/ThingLog/ViewController/Photos/PhotosViewController+CollectionView.swift
@@ -84,23 +84,21 @@ extension PhotosViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.item == 0 {
             switch AVCaptureDevice.authorizationStatus(for: .video) {
-              case .authorized:
-                  present(imagePickerController, animated: true)
-              case .notDetermined:
-                  AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
-                      guard let self = self else { return }
-                      if granted {
-                          DispatchQueue.main.async {
-                              self.present(self.imagePickerController, animated: true)
-                          }
-                      }
-                  }
-              case .denied:
-                  coordinator?.showMoveSettingAlert()
-              case .restricted:
-                  coordinator?.showMoveSettingAlert()
-              @unknown default:
-                  coordinator?.showMoveSettingAlert()
+            case .authorized:
+                present(imagePickerController, animated: true)
+            case .notDetermined:
+                AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                    guard let self = self else { return }
+                    if granted {
+                        DispatchQueue.main.async {
+                            self.present(self.imagePickerController, animated: true)
+                        }
+                    }
+                }
+            case .denied, .restricted:
+                coordinator?.showMoveSettingAlert()
+            @unknown default:
+                coordinator?.showMoveSettingAlert()
             }
         } else {
             let asset: PHAsset = assets.object(at: indexPath.item - 1)

--- a/ThingLog/ViewController/Post/PostViewController+DataSource.swift
+++ b/ThingLog/ViewController/Post/PostViewController+DataSource.swift
@@ -18,9 +18,31 @@ extension PostViewController: UITableViewDataSource {
         }
 
         let item: PostEntity = viewModel.fetchedResultsController.object(at: indexPath)
-
         cell.configure(with: item)
 
+        bindLikeButton(cell, with: item)
+        bindPhotocardButton(cell, with: item)
+        bindCommentButton(cell, with: item)
+        bindCommentMoreButton(cell, with: item)
+        bindBoughtButton(cell, with: item)
+
+        cell.moreMenuButton.modifyPostCallback = { [weak self] in
+            guard let type: PageType = item.postType?.pageType else {
+                fatalError("\(#function): not found page type")
+            }
+
+            let viewModel: WriteViewModel = WriteViewModel(pageType: type, modifyEntity: item)
+            self?.coordinator?.showWriteViewController(with: viewModel)
+        }
+
+        cell.moreMenuButton.removePostCallback = { [weak self] in
+            self?.showRemovePostAlert(post: item)
+        }
+
+        return cell
+    }
+
+    private func bindLikeButton(_ cell: PostTableCell, with item: PostEntity) {
         cell.likeButton.rx.tap
             .bind { [weak self] in
                 item.isLike.toggle()
@@ -33,16 +55,9 @@ extension PostViewController: UITableViewDataSource {
                     }
                 }
             }.disposed(by: cell.disposeBag)
+    }
 
-        cell.moreMenuButton.modifyPostCallback = { [weak self] in
-            let viewModel: WriteViewModel = WriteViewModel(pageType: .bought, modifyEntity: item)
-            self?.coordinator?.showWriteViewController(with: viewModel)
-        }
-
-        cell.moreMenuButton.removePostCallback = { [weak self] in
-            self?.showRemovePostAlert(post: item)
-        }
-
+    private func bindPhotocardButton(_ cell: PostTableCell, with item: PostEntity) {
         cell.photocardButton.rx.tap
             .bind { [weak self] in
                 guard let image: UIImage = item.getImage(at: cell.currentImagePage - 1) else {
@@ -50,19 +65,30 @@ extension PostViewController: UITableViewDataSource {
                 }
                 self?.coordinator?.showPhotoCardController(post: item, image: image)
             }.disposed(by: cell.disposeBag)
+    }
 
+    private func bindCommentButton(_ cell: PostTableCell, with item: PostEntity) {
         cell.commentButton.rx.tap
             .bind { [weak self] in
                 let viewModel: CommentViewModel = CommentViewModel(postEntity: item)
                 self?.coordinator?.showCommentViewController(with: viewModel)
             }.disposed(by: cell.disposeBag)
+    }
 
+    private func bindCommentMoreButton(_ cell: PostTableCell, with item: PostEntity) {
         cell.commentMoreButton.rx.tap
             .bind { [weak self] in
                 let viewModel: CommentViewModel = CommentViewModel(postEntity: item)
                 self?.coordinator?.showCommentViewController(with: viewModel)
             }.disposed(by: cell.disposeBag)
+    }
 
-        return cell
+    private func bindBoughtButton(_ cell: PostTableCell, with item: PostEntity) {
+        cell.boughtButton.rx.tap
+            .bind { [weak self] in
+                let viewModel: WriteViewModel = WriteViewModel(pageType: .bought,
+                                                               modifyEntity: item)
+                self?.coordinator?.showWriteViewController(with: viewModel)
+            }.disposed(by: cell.disposeBag)
     }
 }

--- a/ThingLog/ViewController/Post/PostViewController+DataSource.swift
+++ b/ThingLog/ViewController/Post/PostViewController+DataSource.swift
@@ -25,19 +25,7 @@ extension PostViewController: UITableViewDataSource {
         bindCommentButton(cell, with: item)
         bindCommentMoreButton(cell, with: item)
         bindBoughtButton(cell, with: item)
-
-        cell.moreMenuButton.modifyPostCallback = { [weak self] in
-            guard let type: PageType = item.postType?.pageType else {
-                fatalError("\(#function): not found page type")
-            }
-
-            let viewModel: WriteViewModel = WriteViewModel(pageType: type, modifyEntity: item)
-            self?.coordinator?.showWriteViewController(with: viewModel)
-        }
-
-        cell.moreMenuButton.removePostCallback = { [weak self] in
-            self?.showRemovePostAlert(post: item)
-        }
+        setupMoreMenuCallback(cell, item)
 
         return cell
     }
@@ -90,5 +78,20 @@ extension PostViewController: UITableViewDataSource {
                                                                modifyEntity: item)
                 self?.coordinator?.showWriteViewController(with: viewModel)
             }.disposed(by: cell.disposeBag)
+    }
+
+    private func setupMoreMenuCallback(_ cell: PostTableCell, _ item: PostEntity) {
+        cell.moreMenuButton.modifyPostCallback = { [weak self] in
+            guard let type: PageType = item.postType?.pageType else {
+                fatalError("\(#function): not found page type")
+            }
+
+            let viewModel: WriteViewModel = WriteViewModel(pageType: type, modifyEntity: item)
+            self?.coordinator?.showWriteViewController(with: viewModel)
+        }
+
+        cell.moreMenuButton.removePostCallback = { [weak self] in
+            self?.showRemovePostAlert(post: item)
+        }
     }
 }

--- a/ThingLog/ViewController/Post/PostViewController+DataSource.swift
+++ b/ThingLog/ViewController/Post/PostViewController+DataSource.swift
@@ -34,8 +34,9 @@ extension PostViewController: UITableViewDataSource {
                 }
             }.disposed(by: cell.disposeBag)
 
-        cell.moreMenuButton.modifyPostCallback = {
-            // TODO: 수정 기능
+        cell.moreMenuButton.modifyPostCallback = { [weak self] in
+            let viewModel: WriteViewModel = WriteViewModel(pageType: .bought, modifyEntity: item)
+            self?.coordinator?.showWriteViewController(with: viewModel)
         }
 
         cell.moreMenuButton.removePostCallback = { [weak self] in

--- a/ThingLog/ViewController/Post/PostViewController.swift
+++ b/ThingLog/ViewController/Post/PostViewController.swift
@@ -44,11 +44,15 @@ final class PostViewController: BaseViewController {
         if isMovingToParent {
             let startIndexPath: IndexPath = IndexPath(row: viewModel.startIndexPath.row, section: 0)
             tableView.scrollToRow(at: startIndexPath, at: .top, animated: false)
+            UIView.performWithoutAnimation {
+                tableView.reloadRows(at: [startIndexPath], with: .automatic)
+            }
         } else {
-            if let indexPaths: [IndexPath] = tableView.indexPathsForVisibleRows {
+            if viewModel.fetchedResultsController.fetchedObjects?.count ?? 0 > 0,
+               let indexPaths: [IndexPath] = tableView.indexPathsForVisibleRows {
                 tableView.reloadRows(at: indexPaths, with: .none)
             } else {
-                tableView.reloadData()
+                coordinator?.back()
             }
         }
     }

--- a/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
+++ b/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
@@ -106,10 +106,9 @@ extension WriteViewController {
         }
 
         cell.delegate = self
-        if viewModel.contents.isNotEmpty {
-            cell.textView.text = viewModel.contents
-            cell.textView.textColor = SwiftGenColors.primaryBlack.color
-        }
+        cell.textView.text = viewModel.contents.isNotEmpty ? viewModel.contents : "물건에 대한 생각이나 감정을 자유롭게 기록해보세요."
+        cell.textView.textColor = viewModel.contents.isNotEmpty ? SwiftGenColors.primaryBlack.color : SwiftGenColors.gray2.color
+
         cell.textView.rx.didBeginEditing
             .bind { [weak self] in
                 self?.scrollToCurrentRow(at: indexPath)

--- a/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
+++ b/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
@@ -72,7 +72,8 @@ extension WriteViewController {
         }
 
         cell.configure(keyboardType: viewModel.typeInfo[indexPath.row].keyboardType,
-                       placeholder: viewModel.typeInfo[indexPath.row].placeholder)
+                       placeholder: viewModel.typeInfo[indexPath.row].placeholder,
+                       text: viewModel.typeValues[indexPath.row])
         cell.isEditingSubject
             .bind { [weak self] _ in
                 self?.scrollToCurrentRow(at: indexPath)
@@ -90,6 +91,7 @@ extension WriteViewController {
             fatalError("Unable to downcast the cell in dequeueReusableCell to WriteRatingCell")
         }
 
+        cell.setCurrentRating(viewModel.rating)
         cell.selectRatingBlock = { [weak self] in
             self?.viewModel.rating = cell.currentRating
             self?.view.endEditing(true)
@@ -104,6 +106,10 @@ extension WriteViewController {
         }
 
         cell.delegate = self
+        if viewModel.contents.isNotEmpty {
+            cell.textView.text = viewModel.contents
+            cell.textView.textColor = SwiftGenColors.primaryBlack.color
+        }
         cell.textView.rx.didBeginEditing
             .bind { [weak self] in
                 self?.scrollToCurrentRow(at: indexPath)

--- a/ThingLog/ViewController/Write/WriteViewController.swift
+++ b/ThingLog/ViewController/Write/WriteViewController.swift
@@ -80,7 +80,8 @@ final class WriteViewController: BaseViewController {
         closeButton.rx.tap.bind { [weak self] in
             self?.closeWithAlert()
         }.disposed(by: disposeBag)
-        
+
+        navigationItem.hidesBackButton = true
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: closeButton)
     }
     

--- a/ThingLog/ViewController/Write/WriteViewController.swift
+++ b/ThingLog/ViewController/Write/WriteViewController.swift
@@ -12,7 +12,7 @@ import RxSwift
 /// 글쓰기 화면(샀다, 사고싶다, 선물받았다)를 담당하는 ViewController
 final class WriteViewController: BaseViewController {
     // MARK: - View Properties
-    let tableView: UITableView = {
+    lazy var tableView: UITableView = {
         let tableView: UITableView = UITableView(frame: .zero, style: .plain)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
@@ -21,7 +21,7 @@ final class WriteViewController: BaseViewController {
         let headerLabel: UILabel = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 29.0))
         headerLabel.font = UIFont.Pretendard.body2
         headerLabel.textColor = SwiftGenColors.gray2.color
-        headerLabel.text = "\(Date().toString(.year))년 \(Date().toString(.month))월 \(Date().toString(.day))일"
+        headerLabel.text = viewModel.createDate
         headerLabel.textAlignment = .center
         
         tableView.tableHeaderView = headerLabel
@@ -60,6 +60,21 @@ final class WriteViewController: BaseViewController {
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+
+    // 게시물 수정일 때 썸네일과 카테고리가 제대로 표시되지 않는 문제를 해결하기 위해 해당 섹션만 별도로 reload
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if viewModel.modifyEntity != nil {
+            let imageSection: Int = WriteViewModel.Section.image.rawValue
+            let categorySection: Int = WriteViewModel.Section.category.rawValue
+            UIView.performWithoutAnimation {
+                tableView.reloadRows(at: [IndexPath(row: 0, section: imageSection)],
+                                     with: .none)
+                tableView.reloadRows(at: [IndexPath(row: 0, section: categorySection)],
+                                     with: .none)
+            }
+        }
     }
 
     // MARK: - Setup

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -45,6 +45,7 @@ final class WriteViewModel {
     lazy var typeValues: [String?] = Array(repeating: "", count: typeInfo.count)
     private(set) var originalImages: [UIImage] = []
     private var categories: [Category] = []
+    private var modifyEntity: PostEntity?
 
     // MARK: - Rx
     private(set) var thumbnailImagesSubject: BehaviorSubject<[UIImage]> = BehaviorSubject<[UIImage]>(value: [])
@@ -52,8 +53,9 @@ final class WriteViewModel {
     private let disposeBag: DisposeBag = DisposeBag()
 
     // MARK: - Init
-    init(pageType: PageType) {
+    init(pageType: PageType, modifyEntity: PostEntity? = nil) {
         self.pageType = pageType
+        self.modifyEntity = modifyEntity
 
         setupBinding()
     }

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -152,9 +152,18 @@ final class WriteViewModel {
         }
 
         modifyEntity.title = typeValues[0]
-        modifyEntity.price = Int64(typeValues[1]?.filter("0123456789".contains) ?? "") ?? 0
-        modifyEntity.purchasePlace = typeValues[2]
-        modifyEntity.postType?.pageType = .bought
+        switch pageType {
+        case .bought:
+            modifyEntity.price = Int64(typeValues[1]?.filter("0123456789".contains) ?? "") ?? 0
+            modifyEntity.purchasePlace = typeValues[2]
+        case .wish:
+            modifyEntity.price = Int64(typeValues[1]?.filter("0123456789".contains) ?? "") ?? 0
+            modifyEntity.purchasePlace = typeValues[2]
+        case .gift:
+            modifyEntity.giftGiver = typeValues[1]
+        }
+
+        modifyEntity.postType?.pageType = pageType
 
         if let attachmentEntities: NSSet = modifyEntity.attachments {
             modifyEntity.removeFromAttachments(attachmentEntities)

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -35,7 +35,7 @@ final class WriteViewModel {
     }
     var createDate: String = "\(Date().toString(.year))년 \(Date().toString(.month))월 \(Date().toString(.day))일"
     /// Section 마다 표시할 항목의 개수
-    lazy var itemCount: [Int] = [1, 1, typeInfo.count, 1, 1]
+    lazy var itemCount: [Int] = [1, 1, typeInfo.count, pageType == .wish ? 0 : 1, 1]
     private let repository: PostRepository = PostRepository(fetchedResultsControllerDelegate: nil)
     private var isSelectImages: Bool = false
 
@@ -174,6 +174,7 @@ final class WriteViewModel {
         }
 
         modifyEntity.contents = contents
+        modifyEntity.rating?.scoreType = ScoreType(rawValue: Int16(rating)) ?? ScoreType.unrated
     }
 }
 


### PR DESCRIPTION
## 개요

![ezgif-2-76925612f22f](https://user-images.githubusercontent.com/15073405/143732899-8eb4583b-4917-4189-8a4c-9fdb1b599f18.gif)

글쓰기: 수정 기능 구현

## 작업 사항

- 게시물 수정 기능 구현
- 게시물 수정일 때 실제 데이터를 글쓰기 입력폼에 표시
- 게시물에서 수정 버튼을 선택하면 게시물 수정화면으로 이동, 저장 시 샀어요로 저장
- 게시물에서 카테고리가 제대로 표시 되고 있지 않아서.. 이미지와 동일하게 reloadData() 호출
- 사고싶다 글쓰기일 때 만족도가 표시되면 안되는데, 표시되고 있어서 수정했습니다.

### Linked Issue

close #245