### PR TITLE
[#263] 글쓰기: 사진 촬영 후 글쓰기 화면으로 이미지 전달

### DIFF
--- a/ThingLog/SwiftGen/ColorsAsset.swift
+++ b/ThingLog/SwiftGen/ColorsAsset.swift
@@ -59,6 +59,17 @@ internal final class ColorSwiftGen {
     return color
   }()
 
+  #if os(iOS) || os(tvOS)
+  @available(iOS 11.0, tvOS 11.0, *)
+  internal func color(compatibleWith traitCollection: UITraitCollection) -> Color {
+    let bundle = BundleToken.bundle
+    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }

--- a/ThingLog/SwiftGen/DrawersAssets.swift
+++ b/ThingLog/SwiftGen/DrawersAssets.swift
@@ -42,6 +42,7 @@ internal struct DrawerImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -57,9 +58,21 @@ internal struct DrawerImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension DrawerImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the DrawerImageSwiftGen.image property")
   convenience init?(asset: DrawerImageSwiftGen) {

--- a/ThingLog/SwiftGen/Fonts.swift
+++ b/ThingLog/SwiftGen/Fonts.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
-#if os(OSX)
+#if os(macOS)
   import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
@@ -38,7 +38,7 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
-  #if os(OSX)
+  #if os(macOS)
   internal typealias Font = NSFont
   #elseif os(iOS) || os(tvOS) || os(watchOS)
   internal typealias Font = UIFont
@@ -69,7 +69,7 @@ internal extension FontConvertible.Font {
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
-    #elseif os(OSX)
+    #elseif os(macOS)
     if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }

--- a/ThingLog/SwiftGen/FrameAssets.swift
+++ b/ThingLog/SwiftGen/FrameAssets.swift
@@ -46,6 +46,7 @@ internal struct FrameImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -61,9 +62,21 @@ internal struct FrameImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension FrameImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the FrameImageSwiftGen.image property")
   convenience init?(asset: FrameImageSwiftGen) {

--- a/ThingLog/SwiftGen/IconsAssets.swift
+++ b/ThingLog/SwiftGen/IconsAssets.swift
@@ -77,6 +77,7 @@ internal struct IconImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -92,9 +93,21 @@ internal struct IconImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension IconImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the IconImageSwiftGen.image property")
   convenience init?(asset: IconImageSwiftGen) {

--- a/ThingLog/SwiftGen/ImageAssets.swift
+++ b/ThingLog/SwiftGen/ImageAssets.swift
@@ -56,6 +56,7 @@ internal struct ImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -71,9 +72,21 @@ internal struct ImageSwiftGen {
     }
     return result
   }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = BundleToken.bundle
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
 }
 
 internal extension ImageSwiftGen.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the ImageSwiftGen.image property")
   convenience init?(asset: ImageSwiftGen) {

--- a/ThingLog/ViewController/Photos/PhotosViewController.swift
+++ b/ThingLog/ViewController/Photos/PhotosViewController.swift
@@ -211,7 +211,6 @@ extension PhotosViewController {
 }
 // MARK: - Bind
 extension PhotosViewController {
-    
     private func bindNavigationButton() {
         successButton.rx.tap
             .bind { [weak self] in
@@ -382,9 +381,12 @@ extension PhotosViewController: UINavigationControllerDelegate, UIImagePickerCon
             return
         }
 
-        // print out the image size as a test
-        print(image.size)
-        // TODO: WriteViewModel로 편집된 이미지 전달
+        let indexPath: IndexPath = IndexPath(row: 0, section: 0)
+        self.selectedIndexPath = [(indexPath, image)]
+
+        NotificationCenter.default.post(name: .passSelectImages,
+                                        object: nil,
+                                        userInfo: [Notification.Name.passSelectImages: self.convertIndexPathToImages()])
         coordinator?.back()
     }
 }


### PR DESCRIPTION
## 개요

<img src="https://user-images.githubusercontent.com/15073405/143733815-9e712818-410e-4658-addc-1dd44dd2ab5a.gif" width="50%" />

사진 촬영 후 글쓰기 화면으로 이미지 전달

## 작업 사항

- 사진 촬영 후 글쓰기 화면으로 이미지 전달
  - `selectedIndexPath`를 초기화해서 Notification을 post 하고, 이전 화면으로 돌아가게 작성했습니다. 따라서 ... 제가 별도로 이미지 리사이즈를 위해서 구현한 부분은 없습니당

## 예외 사항

- 실 기기에서만 테스트가 가능합니다.
- 현재 `PhotosViewController.collectionView(_:didSelectItemAt:)` 함수 길이가 길어서 실행되지 않는데 해당 부분은 #264 에서 수정했습니다. 테스트할 때는 `.swiftlint`에서 `function_body_length`를 수정해서 실행해주세요 🙏

### Linked Issue

close #263

