### PR TITLE
[#288] 버그: 선택한 게시물로 제대로 이동하지 않는 문제

### DIFF
--- a/ThingLog/ViewController/Post/PostViewController.swift
+++ b/ThingLog/ViewController/Post/PostViewController.swift
@@ -47,9 +47,6 @@ final class PostViewController: BaseViewController {
         if isMovingToParent {
             let startIndexPath: IndexPath = IndexPath(row: viewModel.startIndexPath.row, section: 0)
             tableView.scrollToRow(at: startIndexPath, at: .top, animated: false)
-            UIView.performWithoutAnimation {
-                tableView.reloadRows(at: [startIndexPath], with: .automatic)
-            }
         } else {
             if canShowPosts {
                 UIView.performWithoutAnimation {


### PR DESCRIPTION
## 개요

선택한 게시물로 제대로 이동하지 않는 문제 해결

## 작업 사항

기존 코드는 상위 뷰에서 게시물 화면으로 진입할 때, 해당 위치(선택한 이미지)로 이동 후 애니메이션 없이 테이블뷰를 다시 그린다.
해당 코드를 작성하던 시점에서는 해당 코드가 게시물을 수정했을 때 변경사항을 반영하기 위해서 추가한 것으로 보이는데, 이는 불필요한 코드였으며 오히려 선택한 게시물로 이동하지 못하는 문제를 유발했다. 따라서 해당 코드를 제거했다.

### Linked Issue

close #288

