### PR TITLE
[#324] 게시물 화면으로 이동할 때 첫번째 셀이 잔상으로 보이는 문제 해결

### DIFF
--- a/ThingLog/ViewController/Post/PostViewController.swift
+++ b/ThingLog/ViewController/Post/PostViewController.swift
@@ -26,6 +26,7 @@ final class PostViewController: BaseViewController {
         viewModel.fetchedResultsController.fetchedObjects?.count ?? 0 > 0
     }
     private(set) var viewModel: PostViewModel
+    private var isFirstLoad: Bool = true
 
     init(viewModel: PostViewModel) {
         self.viewModel = viewModel
@@ -40,23 +41,30 @@ final class PostViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        if isFirstLoad {
+            let startIndexPath: IndexPath = IndexPath(row: viewModel.startIndexPath.row, section: 0)
+            tableView.scrollToRow(at: startIndexPath, at: .top, animated: false)
+            isFirstLoad = false
+        }
+    }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
-        if isMovingToParent {
-            let startIndexPath: IndexPath = IndexPath(row: viewModel.startIndexPath.row, section: 0)
-            tableView.scrollToRow(at: startIndexPath, at: .top, animated: false)
-        } else {
-            if canShowPosts {
-                UIView.performWithoutAnimation {
-                    let contentOffset: CGPoint = tableView.contentOffset
-                    tableView.reloadData()
-                    tableView.contentOffset = contentOffset
-                }
-            } else {
-                coordinator?.back()
+        
+        if isFirstLoad == true { return }
+        
+        if canShowPosts {
+            UIView.performWithoutAnimation {
+                let contentOffset: CGPoint = tableView.contentOffset
+                tableView.reloadData()
+                tableView.contentOffset = contentOffset
             }
+        } else {
+            coordinator?.back()
         }
     }
 


### PR DESCRIPTION
## 개요

게시물 화면으로 이동할 때 첫번째 셀이 잔상으로 보이는 문제 해결

## 작업 사항

- 기존
  - 뷰가 표시된 후에 홈/모아보기/검색에서 선택한 위치로 이동
  - 이로 인해 첫번째 셀이 이동 전에 표시되는 문제가 있었음
- 변경
  - 서브 뷰의 레이아웃이 배치 된 후에 선택한 위치로 이동하게 수정
  - `viewDidLayoutSubviews()`는 여러번 호출되기 때문에 단 한 번만 호출하기 위해서 이를 검사하는 변수 추가

첫번째 셀이 잔상으로 보이는 현상 때문에 스켈레톤 뷰를 추가하려 했으나, 해당 현상을 해결함으로써 스켈레톤 뷰는 추가하지 않기로 결정(협의 사항)

### Linked Issue

close #324

