### PR TITLE
[#309] 진열장: 블랙카드 획득 조건 = 기록의 합이 100만원 이상으로 변경

### DIFF
--- a/ThingLog/Repository/DrawerCoreDataRepository.swift
+++ b/ThingLog/Repository/DrawerCoreDataRepository.swift
@@ -42,6 +42,9 @@ protocol DrawerRepositoryable {
     
     /// 새로 획득한 진열장 아이템의 이벤트를 확인처리합니다.
     func completeNewEvent()
+    
+    /// 파라미터로 들어온 아이템의 획득 여부를 반환합니다.
+    func hasItem(for item: Drawerable, _ completion: @escaping((Bool)) -> Void)
 }
 
 /// `CoreData`를 이용하여 `Drawer`를 가져오고 업데이트 하는 객체다.
@@ -182,6 +185,16 @@ class DrawerCoreDataRepository: DrawerRepositoryable {
                 } catch {
                     return
                 }
+            }
+        }
+    }
+    
+    /// 파라미터로 들어온 아이템의 획득 여부를 반환합니다.
+    func hasItem(for item: Drawerable, _ completion: @escaping((Bool)) -> Void) {
+        fetchDrawers { drawers in
+            if let drawers: [Drawerable] = drawers,
+               let index: Int = drawers.firstIndex(where: { $0.imageName == item.imageName }) {
+                completion(drawers[index].isAcquired)
             }
         }
     }


### PR DESCRIPTION
## 개요

블랙카드 획득 조건 = 기록의 합이 100만원 이상으로 변경

## 작업 사항

기존: 샀다 혹은 사고싶다에서 샀다로 수정했을 때, 단일 포스트 항목이 100만원 이상인 경우 VIP 획득
변경: 모든 샀다 게시물의 합이 100만원 이상일 때 VIP 획득

- `DrawerCoreDataRepository.hasItem(for:)`
  - 파라미터로 들어온 `Drawerable` 아이템의 획득 여부를 반환
- `PostRepository.getSumAllPriceofBought(_:)`
  - 모든 샀다 게시물 가격의 총합을 반환, 비동기 메서드
- `PostRepository.updateVIP()`
  - 이미 블랙카드를 획득한 상태라면 종료
  - 획득하지 않았다면, `getSumAllPriceofBought(_:)`값을 `DrawerCoreDataRepository.updateVIP(by:)`에 넣고 호출
### Linked Issue

close #309 

