### PR TITLE
테스트: 12월 7일자 요청사항

### DIFF
--- a/ThingLog/Coordinator/WriteCoordinator.swift
+++ b/ThingLog/Coordinator/WriteCoordinator.swift
@@ -5,6 +5,7 @@
 //  Created by 이지원 on 2021/10/03.
 //
 
+import CoreData
 import UIKit
 
 protocol WriteCoordinatorProtocol: SystemSettingCoordinatorProtocol {
@@ -13,7 +14,8 @@ protocol WriteCoordinatorProtocol: SystemSettingCoordinatorProtocol {
     func showWriteViewController(with viewModel: WriteViewModel)
 
     /// CategoryViewController로 이동한다.
-    func showCategoryViewController(with type: CategoryViewController.CategoryViewType)
+    func showCategoryViewController(with type: CategoryViewController.CategoryViewType,
+                                    entities: [CategoryEntity])
 
     /// PhotosViewController로 이동한다.
     func showPhotosViewController()
@@ -24,9 +26,11 @@ protocol WriteCoordinatorProtocol: SystemSettingCoordinatorProtocol {
 
 extension WriteCoordinatorProtocol {
     /// CategoryViewController로 이동한다.
-    func showCategoryViewController(with type: CategoryViewController.CategoryViewType = .select) {
+    func showCategoryViewController(with type: CategoryViewController.CategoryViewType = .select,
+                                    entities: [CategoryEntity] = []) {
         let categoryViewController: CategoryViewController = CategoryViewController(categoryViewType: type)
         categoryViewController.coordinator = self
+        categoryViewController.selectedCategory = entities
         navigationController.pushViewController(categoryViewController, animated: true)
     }
 

--- a/ThingLog/Model/Attachment.swift
+++ b/ThingLog/Model/Attachment.swift
@@ -12,6 +12,7 @@ import UIKit.UIImage
 struct Attachment {
     let identifier: UUID = UUID()
     let thumbnail: UIImage
+    let createDate: Date = Date()
 
     // MARK: Relationship
     let imageData: ImageData
@@ -27,6 +28,7 @@ extension Attachment {
         entity.identifier = identifier
         entity.thumbnail = thumbnail.jpegData(compressionQuality: 0.8)
         entity.imageData = imageData.toEntity(in: context)
+        entity.createDate = createDate
         return entity
     }
 }

--- a/ThingLog/SupportingFiles/ThingLog.xcdatamodeld/ThingLog.xcdatamodel/contents
+++ b/ThingLog/SupportingFiles/ThingLog.xcdatamodeld/ThingLog.xcdatamodel/contents
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Attachment" representedClassName="AttachmentEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="createDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="identifier" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="thumbnail" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
         <relationship name="imageData" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ImageData" inverseName="attachment" inverseEntity="ImageData"/>
@@ -59,7 +60,7 @@
         <relationship name="post" maxCount="1" deletionRule="Deny" destinationEntity="Post" inverseName="rating" inverseEntity="Post"/>
     </entity>
     <elements>
-        <element name="Attachment" positionX="-7253.027587890626" positionY="-4690.344833374023" width="128" height="103"/>
+        <element name="Attachment" positionX="-7253.027587890626" positionY="-4690.344833374023" width="128" height="104"/>
         <element name="Category" positionX="-7669.173278808594" positionY="-4417.294006347656" width="128" height="74"/>
         <element name="Comment" positionX="-6921.718536376953" positionY="-4342.518676757812" width="128" height="89"/>
         <element name="Drawer" positionX="-6919.932647705078" positionY="-4487.72053527832" width="128" height="134"/>

--- a/ThingLog/View/DropDownView/DropDownView.swift
+++ b/ThingLog/View/DropDownView/DropDownView.swift
@@ -27,6 +27,9 @@ final class DropDownView: UIView {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorStyle = .none
         tableView.backgroundColor = SwiftGenColors.primaryBackground.color
+        tableView.layer.cornerRadius = 5
+        tableView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        tableView.clipsToBounds = true
         return tableView
     }()
 

--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
@@ -359,7 +359,9 @@ extension PostTableCell {
     /// SlideImageView의 데이터를 구성한다.
     private func configureSlideImageView(with attachments: NSSet?) {
         if let attachments: [AttachmentEntity] = attachments?.allObjects as? [AttachmentEntity] {
-            let imageDatas: [Data] = attachments.compactMap { $0.imageData?.originalImage }
+            let imageDatas: [Data] = attachments.sorted(by: {
+                $0.createDate ?? Date() < $1.createDate ?? Date()
+            }).compactMap { $0.imageData?.originalImage }
             slideImageViewDataSource.images = imageDatas.compactMap { UIImage(data: $0) }
             imageCount = imageDatas.count
             slideImageCollectionView.reloadData()

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -66,7 +66,7 @@ final class CategoryViewController: UIViewController {
     private let disposeBag: DisposeBag = DisposeBag()
     private let leadingTrailingConstant: CGFloat = 18.0
     private let topBottomConstant: CGFloat = 12.0
-    private var selectedCategory: [CategoryEntity] = [] {
+    var selectedCategory: [CategoryEntity] = [] {
         didSet { successButton.isEnabled = selectedCategory.isNotEmpty }
     }
     private let textFieldMaxLength: Int = 21
@@ -107,7 +107,7 @@ final class CategoryViewController: UIViewController {
         
         if categoryViewType == .modify { return }
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: successButton)
-        successButton.isEnabled = false
+        successButton.isEnabled = selectedCategory.isNotEmpty
     }
     
     private func setupView() {

--- a/ThingLog/ViewController/CategoryViewController.swift
+++ b/ThingLog/ViewController/CategoryViewController.swift
@@ -41,7 +41,7 @@ final class CategoryViewController: UIViewController {
         textField.font = UIFont.Pretendard.body1
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.returnKeyType = .done
-        textField.attributedPlaceholder = NSAttributedString(string: "카테고리를 만들어보세요! (최대 20자)", attributes: [NSAttributedString.Key.foregroundColor: SwiftGenColors.gray2.color])
+        textField.attributedPlaceholder = NSAttributedString(string: "이곳을 눌러 카테고리를 만들어보세요! (최대 20자)", attributes: [NSAttributedString.Key.foregroundColor: SwiftGenColors.gray2.color])
         return textField
     }()
     private let bottomLineView: UIView = {

--- a/ThingLog/ViewController/Photos/PhotosViewController.swift
+++ b/ThingLog/ViewController/Photos/PhotosViewController.swift
@@ -381,8 +381,8 @@ extension PhotosViewController: UINavigationControllerDelegate, UIImagePickerCon
             return
         }
 
-        let indexPath: IndexPath = IndexPath(row: 0, section: 0)
-        self.selectedIndexPath = [(indexPath, image)]
+        let indexPath: IndexPath = IndexPath(row: -1, section: -1)
+        self.selectedIndexPath.append((indexPath, image))
 
         NotificationCenter.default.post(name: .passSelectImages,
                                         object: nil,

--- a/ThingLog/ViewController/Photos/PhotosViewController.swift
+++ b/ThingLog/ViewController/Photos/PhotosViewController.swift
@@ -34,6 +34,7 @@ final class PhotosViewController: BaseViewController {
         button.setImage(SwiftGenIcons.arrowDropDown.image.withTintColor(SwiftGenColors.gray3.color),
                         for: .normal)
         button.semanticContentAttribute = .forceRightToLeft
+        button.sizeToFit()
         return button
     }()
     

--- a/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
+++ b/ThingLog/ViewController/Write/WriteViewController+DataSource.swift
@@ -60,7 +60,12 @@ extension WriteViewController {
 
         cell.categorySubject = viewModel.categorySubject
         cell.indicatorButtonDidTappedCallback = { [weak self] in
-            self?.coordinator?.showCategoryViewController()
+            guard let categories: [Category] = try? self?.viewModel.categorySubject.value() else {
+                return
+            }
+
+            let entities: [CategoryEntity] = categories.map { $0.toEntity(in: CoreDataStack.shared.mainContext) }
+            self?.coordinator?.showCategoryViewController(entities: entities)
         }
 
         return cell

--- a/ThingLog/ViewController/Write/WriteViewController.swift
+++ b/ThingLog/ViewController/Write/WriteViewController.swift
@@ -179,7 +179,12 @@ extension WriteViewController {
 extension WriteViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath.section == WriteViewModel.Section.category.rawValue {
-            coordinator?.showCategoryViewController()
+            guard let categories: [Category] = try? viewModel.categorySubject.value() else {
+                return
+            }
+
+            let entities: [CategoryEntity] = categories.map { $0.toEntity(in: CoreDataStack.shared.mainContext) }
+            coordinator?.showCategoryViewController(entities: entities)
         }
     }
 }


### PR DESCRIPTION
## 개요

검수 시나리오 - 요청 사항에 있는 12월 7일자 요청 사항 반영

## 작업 사항

- 게시물 > 공통
  - 더보기(수정/삭제) 박스 하단 양쪽 라운딩 추가
- 글쓰기 > 사진
  - 앨범에서 사진 다중 선택한 상태에서 추가로 카메라로 사진 찍고 '사진 사용' 누르면, 이미 선택한 사진들 지워지는 게 아닌 옆에 추가되는 형식으로 수정
    - IndexPath를 추가해야 해서 임의의 값으로 지정했습니다. `row: -1, section: -1`
- 글쓰기 > 카테고리
  - 문구 수정: 카테고리를 만들어보세요! (최대 20자) → 이곳을 눌러 카테고리를 만들어보세요! (최대 20자)
  - 카테고리 선택 후 나갔다 다시 들어오면 기존에 선택했던 것들이 리셋되지 않고 선택 활성화 되어있게 수정
- AttachmentsEntity에 createDate 추가
  - 이미지를 불러오는 기준이 없어서 화면이 다시 그려질 때마다(?) 이미지 순서가 뒤바뀌고 있어서 사진을 저장할 때 생성 시점을 추가해서 정렬해서 보여줄 수 있게 수정했습니다.

## 예외 사항

- '사진첩 선택'이 아닌 '사진... 선택'으로 표시되는 문제 → 이 문제는 여러 시뮬레이터와 제가 보유하고 있는 기기에서 똑같이 재현할 수가 없어서 수정하지 못했습니다. 그래도 `PhotosViewController.titleButton`에 `sizeToFit()`를 호출해놨는데, 이 코드로 해결되면 좋겠네요;ㅅ;

### Linked Issue

close #273

