### PR TITLE
[#294] 게시물: 게시물 이미지 카운트가 초기화 안되는 문제 

### DIFF
--- a/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
+++ b/ThingLog/View/TableVeiwCell/PostTableCell/PostTableCell.swift
@@ -265,7 +265,11 @@ final class PostTableCell: UITableViewCell {
         disposeBag = DisposeBag()
         identifier = ""
         currentImagePage = 1
-        slideImageCollectionView.reloadData()
+        DispatchQueue.main.async { [weak self] in
+            self?.slideImageCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0),
+                                                        at: .top,
+                                                        animated: false)
+        }
     }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {


### PR DESCRIPTION
## 개요

PostTableCell이 다시 그려질 때 이미지의 첫번째 아이템으로 이동

## 작업 사항

PostTableCell이 다시 그려질 때 이미지의 첫번째 아이템으로 이동

### Linked Issue

close #294

