### PR TITLE
[#304] 포토카드: 여러 개의 사진이 있을 때 선택한 사진이 아니라 다른 사진이 표시되는 문제

### DIFF
--- a/ThingLog/Entity/PostEntity+.swift
+++ b/ThingLog/Entity/PostEntity+.swift
@@ -32,7 +32,8 @@ extension PostEntity {
 
     /// 특정 인덱스에 이미지를 반환한다.
     func getImage(at index: Int) -> UIImage? {
-        guard let attachments: [AttachmentEntity] = self.attachments?.allObjects as? [AttachmentEntity],
+        guard let attachments: [AttachmentEntity] = self.attachments?.sortedArray(using: [NSSortDescriptor(key: "createDate",
+                                                                                                           ascending: true)]) as? [AttachmentEntity],
            let imageData: Data = attachments[index].imageData?.originalImage else {
             return nil
         }


### PR DESCRIPTION
## 개요

여러 개의 사진이 있을 때, 포토카드에서 선택한 사진이 아니라 다른 사진이 표시되는 문제 해결

## 작업 사항

- `PostEntity.getImage(at:)`에서 이미지를 찾을 때, 날짜 순으로 정렬 후 해당 인덱스에 있는 이미지를 반환하게 수정

### Linked Issue

close #304

