### PR TITLE
[#323] 설정: 다크모드 변경 시 모아보기 화면 업데이트

### DIFF
--- a/ThingLog/ViewController/EasyLook/EasyLookViewController.swift
+++ b/ThingLog/ViewController/EasyLook/EasyLookViewController.swift
@@ -70,6 +70,11 @@ final class EasyLookViewController: UIViewController {
         setupContentsViewControllerCompletion()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        view.layoutIfNeeded()
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         easyLookTopView.horizontalCollectionView.reloadData()


### PR DESCRIPTION
## 개요

다크모드 변경 시 모아보기 화면 업데이트

## 작업 사항

모아보기 화면이 띄워지기 전에 `view.layoutIfneeded()`를 호출해서 뷰를 업데이트한다.

### Linked Issue

close #323
