### PR TITLE
[#305] 글쓰기>사진: 사진이 여러 개 있을 때, 썸네일이 랜덤하게 노출되는 문제

### DIFF
--- a/ThingLog/ViewController/ContentsCollection/BaseContentsCollectionViewController.swift
+++ b/ThingLog/ViewController/ContentsCollection/BaseContentsCollectionViewController.swift
@@ -161,8 +161,7 @@ extension BaseContentsCollectionViewController: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        if let item: PostEntity = fetchResultController?.fetchedObjects?[indexPath.item],
-           let data: Data = (item.attachments?.allObjects as? [AttachmentEntity])?.first?.thumbnail {
+        if let item: PostEntity = fetchResultController?.fetchedObjects?[indexPath.item] {
             cell.updateView(item)
         }
         

--- a/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
+++ b/ThingLog/ViewController/ContentsCollection/ContentsCollectionViewCell.swift
@@ -5,11 +5,11 @@
 //  Created by hyunsu on 2021/09/22.
 //
 import CoreData
+import Photos
 import UIKit
 
 import RxCocoa
 import RxSwift
-import Photos
 
 /// 기본적인 이미지만을 보여주기 위한 cell이다.
 ///
@@ -170,7 +170,8 @@ class ContentsCollectionViewCell: UICollectionViewCell {
     /// PostEntity를 기반으로 뷰를 업데이트한다.
     /// - Parameter postEntity: 특정 PostEntity를 주입한다.
     func updateView(_ postEntity: PostEntity) {
-        if let imageData: Data = (postEntity.attachments?.allObjects as? [AttachmentEntity])?[0].thumbnail {
+        if let thumbnailData: AttachmentEntity = postEntity.attachments?.sortedArray(using: [NSSortDescriptor(key: "createDate", ascending: true)]).first as? AttachmentEntity,
+           let imageData: Data = thumbnailData.thumbnail {
             imageView.image = UIImage(data: imageData)
         }
         smallIconView.isHidden = postEntity.attachments?.allObjects.count == 1


### PR DESCRIPTION
## 개요

첫번째 선택한 사진을 썸네일로 지정

## 작업 사항

- `BaseContentsCollectionViewController`에서 불필요한 바인딩 제거
- 썸네일을 지정할 때 `NSSortDescriptor`를 이용해서 `createDate`로 정렬, 첫번째 썸네일로 이미지 표시

### Linked Issue

close #305 

