### PR TITLE
[#178] feat: 장바구니 진열장 업데이트 메소드 삽입

### DIFF
--- a/ThingLog/SwiftGen/ColorsAsset.swift
+++ b/ThingLog/SwiftGen/ColorsAsset.swift
@@ -59,17 +59,6 @@ internal final class ColorSwiftGen {
     return color
   }()
 
-  #if os(iOS) || os(tvOS)
-  @available(iOS 11.0, tvOS 11.0, *)
-  internal func color(compatibleWith traitCollection: UITraitCollection) -> Color {
-    let bundle = BundleToken.bundle
-    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load color asset named \(name).")
-    }
-    return color
-  }
-  #endif
-
   fileprivate init(name: String) {
     self.name = name
   }

--- a/ThingLog/SwiftGen/DrawersAssets.swift
+++ b/ThingLog/SwiftGen/DrawersAssets.swift
@@ -42,7 +42,6 @@ internal struct DrawerImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -58,21 +57,9 @@ internal struct DrawerImageSwiftGen {
     }
     return result
   }
-
-  #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-  #endif
 }
 
 internal extension DrawerImageSwiftGen.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the DrawerImageSwiftGen.image property")
   convenience init?(asset: DrawerImageSwiftGen) {

--- a/ThingLog/SwiftGen/Fonts.swift
+++ b/ThingLog/SwiftGen/Fonts.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
-#if os(macOS)
+#if os(OSX)
   import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
@@ -38,7 +38,7 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
-  #if os(macOS)
+  #if os(OSX)
   internal typealias Font = NSFont
   #elseif os(iOS) || os(tvOS) || os(watchOS)
   internal typealias Font = UIFont
@@ -69,7 +69,7 @@ internal extension FontConvertible.Font {
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
-    #elseif os(macOS)
+    #elseif os(OSX)
     if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }

--- a/ThingLog/SwiftGen/FrameAssets.swift
+++ b/ThingLog/SwiftGen/FrameAssets.swift
@@ -46,7 +46,6 @@ internal struct FrameImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -62,21 +61,9 @@ internal struct FrameImageSwiftGen {
     }
     return result
   }
-
-  #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-  #endif
 }
 
 internal extension FrameImageSwiftGen.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the FrameImageSwiftGen.image property")
   convenience init?(asset: FrameImageSwiftGen) {

--- a/ThingLog/SwiftGen/IconsAssets.swift
+++ b/ThingLog/SwiftGen/IconsAssets.swift
@@ -77,7 +77,6 @@ internal struct IconImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -93,21 +92,9 @@ internal struct IconImageSwiftGen {
     }
     return result
   }
-
-  #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-  #endif
 }
 
 internal extension IconImageSwiftGen.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the IconImageSwiftGen.image property")
   convenience init?(asset: IconImageSwiftGen) {

--- a/ThingLog/SwiftGen/ImageAssets.swift
+++ b/ThingLog/SwiftGen/ImageAssets.swift
@@ -56,7 +56,6 @@ internal struct ImageSwiftGen {
   internal typealias Image = UIImage
   #endif
 
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   internal var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
@@ -72,21 +71,9 @@ internal struct ImageSwiftGen {
     }
     return result
   }
-
-  #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  internal func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-  #endif
 }
 
 internal extension ImageSwiftGen.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
     message: "This initializer is unsafe on macOS, please use the ImageSwiftGen.image property")
   convenience init?(asset: ImageSwiftGen) {

--- a/ThingLog/ViewController/Write/WriteViewController+setup.swift
+++ b/ThingLog/ViewController/Write/WriteViewController+setup.swift
@@ -91,6 +91,7 @@ extension WriteViewController {
                 guard let self = self else { return }
                 self.viewModel.save { isSave in
                     if isSave {
+                        self.checkIsFromBoughtButton()
                         self.close()
                     } else {
                         self.showRequiredAlert()
@@ -115,7 +116,10 @@ extension WriteViewController {
             }).disposed(by: disposeBag)
     }
     
-    
-    
-    
+    /// 게시글의 샀어요 버튼에서 온 경우인지 판단하는 메서드이다. 만약 맞다면 장바구니 진열장을 업데이트한다.
+    func checkIsFromBoughtButton() {
+        if viewModel.pageType == .bought {
+            DrawerCoreDataRepository(coreDataStack: CoreDataStack.shared).updateBasket()
+        }
+    }
 }

--- a/ThingLog/ViewController/Write/WriteViewController+setup.swift
+++ b/ThingLog/ViewController/Write/WriteViewController+setup.swift
@@ -91,7 +91,7 @@ extension WriteViewController {
                 guard let self = self else { return }
                 self.viewModel.save { isSave in
                     if isSave {
-                        self.checkIsFromBoughtButton()
+                        self.viewModel.checkIsFromBoughtButton()
                         self.close()
                     } else {
                         self.showRequiredAlert()
@@ -114,12 +114,5 @@ extension WriteViewController {
             .subscribe(onNext: { [weak self] _ in
                 self?.tableView.reloadData()
             }).disposed(by: disposeBag)
-    }
-    
-    /// 게시글의 샀어요 버튼에서 온 경우인지 판단하는 메서드이다. 만약 맞다면 장바구니 진열장을 업데이트한다.
-    func checkIsFromBoughtButton() {
-        if viewModel.pageType == .bought {
-            DrawerCoreDataRepository(coreDataStack: CoreDataStack.shared).updateBasket()
-        }
     }
 }

--- a/ThingLog/ViewModel/WriteViewModel.swift
+++ b/ThingLog/ViewModel/WriteViewModel.swift
@@ -47,6 +47,8 @@ final class WriteViewModel {
     private(set) var originalImages: [UIImage] = []
     private var categories: [Category] = []
     private(set) var modifyEntity: PostEntity?
+    /// 수정할 entity의 변하지 않는 PageType이다.
+    private(set) var modifyEntityPageType: PageType?
 
     // MARK: - Rx
     private(set) var thumbnailImagesSubject: BehaviorSubject<[UIImage]> = BehaviorSubject<[UIImage]>(value: [])
@@ -57,7 +59,7 @@ final class WriteViewModel {
     init(pageType: PageType, modifyEntity: PostEntity? = nil) {
         self.pageType = pageType
         self.modifyEntity = modifyEntity
-
+        self.modifyEntityPageType = modifyEntity?.postType?.pageType
         setupBinding()
     }
 
@@ -280,5 +282,12 @@ extension WriteViewModel {
         rating = Int(entity.rating?.score ?? 0)
         // 본문
         contents = entity.contents ?? ""
+    }
+    
+    /// 게시글의 샀어요 버튼에서 온 경우인지 판단하는 메서드이다. 만약 맞다면 장바구니 진열장을 업데이트한다.
+    func checkIsFromBoughtButton() {
+        if modifyEntityPageType == .wish && pageType == .bought {
+            DrawerCoreDataRepository(coreDataStack: CoreDataStack.shared).updateBasket()
+        }
     }
 }


### PR DESCRIPTION
## 개요
-  장바구니 진열장 업데이트 메소드 삽입

![dra](https://user-images.githubusercontent.com/48749182/144032596-39f51d4b-e408-47d0-befe-1eca952cba59.gif)


## 작업 사항
- 파일 하나만 수정했습니다
    -  ~~`PostViewController+DataSource.swift` 에서 샀어요 버튼을 누르면, `ViewModel`에 `pageType`을 `.bought`으로 전달하는 것을 보고,  `WriteViewController`에서 `Done` 버튼을 누를 경우,  `viewModel`을 체크하는 메소드를 추가하여,  장바구니 업데이트 메소드를 삽입했습니다.~~

## 추가작업 
-  기존에 구현한 체크하는 메소드 를 `WriteViewModel`에 옮김.
- `modifyEntity`를 그대로 이용하게 되면, `save` 이후에 `modifyEntity`의 타입이 변경되므로, 변경되지 않는 `modifyEntityPageType`의 프로퍼티를 `WriteViewModel`에 갖도록 했고, 이를 조건으로 판단함

### Linked Issue

close #178 

