### PR TITLE
Bug/282 search text

### DIFF
--- a/ThingLog/View/SearchTextField.swift
+++ b/ThingLog/View/SearchTextField.swift
@@ -115,6 +115,7 @@ final class SearchTextField: UIView {
         super.init(frame: .zero)
         setupView()
         setupTextFieldCloseButton()
+        setDarkMode()
     }
     
     required init?(coder: NSCoder) {
@@ -229,6 +230,22 @@ extension SearchTextField {
     
     private func setupTextField() {
         textField.delegate = self
+    }
+    
+    /// 강제적으로 다크모드를 안하고자 할 때, textFieldView의 layer의 색이 반영되지 않는 점을 해결하기 위한 메소드. 아무래도 cgColor여서 그런것 같기도 하고...
+    private func setDarkMode() {
+        let userInformationViewModel: UserInformationViewModelable = UserInformationUserDefaultsViewModel()
+        userInformationViewModel.fetchUserInformation { userInfor in
+            guard let userInfor = userInfor else {
+                return
+            }
+            let darkMode: Bool = userInfor.isAumatedDarkMode
+            if darkMode {
+                self.textFieldView.layer.borderColor = UIColor(red: 255, green: 247, blue: 237, alpha: 1).cgColor
+            } else {
+                self.textFieldView.layer.borderColor = UIColor.black.cgColor
+            }
+        }
     }
 }
 

--- a/ThingLog/ViewController/Crop/CropViewController.swift
+++ b/ThingLog/ViewController/Crop/CropViewController.swift
@@ -92,9 +92,10 @@ class CropViewController: UIViewController {
         setupImageConatinerView()
         setupTopView()
         setupBottomView()
-        setupNumberView()
-        setupZoomButton()
         setupScreenPanGesture()
+        
+//        setupZoomButton() // 기능 없애기로 함
+//        setupNumberView() // 기능 없애기로 함
     }
     
     // MARK: - Setup
@@ -122,7 +123,7 @@ class CropViewController: UIViewController {
             imageView.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor)
         ])
     }
-
+    
     func setupTopView() {
         view.addSubview(topView)
         
@@ -207,7 +208,7 @@ class CropViewController: UIViewController {
 }
 
 extension CropViewController: UIScrollViewDelegate {
-  func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         imageView
     }
 }

--- a/ThingLog/ViewController/Photos/PhotosViewController+Crop.swift
+++ b/ThingLog/ViewController/Photos/PhotosViewController+Crop.swift
@@ -11,7 +11,7 @@ extension PhotosViewController {
     /// 오른쪽에서 왼쪽으로 나타나는 애니메이션과 함께 CropViewController를 표시한다.
     func showCropViewController(selectedIndexImage: (index: IndexPath, image: UIImage?)) {
         cropViewController = CropViewController(selectedIndexImage: selectedIndexImage)
-        cropViewController?.numberView.label.text = "\(selectedIndexPath.count)"
+//        cropViewController?.numberView.label.text = "\(selectedIndexPath.count)" // 기능 없애기로 함.
         cropViewController?.backCompletion = dismissCropViewController
         guard let cropViewController: CropViewController = cropViewController else { return }
         let cropView: UIView = cropViewController.view


### PR DESCRIPTION
## 개요

## 작업 사항

- 모아보기-검색 검색텍스트필드의 레이어 색 오류 수정 
    - 기존 코드에는 문제가 없는걸로 확인됌. ( 다크모드일 때는 흰색으로, 아닌경우에는 검은색으로 코드를 지정해둠. )
    - 이 문제가 발생하는 이유는, 디바이스를 다크모드로 설정한 경우에, 앱은 다크모드를 설정하지 않는 경우에 발생되는 현상으로 추측됌.
    - 확실하지는 않지만, layer 컬러에서는 cgColor를 사용하고 있어서, 디바이스 환경을 무시하면서 다크모드를 안하기 위해서는 추가적인 조치가필요하다고 판단됌.
    - 그래서, 직접 UIView가 초기화하는 시점에, darkMode인지 판별하여, 직접 layer에 색을 지정하도록 함.
- 크롭뷰 - 1:1크롭 기능 없애고, 상단 우측 하단의 초록색 숫자 뷰 없애기.

### Linked Issue

- close #282 
- close #283 

