### PR TITLE
[#271] ref:병연님 피드백 반영 1.0.0 ( 23 )

### DIFF
--- a/ThingLog/Coordinator/OnboardingCoordinator.swift
+++ b/ThingLog/Coordinator/OnboardingCoordinator.swift
@@ -21,7 +21,7 @@ class OnboardingCoordinator: Coordinator {
     
     func start() {
         // 이미 유저정보가 있는 경우에는 온보딩을 스킵하고, TabBar를 보여준다. 
-        UserInformationiCloudViewModel().fetchUserInformation { userInformation in
+        UserInformationUserDefaultsViewModel().fetchUserInformation { userInformation in
             if let _ = userInformation {
                 self.window?.rootViewController = TabBarController()
             } else {

--- a/ThingLog/Extension/UIViewController+.swift
+++ b/ThingLog/Extension/UIViewController+.swift
@@ -26,7 +26,7 @@ extension UIViewController {
     }
     
     func setDarkMode() {
-        let userInformationViewModel: UserInformationViewModelable = UserInformationiCloudViewModel()
+        let userInformationViewModel: UserInformationViewModelable = UserInformationUserDefaultsViewModel()
         userInformationViewModel.fetchUserInformation { userInfor in
             guard let userInfor = userInfor else {
                 return

--- a/ThingLog/ThingLog.entitlements
+++ b/ThingLog/ThingLog.entitlements
@@ -4,7 +4,5 @@
 <dict>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array/>
-	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 </dict>
 </plist>

--- a/ThingLog/View/ImageWithTwoLabelVerticalCetnerXView.swift
+++ b/ThingLog/View/ImageWithTwoLabelVerticalCetnerXView.swift
@@ -28,7 +28,7 @@ final class ImageWithTwoLabelVerticalCetnerXView: UIView {
     
     private let titleLabel: UILabel = {
         let label: UILabel = UILabel()
-        label.text = "문구세트"
+        label.text = "대표 물건"
         label.textAlignment = .center
         label.font = UIFont.Pretendard.title1
         label.textColor = SwiftGenColors.primaryBlack.color

--- a/ThingLog/View/ProfileView.swift
+++ b/ThingLog/View/ProfileView.swift
@@ -197,7 +197,7 @@ final class ProfileView: UIView {
     
     /// 다크모드 설정 여부에 따라 애니메이션 뷰의 색을 변경해준다. AnimationView는 다른 아이콘과 다르게 다크모드 라이트모드에 대응하는 쌍이 없기 때문에, 따로 로직을 추가했다. 
     func setupDarkModeForAnimation() {
-        let userInformationViewModel: UserInformationViewModelable = UserInformationiCloudViewModel()
+        let userInformationViewModel: UserInformationViewModelable = UserInformationUserDefaultsViewModel()
         userInformationViewModel.fetchUserInformation { userInfor in
             if let userInfor: UserInformationable = userInfor {
                 let darkMode: Bool = userInfor.isAumatedDarkMode

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -38,6 +38,11 @@ class ContentsCollectionViewCell: UICollectionViewCell {
         let imageView: UIImageView = UIImageView(image: image)
         imageView.transform = CGAffineTransform(rotationAngle: .pi)
         imageView.tintColor = .white
+        imageView.layer.shadowColor = UIColor.black.cgColor
+        imageView.layer.masksToBounds = false
+        imageView.layer.shadowOffset = CGSize(width: -2, height: -2)
+        imageView.layer.shadowRadius = 5
+        imageView.layer.shadowOpacity = 0.3
         imageView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         imageView.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         imageView.setContentHuggingPriority(.defaultHigh, for: .vertical)
@@ -142,8 +147,8 @@ class ContentsCollectionViewCell: UICollectionViewCell {
             
             smallIconView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 7),
             smallIconView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -7),
-            smallIconView.widthAnchor.constraint(equalToConstant: 12),
-            smallIconView.heightAnchor.constraint(equalToConstant: 12),
+            smallIconView.widthAnchor.constraint(equalToConstant: 15),
+            smallIconView.heightAnchor.constraint(equalToConstant: 15),
             
             imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor),
             

--- a/ThingLog/ViewController/Crop/CropViewController.swift
+++ b/ThingLog/ViewController/Crop/CropViewController.swift
@@ -71,6 +71,10 @@ class CropViewController: UIViewController {
     var inset: CropInset = CropInset()
     var disposeBag: DisposeBag = DisposeBag()
     
+    /// ScreenEdgePanGesture는 여러번 호출될 수 있어서, 한번만 실행되도록 flag변수를 이용함.
+    var gestureFlag: Bool = true
+    var backCompletion: (() -> Void)?
+    
     // MARK: - Init
     init(selectedIndexImage: (index: IndexPath, image: UIImage?)) {
         self.selectedIndexImage = selectedIndexImage
@@ -90,6 +94,7 @@ class CropViewController: UIViewController {
         setupBottomView()
         setupNumberView()
         setupZoomButton()
+        setupScreenPanGesture()
     }
     
     // MARK: - Setup
@@ -177,6 +182,27 @@ class CropViewController: UIViewController {
                 self?.imageView.contentMode = .scaleAspectFit
             }
         }.disposed(by: disposeBag)
+    }
+    
+    /// 왼쪽 가장 끝지점에서 제스쳐를 인식하여, 뒤로가도록 한다.
+    func setupScreenPanGesture() {
+        let gesture: UIScreenEdgePanGestureRecognizer = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(back))
+        gesture.edges = .left
+        self.view.addGestureRecognizer(gesture)
+    }
+    
+    @objc
+    func back() {
+        DispatchQueue.main.async {
+            // ScreenEdgePanGesture는 여러번 호출될 수 있어서, 한번만 실행되도록 flag변수를 이용함.
+            if self.gestureFlag {
+                self.gestureFlag = false
+                self.backCompletion?()
+                DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+                    self.gestureFlag = true
+                }
+            }
+        }
     }
 }
 

--- a/ThingLog/ViewController/Drawer/DrawerViewController.swift
+++ b/ThingLog/ViewController/Drawer/DrawerViewController.swift
@@ -160,8 +160,8 @@ extension DrawerViewController: UICollectionViewDataSource, UICollectionViewDele
            let imageData: Data = representative.imageData,
            let drawerImage: UIImage = UIImage(data: imageData) {
             headerView.drawerView.setImage(drawerImage)
-            headerView.drawerView.setSubLabel(fontType: UIFont.Pretendard.body2,
-                                              color: SwiftGenColors.gray2.color,
+            headerView.drawerView.setSubLabel(fontType: UIFont.Pretendard.title2,
+                                              color: SwiftGenColors.primaryBlack.color,
                                               text: representative.title)
         } else {
             headerView.drawerView.setImage(SwiftGenDrawerList.emptyRepresentative.image.withRenderingMode(.alwaysTemplate))

--- a/ThingLog/ViewController/Home/HomeViewController.swift
+++ b/ThingLog/ViewController/Home/HomeViewController.swift
@@ -36,7 +36,7 @@ final class HomeViewController: UIViewController {
     // MARK: - Properties
     
     var coordinator: HomeCoordinator?
-    let userInformationViewModel: UserInformationViewModelable = UserInformationiCloudViewModel()
+    let userInformationViewModel: UserInformationViewModelable = UserInformationUserDefaultsViewModel()
     var drawerRespository: DrawerRepositoryable = DrawerCoreDataRepository(coreDataStack: CoreDataStack.shared)
     var heightAnchorProfileView: NSLayoutConstraint?
     let profileViewHeight: CGFloat = 3 + 80 + 11

--- a/ThingLog/ViewController/Login/LoginViewController.swift
+++ b/ThingLog/ViewController/Login/LoginViewController.swift
@@ -72,7 +72,7 @@ final class LoginViewController: UIViewController {
         }
     }
     
-    private let userInformationViewModel: UserInformationViewModelable = UserInformationiCloudViewModel()
+    private let userInformationViewModel: UserInformationViewModelable = UserInformationUserDefaultsViewModel()
     
     // MARK: - Init
     /// 로그인이 포함된 화면인지 아닌지를 주입하는 이니셜라이저다.

--- a/ThingLog/ViewController/PhotoCard/PhotoCardViewController+setup.swift
+++ b/ThingLog/ViewController/PhotoCard/PhotoCardViewController+setup.swift
@@ -106,6 +106,10 @@ extension PhotoCardViewController {
             ratingView.centerXAnchor.constraint(equalTo: photoContainerView.centerXAnchor),
             ratingView.heightAnchor.constraint(equalToConstant: inset.heightForRatingView)
         ])
+        
+        if photoCardViewModel.postEntity.postType?.pageType == .wish {
+            ratingView.isHidden = true
+        }
     }
     
     func setupNavigationBar() {

--- a/ThingLog/ViewController/PhotoCard/PhotoCardViewController.swift
+++ b/ThingLog/ViewController/PhotoCard/PhotoCardViewController.swift
@@ -45,6 +45,7 @@ final class PhotoCardViewController: UIViewController {
     let ratingView: RatingView = {
         let ratingView: RatingView = RatingView()
         ratingView.tintButton(.white)
+        ratingView.isUserInteractionEnabled = false 
         ratingView.translatesAutoresizingMaskIntoConstraints = false
         return ratingView
     }()
@@ -215,6 +216,7 @@ final class PhotoCardViewController: UIViewController {
         subscribeOptionView()
         subscribePhotoCardViewModel()
 
-        imageGestureModel.startObserving()
+        // 원래는 사진 이동이 가능했지만, 기획자의 제안에 따라 취소함.
+//        imageGestureModel.startObserving()
     }
 }

--- a/ThingLog/ViewController/Photos/PhotosViewController+Crop.swift
+++ b/ThingLog/ViewController/Photos/PhotosViewController+Crop.swift
@@ -12,6 +12,7 @@ extension PhotosViewController {
     func showCropViewController(selectedIndexImage: (index: IndexPath, image: UIImage?)) {
         cropViewController = CropViewController(selectedIndexImage: selectedIndexImage)
         cropViewController?.numberView.label.text = "\(selectedIndexPath.count)"
+        cropViewController?.backCompletion = dismissCropViewController
         guard let cropViewController: CropViewController = cropViewController else { return }
         let cropView: UIView = cropViewController.view
         cropView.translatesAutoresizingMaskIntoConstraints = false
@@ -33,6 +34,7 @@ extension PhotosViewController {
             cropViewController.view.layer.add(transition, forKey: "showCrop")
         } completion: { _ in
             cropViewController.view.layer.removeAnimation(forKey: "showCrop")
+            self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
             self.changeNavigationBar()
         }
     }
@@ -53,6 +55,7 @@ extension PhotosViewController {
                 crop.removeFromParent()
                 self.cropViewController = nil
                 self.setupNavigationBar()
+                self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
             }
         }
     }

--- a/ThingLog/ViewController/SettingViewController.swift
+++ b/ThingLog/ViewController/SettingViewController.swift
@@ -48,7 +48,7 @@ final class SettingViewController: UIViewController {
     
     // MARK: - Properties
     
-    private let userInformationViewModel: UserInformationViewModelable = UserInformationiCloudViewModel()
+    private let userInformationViewModel: UserInformationViewModelable = UserInformationUserDefaultsViewModel()
     private var userInformation: UserInformationable?
     
     var disposeBag: DisposeBag = DisposeBag()


### PR DESCRIPTION
## 개요

- 포토카드 리뷰 반영
- 크롭뷰에서 좌측 스와이프 하면 글쓰기 화면이 아닌 셀렉터 화면으로 나오도록 변경
- iCloud 관련 데이터 삭제 및 진열장의 대표물건 폰트 변경
- 게시물 다중 아이콘 사이즈 변경 및 그림자 추가

## 작업 사항

- 포토카드 리뷰 반영
    - 내부 사진 이동 없이 가는걸로 변경
    - 만족도가 있다면, 만족도가 눌리는 현상 해결
    - 사고싶다 게시물에서는 만족도가 안보여지도록 반영
- 크롭뷰에서 좌측 스와이프 하면 글쓰기 화면이 아닌 셀렉터 화면으로 나오도록 변경
    - 크롭뷰를 보여줄 때, `NavigationController`에서 기본 `gesture` 인식을 잠깐 `false`로 두고, 
    - 크롭뷰에서 따로 `ScreenEdgePagnGesture`를 등록하여, 이를 인식하여 뒤로 오도록 구현한다.
    - 셀렉터로 돌아왔을때, `NavigationController`의 기본 `gesture` 인식을 `True`로 바꾼다.
- iCloud 관련 데이터 삭제 및 진열장의 대표물건 폰트 변경
    - 기존의 `UserInformationiCloudViewModel` 를 사용한 클래스를 `UserInformationUserDefaultsViewModel` 로 변경
    - `Signing & Capabilitis` - `iCloud` - `Key value storage` 체크 해제
- 게시물 다중 아이콘 사이즈 변경 및 그림자 추가

## 예외 사항 
* #271  에보면, 체크안한 크롭뷰 관련기능이있는데, 이것들은 구현에 있어서 작업시간이 꽤 소요되거나 힘들 것 같아서 보류중입니다.

### Linked Issue

* close #271 

