### PR TITLE
[#310] 게시물: 인스타그램처럼 사진 확대 기능

### DIFF
--- a/ThingLog.xcodeproj/project.pbxproj
+++ b/ThingLog.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		8715B3AC273ABEC5007A3A88 /* PostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715B3AB273ABEC5007A3A88 /* PostViewController.swift */; };
 		8715B3AF273ABFB3007A3A88 /* PostViewController+setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715B3AE273ABFB3007A3A88 /* PostViewController+setup.swift */; };
 		8715B3B1273AC00B007A3A88 /* PostViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715B3B0273AC00B007A3A88 /* PostViewController+DataSource.swift */; };
+		87217EAD27953CA800F94B5D /* ZoomableCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87217EAC27953CA800F94B5D /* ZoomableCollectionCell.swift */; };
 		87336FDD272EE85E00E1C4CA /* UserPermissionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87336FDC272EE85E00E1C4CA /* UserPermissionsViewModel.swift */; };
 		8736B3E326FCB9F3000433E1 /* Rating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8736B3E226FCB9F3000433E1 /* Rating.swift */; };
 		8736B3E526FCBA77000433E1 /* RatingEntity+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8736B3E426FCBA77000433E1 /* RatingEntity+.swift */; };
@@ -289,6 +290,7 @@
 		8715B3AB273ABEC5007A3A88 /* PostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewController.swift; sourceTree = "<group>"; };
 		8715B3AE273ABFB3007A3A88 /* PostViewController+setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostViewController+setup.swift"; sourceTree = "<group>"; };
 		8715B3B0273AC00B007A3A88 /* PostViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostViewController+DataSource.swift"; sourceTree = "<group>"; };
+		87217EAC27953CA800F94B5D /* ZoomableCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableCollectionCell.swift; sourceTree = "<group>"; };
 		87336FDC272EE85E00E1C4CA /* UserPermissionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPermissionsViewModel.swift; sourceTree = "<group>"; };
 		8736B3E226FCB9F3000433E1 /* Rating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rating.swift; sourceTree = "<group>"; };
 		8736B3E426FCBA77000433E1 /* RatingEntity+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RatingEntity+.swift"; sourceTree = "<group>"; };
@@ -963,6 +965,7 @@
 				87B1B6542715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift */,
 				DB05B04B271F04E50067DB17 /* TextFieldWithLabelWithButtonCollectionCell.swift */,
 				87DAEB1C270BEC170038C487 /* ThumbnailCell.swift */,
+				87217EAC27953CA800F94B5D /* ZoomableCollectionCell.swift */,
 			);
 			path = CollectionViewCell;
 			sourceTree = "<group>";
@@ -1460,6 +1463,7 @@
 				87CFA333273A5A1600D08824 /* WriteViewController+DataSource.swift in Sources */,
 				87EDCFD927316F8A002C98BE /* PostTableCell+setup.swift in Sources */,
 				DBA883B6272BEF9B0089643B /* DrawerCoreDataRepository.swift in Sources */,
+				87217EAD27953CA800F94B5D /* ZoomableCollectionCell.swift in Sources */,
 				DB98FBC82744E5EF002409BF /* ImageViewWithSelectViewCollectionCell.swift in Sources */,
 				DB37EC77270C307C00030D9A /* RecentSearchView+update.swift in Sources */,
 				87B1B6552715E252001EA889 /* LabelWithButtonRoundCollectionCell.swift in Sources */,

--- a/ThingLog/View/CollectionViewCell/ZoomableCollectionCell.swift
+++ b/ThingLog/View/CollectionViewCell/ZoomableCollectionCell.swift
@@ -115,7 +115,10 @@ final class ZoomableCollectionCell: UICollectionViewCell, UIGestureRecognizerDel
                                                         .translatedBy(x: pinchCenter.x, y: pinchCenter.y)
                                                         .scaledBy(x: zoomScale, y: zoomScale)
                                                         .translatedBy(x: -centerXDif, y: -centerYDif)
-        windowImageView.transform = transform
+        UIView.animate(withDuration: 0.1) {
+            self.windowImageView.transform = transform
+        }
+        
         sender.scale = 1
     }
     

--- a/ThingLog/View/CollectionViewCell/ZoomableCollectionCell.swift
+++ b/ThingLog/View/CollectionViewCell/ZoomableCollectionCell.swift
@@ -1,0 +1,149 @@
+//
+//  ZoomableCollectionCell.swift
+//  ThingLog
+//
+//  Created by 이지원 on 2022/01/17.
+//  Source: https://stevenpcurtis.medium.com/create-instagrams-pinch-to-zoom-using-swift-16084415b186
+
+import UIKit
+
+protocol ZoomableCollectionCellDelegate: AnyObject {
+    func zooming(started: Bool)
+}
+
+final class ZoomableCollectionCell: UICollectionViewCell, UIGestureRecognizerDelegate {
+    // MARK: - View Properties
+    let imageView: UIImageView = {
+        let imageView: UIImageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.isUserInteractionEnabled = true
+        return imageView
+    }()
+    
+    // MARK: - Properties
+    weak var delegate: ZoomableCollectionCellDelegate?
+    /// 확대했을 때 오버레이 되는 투명한 뷰
+    var overlayView: UIView?
+    /// 배경의 최대 알파 값
+    let maxOverlayAlpha: CGFloat = 0.8
+    /// 배경의 최소 알파 값
+    let minOverlayAlpha: CGFloat = 0.4
+    /// 핀치의 초기 중심
+    var initialCenter: CGPoint?
+    /// 윈도우에 추가할 뷰
+    lazy var windowImageView: UIImageView = {
+        let imageView: UIImageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+    /// 소스 이미지 뷰의 원점(윈도우의 좌표 공간에서)
+    var startingRect: CGRect = .zero
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// 사용자가 컬렉션 뷰 셀을 집었을 때 호출됨
+    @objc
+    private func pinch(_ sender: UIPinchGestureRecognizer) {
+        if sender.state == .began {
+            let currentScale: CGFloat = self.imageView.frame.size.width / self.imageView.bounds.size.width
+            let newScale: CGFloat = currentScale * sender.scale
+            
+            if newScale > 1 {
+                startZooming(with: sender)
+            }
+        } else if sender.state == .changed {
+            changeZooming(with: sender)
+        } else if sender.state == .ended || sender.state == .failed || sender.state == .cancelled {
+            endZooming()
+        }
+    }
+    
+    private func startZooming(with sender: UIPinchGestureRecognizer) {
+        guard let currentWindow: UIWindow = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return }
+        
+        self.delegate?.zooming(started: true)
+
+        overlayView = UIView(frame: CGRect(x: 0,
+                                           y: 0,
+                                           width: (currentWindow.frame.size.width),
+                                           height: (currentWindow.frame.size.height)))
+        overlayView?.backgroundColor = .black
+        overlayView?.alpha = CGFloat(minOverlayAlpha)
+        guard let overlayView = overlayView else { return }
+        currentWindow.addSubview(overlayView)
+        
+        initialCenter = sender.location(in: currentWindow)
+
+        windowImageView.image = imageView.image
+        
+        let point: CGPoint = self.imageView.convert(imageView.frame.origin, to: nil)
+        
+        startingRect = CGRect(x: point.x, y: point.y, width: imageView.frame.size.width, height: imageView.frame.size.height)
+        
+        windowImageView.frame = startingRect
+        currentWindow.addSubview(windowImageView)
+        imageView.isHidden = true
+    }
+    
+    private func changeZooming(with sender: UIPinchGestureRecognizer) {
+        guard let currentWindow = UIApplication.shared.windows.first(where: { $0.isKeyWindow }),
+              let initialCenter = initialCenter else {
+                  return
+              }
+        let windowImageWidth: CGFloat = windowImageView.frame.size.width
+        let currentScale: CGFloat = windowImageWidth / startingRect.size.width
+        let newScale: CGFloat = currentScale * sender.scale
+        
+        overlayView?.alpha = minOverlayAlpha + (newScale - 1) < maxOverlayAlpha ? minOverlayAlpha + (newScale - 1) : maxOverlayAlpha
+        
+        let pinchCenter: CGPoint = CGPoint(x: sender.location(in: currentWindow).x - (currentWindow.bounds.midX),
+                                           y: sender.location(in: currentWindow).y - (currentWindow.bounds.midY))
+        let centerXDif: CGFloat = initialCenter.x - sender.location(in: currentWindow).x
+        let centerYDif: CGFloat = initialCenter.y - sender.location(in: currentWindow).y
+        let zoomScale: CGFloat = (newScale * windowImageWidth >= imageView.frame.width) ? newScale : currentScale
+        let transform: CGAffineTransform = currentWindow.transform
+                                                        .translatedBy(x: pinchCenter.x, y: pinchCenter.y)
+                                                        .scaledBy(x: zoomScale, y: zoomScale)
+                                                        .translatedBy(x: -centerXDif, y: -centerYDif)
+        windowImageView.transform = transform
+        sender.scale = 1
+    }
+    
+    private func endZooming() {
+        UIView.animate(withDuration: 0.3, animations: {
+            self.windowImageView.transform = .identity
+        }, completion: { _ in
+            self.windowImageView.removeFromSuperview()
+            self.overlayView?.removeFromSuperview()
+            self.imageView.isHidden = false
+            self.delegate?.zooming(started: false)
+        })
+    }
+}
+
+extension ZoomableCollectionCell {
+    private func setupView() {
+        let pinch: UIPinchGestureRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(pinch(_:)))
+        pinch.delegate = self
+        
+        imageView.addGestureRecognizer(pinch)
+        addSubview(imageView)
+        
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            imageView.topAnchor.constraint(equalTo: topAnchor),
+            imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+}

--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostSlideImageViewDataSource.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostSlideImageViewDataSource.swift
@@ -17,12 +17,11 @@ extension PostSlideImageViewDataSource: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell: ContentsCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: ContentsCollectionViewCell.reuseIdentifier, for: indexPath) as? ContentsCollectionViewCell else {
-            return ContentsCollectionViewCell()
+        guard let cell: ZoomableCollectionCell = collectionView.dequeueReusableCell(withReuseIdentifier: ZoomableCollectionCell.reuseIdentifier, for: indexPath) as? ZoomableCollectionCell else {
+            return ZoomableCollectionCell()
         }
 
         cell.imageView.image = images[indexPath.item]
-        cell.setupDisplayOnlyImageView()
 
         return cell
     }

--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell+setup.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell+setup.swift
@@ -37,7 +37,8 @@ extension PostTableCell {
     func setupSlideImageCollectionView() {
         slideImageCollectionView.delegate = self
         slideImageCollectionView.dataSource = slideImageViewDataSource
-        slideImageCollectionView.register(ContentsCollectionViewCell.self, forCellWithReuseIdentifier: ContentsCollectionViewCell.reuseIdentifier)
+        slideImageCollectionView.register(ZoomableCollectionCell.self,
+                                          forCellWithReuseIdentifier: ZoomableCollectionCell.reuseIdentifier)
 
         NSLayoutConstraint.activate([
             slideImageCollectionView.widthAnchor.constraint(equalTo: contentView.widthAnchor),
@@ -170,5 +171,11 @@ extension PostTableCell: UICollectionViewDelegate, UIScrollViewDelegate {
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let pageWidth: CGFloat = scrollView.frame.size.width
         currentImagePage = Int(slideImageCollectionView.contentOffset.x / pageWidth) + 1
+    }
+}
+
+extension PostTableCell: ZoomableCollectionCellDelegate {
+    func zooming(started: Bool) {
+        slideImageCollectionView.isScrollEnabled = !started
     }
 }


### PR DESCRIPTION
## 개요

https://user-images.githubusercontent.com/15073405/150073534-addf3783-ee19-493d-9f1a-8a80b1ba7bc3.mp4

게시물 화면에서 이미지를 확대할 수 있다.

## 작업 사항

- 이미지 확대가 가능한 `ZoomableCollectionCell` 구현
- `PostTableCell.slideImageCollectionView`의 셀을 `ZoomableCollectionCell`로 변경

### Linked Issue

close #310

